### PR TITLE
Removed sizes attribute for amp mode

### DIFF
--- a/packages/react/src/blocks/Image.tsx
+++ b/packages/react/src/blocks/Image.tsx
@@ -188,13 +188,14 @@ class ImageComponent extends React.Component<any> {
                 transition: 'opacity 0.2s ease-in-out',
                 objectFit: this.props.backgroundSize || 'cover',
                 objectPosition: this.props.backgroundPosition || 'center',
-                ...(aspectRatio && {
-                  position: 'absolute',
-                  height: '100%',
-                  width: '100%',
-                  left: 0,
-                  top: 0
-                }),
+                ...(aspectRatio &&
+                  !amp && {
+                    position: 'absolute',
+                    height: '100%',
+                    width: '100%',
+                    left: 0,
+                    top: 0
+                  }),
                 ...(amp && {
                   ['& img']: {
                     objectFit: this.props.backgroundSize,
@@ -213,7 +214,7 @@ class ImageComponent extends React.Component<any> {
               })}
               // TODO: memoize on image on client
               srcSet={srcset}
-              sizes={sizes}
+              sizes={!amp && sizes ? sizes : undefined}
             />
           )
 

--- a/packages/webcomponents/src/elements.ts
+++ b/packages/webcomponents/src/elements.ts
@@ -35,7 +35,6 @@ if (Builder.isBrowser && !customElements.get(componentName)) {
     Builder,
     builder
   }
-  
   ;(window as any).BuilderWC = BuilderWC
 
   const { builderWcLoadCallbacks } = window as any


### PR DESCRIPTION
According to the amp docs, we don't need to add `sizes` if we are already including `srcset`. If we include `sizes`, then amp will add an inline style to the image to make it whatever width we set in the sizes attribute (https://amp.dev/documentation/components/amp-img/). I believe this is causing the issue here https://github.com/BuilderIO/builder/issues/154. I also removed the absolute positioning css that gets added for elements with `aspectRatio` since amp will handle that.