### PR TITLE
Added sizes logic, ensure lazy loading, fixed typo

### DIFF
--- a/packages/react/src/blocks/Image.tsx
+++ b/packages/react/src/blocks/Image.tsx
@@ -109,11 +109,35 @@ class ImageComponent extends React.Component<any> {
     return getSrcSet(url)
   }
 
+  getSizes(sizes: string) {
+    if (!sizes) {
+      return ''
+    }
+
+    const splitSizes = sizes.split(',')
+    const sizesLength = splitSizes.length
+    return splitSizes
+      .map((size: string, index) => {
+        if (sizesLength === index + 1) {
+          // If it is the last size in the array, then we want to strip out
+          // any media query information. According to the img spec, the last
+          // value for sizes cannot have a media query. If there is a media
+          // query at the end it breaks AMP mode rendering
+          // https://github.com/ampproject/amphtml/blob/b6313e372fdd1298928e2417dcc616b03288e051/src/size-list.js#L169
+          return size.replace(/\([\s\S]*?\)/g, '').trim()
+        } else {
+          return size
+        }
+      })
+      .join(', ')
+  }
+
   render() {
     const { aspectRatio, lazy } = this.props
     const children = this.props.builderBlock && this.props.builderBlock.children
 
     let srcset = this.props.srcset
+    const sizes = this.getSizes(this.props.sizes)
     const image = this.props.image
 
     if (srcset && image && image.includes('builder.io/api/v1/image')) {
@@ -131,7 +155,7 @@ class ImageComponent extends React.Component<any> {
           const amp = value.ampMode
           const Tag: 'img' = amp ? ('amp-img' as any) : 'img'
 
-          const imageContents = (!lazy || this.state.load) && (
+          const imageContents = (!lazy || this.state.load || amp) && (
             <Tag
               {...(amp
                 ? ({
@@ -189,7 +213,7 @@ class ImageComponent extends React.Component<any> {
               })}
               // TODO: memoize on image on client
               srcSet={srcset}
-              sizes={this.props.sizes}
+              sizes={sizes}
             />
           )
 

--- a/packages/react/src/blocks/Image.tsx
+++ b/packages/react/src/blocks/Image.tsx
@@ -41,6 +41,29 @@ export const getSrcSet = (url: string) => {
     .join(', ')
 }
 
+export const getSizes = (sizes: string) => {
+  if (!sizes) {
+    return ''
+  }
+
+  const splitSizes = sizes.split(',')
+  const sizesLength = splitSizes.length
+  return splitSizes
+    .map((size: string, index) => {
+      if (sizesLength === index + 1) {
+        // If it is the last size in the array, then we want to strip out
+        // any media query information. According to the img spec, the last
+        // value for sizes cannot have a media query. If there is a media
+        // query at the end it breaks AMP mode rendering
+        // https://github.com/ampproject/amphtml/blob/b6313e372fdd1298928e2417dcc616b03288e051/src/size-list.js#L169
+        return size.replace(/\([\s\S]*?\)/g, '').trim()
+      } else {
+        return size
+      }
+    })
+    .join(', ')
+}
+
 // TODO: use picture tag to support more formats
 class ImageComponent extends React.Component<any> {
   get useLazyLoading() {
@@ -109,35 +132,12 @@ class ImageComponent extends React.Component<any> {
     return getSrcSet(url)
   }
 
-  getSizes(sizes: string) {
-    if (!sizes) {
-      return ''
-    }
-
-    const splitSizes = sizes.split(',')
-    const sizesLength = splitSizes.length
-    return splitSizes
-      .map((size: string, index) => {
-        if (sizesLength === index + 1) {
-          // If it is the last size in the array, then we want to strip out
-          // any media query information. According to the img spec, the last
-          // value for sizes cannot have a media query. If there is a media
-          // query at the end it breaks AMP mode rendering
-          // https://github.com/ampproject/amphtml/blob/b6313e372fdd1298928e2417dcc616b03288e051/src/size-list.js#L169
-          return size.replace(/\([\s\S]*?\)/g, '').trim()
-        } else {
-          return size
-        }
-      })
-      .join(', ')
-  }
-
   render() {
     const { aspectRatio, lazy } = this.props
     const children = this.props.builderBlock && this.props.builderBlock.children
 
     let srcset = this.props.srcset
-    const sizes = this.getSizes(this.props.sizes)
+    const sizes = getSizes(this.props.sizes)
     const image = this.props.image
 
     if (srcset && image && image.includes('builder.io/api/v1/image')) {

--- a/packages/react/src/components/builder-page.component.tsx
+++ b/packages/react/src/components/builder-page.component.tsx
@@ -804,7 +804,7 @@ export class BuilderPage extends React.Component<
           contentId ? `builder-component-${contentId}` : ''
         }`}
         data-name={this.name}
-        date-source={`Rendered by Builder.io on ${new Date().toUTCString()}`}
+        data-source={`Rendered by Builder.io on ${new Date().toUTCString()}`}
         key={this.state.key}
         ref={ref => (this.ref = ref)}
       >

--- a/packages/webcomponents/src/elements.ts
+++ b/packages/webcomponents/src/elements.ts
@@ -433,10 +433,12 @@ if (Builder.isBrowser && !customElements.get(componentName)) {
                   initialContent: data ? [data] : undefined,
                   // TODO: make this a settable property too
                   key:
-                  this.getAttribute('key') ||
-                  (slot ? `slot:${slot}` : null) ||
-                  (Builder.isEditing ? name! : (data && data.id) || undefined),
-                  ...this.options,
+                    this.getAttribute('key') ||
+                    (slot ? `slot:${slot}` : null) ||
+                    (Builder.isEditing
+                      ? name!
+                      : (data && data.id) || undefined),
+                  ...this.options
                 }
               },
               this.getAttribute('hydrate') !== 'false', // TODO: query param override builder.hydrate
@@ -485,13 +487,13 @@ if (Builder.isBrowser && !customElements.get(componentName)) {
                     entry: data ? data.id : entry,
                     initialContent: data ? [data] : undefined,
                     key:
-                    this.getAttribute('key') ||
-                    (slot ? `slot:${slot}` : null) ||
-                    (Builder.isEditing
-                      ? name!
-                      : (data && data.id) || undefined),
-                      ...this.options,
-                      // TODO: specify variation?
+                      this.getAttribute('key') ||
+                      (slot ? `slot:${slot}` : null) ||
+                      (Builder.isEditing
+                        ? name!
+                        : (data && data.id) || undefined),
+                    ...this.options
+                    // TODO: specify variation?
                   },
                   fresh
                 },


### PR DESCRIPTION
This PR fixes a couple of things
- it ensures that lazy loading of images never occurs when in `ampMode`
- it ensures that the final entry in the image `sizes` string does not have a media query. This should fix https://github.com/BuilderIO/builder/issues/144 
- fixes what looks to be a typo (`date-source` -> `data-source`) that was causing the preview in the Builder editor to fail