### PR TITLE
do not show 'undefined' for custom css

### DIFF
--- a/packages/react/src/components/builder-page.component.tsx
+++ b/packages/react/src/components/builder-page.component.tsx
@@ -669,11 +669,12 @@ export class BuilderPage extends React.Component<
   getFontCss(data: any) {
     // TODO: separate internal data from external
     return (
-      data.customFonts &&
-      data.customFonts.length &&
-      data.customFonts
-        .map((font: any) => this.getCssFromFont(font, data))
-        .join(' ')
+      (data.customFonts &&
+        data.customFonts.length &&
+        data.customFonts
+          .map((font: any) => this.getCssFromFont(font, data))
+          .join(' ')) ||
+      ''
     )
   }
 


### PR DESCRIPTION
this was causing an issue where ie11 stopped parsing the rest of the css in the block.