### PR TITLE
Remove toJSON for object destructuring

### DIFF
--- a/plugins/dynamic-dropdown/__tests__/dropdownPropsExtractor.test.ts
+++ b/plugins/dynamic-dropdown/__tests__/dropdownPropsExtractor.test.ts
@@ -1,5 +1,4 @@
 import { getMassagedProps } from '../src/dropdownPropsExtractor'
-const mockMap = (obj: any) => ({ toJSON: () => obj })
 
 describe('Get Massaged Props', () => {
   describe('should throw', () => {
@@ -7,7 +6,7 @@ describe('Get Massaged Props', () => {
       'when url is %o',
       invalidUrl => {
         try {
-          getMassagedProps({ field: { options: mockMap({ url: invalidUrl }) } })
+          getMassagedProps({ field: { options: { url: invalidUrl } } })
           fail('Should have thrown')
         } catch (e) {
           expect(e.message).toBe('Missing { url: "" } required option')
@@ -21,7 +20,7 @@ describe('Get Massaged Props', () => {
         try {
           getMassagedProps({
             field: {
-              options: mockMap({ url: 'any-url', mapper: invalidMapper })
+              options: { url: 'any-url', mapper: invalidMapper }
             }
           })
           fail('Should have thrown')
@@ -50,7 +49,7 @@ describe('Get Massaged Props', () => {
       const expectedUrl = `https://www.domain.net/v2/${locale}/endpoint`
 
       const actual = getMassagedProps({
-        field: { options: mockMap({ url: templatedUrl, mapper: '() => {}' }) },
+        field: { options: { url: templatedUrl, mapper: '() => {}' } },
         ...builderPluginContext
       })
 
@@ -61,7 +60,7 @@ describe('Get Massaged Props', () => {
       const expected = '() => {}'
 
       const actual = getMassagedProps({
-        field: { options: mockMap({ url: 'any-url', mapper: expected }) },
+        field: { options: { url: 'any-url', mapper: expected } },
         ...builderPluginContext
       })
 

--- a/plugins/dynamic-dropdown/src/dropdownPropsExtractor.ts
+++ b/plugins/dynamic-dropdown/src/dropdownPropsExtractor.ts
@@ -1,7 +1,7 @@
 import Mustache from 'mustache'
 
 const getMassagedProps = (props: any): any => {
-  const { url, mapper } = props.field.options?.toJSON() || ({} as any)
+  const { url, mapper } = props.field.options || ({} as any)
 
   if (isNullOrEmpty(url)) throw new Error('Missing { url: "" } required option')
   if (isNullOrEmpty(mapper))


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4102787/75254694-09174700-57e1-11ea-9af5-ed322fce660f.png)
Evidence of the toJSON failing:
![image](https://user-images.githubusercontent.com/4102787/75254743-1f250780-57e1-11ea-9c89-b6f0e6794fa5.png)

I've just removed the toJSON method and fixed the tests. It may probably be automatically fixed by updating the type from `any` to what it should be however.