### PR TITLE
docs: fix typo

### DIFF
--- a/examples/gatsby/README.md
+++ b/examples/gatsby/README.md
@@ -63,7 +63,7 @@ export const pageQuery = graphql`
   query {
     allBuilderModels {
       # (optional) custom "header" component model
-      header(limit: 1, options: { cachebust: ture }) {
+      header(limit: 1, options: { cachebust: true }) {
         content
       }
       # Manually grab the example content matching "/"


### PR DESCRIPTION
Just spotted a little typo while reading the docs.