### PR TITLE
Update Next.js example to use `getServerSideProps`

### DIFF
--- a/examples/next-js/pages/[...slug].js
+++ b/examples/next-js/pages/[...slug].js
@@ -8,43 +8,47 @@ import Nav from '../components/nav';
 const BUILDER_API_KEY = 'YOUR_KEY';
 builder.init(BUILDER_API_KEY);
 
-class CatchallPage extends React.Component {
-  static async getInitialProps({ res, req, asPath }) {
-    // Get the upcoming route full location path and set that for Builder.io page targeting
-    const path = asPath.split('?')[0];
+const getServerSideProps = async ({req, res}) => {
+  // Get the upcoming route full location path and set that for Builder.io page targeting
+  const [path] = req.url.split('?');
 
-    // 'page' is the model name for your pages. If you made a new model with a different name,
-    // such as 'my-page', use `builder.get('my-page', ...)
-    const page = await builder
-      .get('page', { req, res, userAttributes: { urlPath: path } })
-      .promise();
+  // 'page' is the model name for your pages. If you made a new model with a different name,
+  // such as 'my-page', use `builder.get('my-page', ...)
+  const page = await builder
+    .get('page', { req, res, userAttributes: { urlPath: path } })
+    .promise();
 
-    if (res && !page) {
-      res.statusCode = 404;
+  if (res && !page) {
+    res.statusCode = 404;
+  }
+
+  return {
+    props: {
+      builderPage: {
+        ...page,
+        testVariationName: page?.testVariationName || null
+      }
     }
-    return { builderPage: page };
-  }
+  };
+};
 
-  render() {
-    const page = this.props.builderPage;
-    return (
-      <>
-        <Nav />
-        <div>
-          {page ? (
-            <>
-              <Head>
-                <title>{page.data.title}</title>
-              </Head>
-              <BuilderComponent model="page" content={page} />
-            </>
-          ) : (
-            <div>Page not found!</div>
-          )}
-        </div>
-      </>
-    );
-  }
-}
+const CatchallPage = ({builderPage: page}) => (
+  <>
+    <Nav />
+    <div>
+      {page ? (
+        <>
+          <Head>
+            <title>{page.data.title}</title>
+          </Head>
+          <BuilderComponent model="page" content={page} />
+        </>
+      ) : (
+        <div>Page not found!</div>
+      )}
+    </div>
+  </>
+);
 
 export default CatchallPage;
+export {getServerSideProps};

--- a/examples/next-js/pages/[...slug].js
+++ b/examples/next-js/pages/[...slug].js
@@ -18,16 +18,16 @@ const getServerSideProps = async ({req, res}) => {
     .get('page', { req, res, userAttributes: { urlPath: path } })
     .promise();
 
-  if (res && !page) {
+  if (!page) {
     res.statusCode = 404;
   }
 
   return {
     props: {
-      builderPage: {
+      builderPage: page ? {
         ...page,
-        testVariationName: page?.testVariationName || null
-      }
+        testVariationName: page.testVariationName || null
+      } : null
     }
   };
 };

--- a/examples/next-js/pages/[...slug].js
+++ b/examples/next-js/pages/[...slug].js
@@ -24,10 +24,9 @@ const getServerSideProps = async ({req, res}) => {
 
   return {
     props: {
-      builderPage: page ? {
-        ...page,
-        testVariationName: page.testVariationName || null
-      } : null
+      builderPage: page ?
+        { ...page, testVariationName: page.testVariationName || null } :
+        null
     }
   };
 };


### PR DESCRIPTION
It's also possible to use `getStaticProps`, but then you'd need to build the site every time you update something in Builder so I went with `getServerSideProps`.

https://nextjs.org/docs/basic-features/data-fetching