### PR TITLE
fix(common): fix for angular example: add options variable

### DIFF
--- a/packages/angular/examples/basic-site/src/app/app.component.ts
+++ b/packages/angular/examples/basic-site/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import { BuilderBlock } from '@builder.io/angular';
 import { Component, Input } from '@angular/core';
+import { GetContentOptions } from '@builder.io/sdk';
 
 @BuilderBlock({
   tag: 'custom-thing',
@@ -28,7 +29,7 @@ export class CustomThing {
 })
 export class AppComponent {
   title = 'app';
-  options = null;
+  options: GetContentOptions;
 
   data = {
     property: 'hello',

--- a/packages/angular/examples/basic-site/src/app/app.component.ts
+++ b/packages/angular/examples/basic-site/src/app/app.component.ts
@@ -28,6 +28,7 @@ export class CustomThing {
 })
 export class AppComponent {
   title = 'app';
+  options = null;
 
   data = {
     property: 'hello',


### PR DESCRIPTION
In `app.component.ts`, `options` variable was missing.