### PR TITLE
Add api key to query calls

### DIFF
--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -75,7 +75,7 @@ const parse = isReactNative
 
 function setCookie(name: string, value: string, expires?: Date) {
   let expiresString = '';
-  
+
   // TODO: need to know if secure server side
   if (expires) {
     expiresString = '; expires=' + expires.toUTCString();
@@ -1661,6 +1661,7 @@ export class Builder {
 
     const queryParams: ParamsMap = {
       omit: 'meta.componentsUsed',
+      apiKey: this.apiKey,
     };
     const pageQueryParams: ParamsMap =
       typeof location !== 'undefined'


### PR DESCRIPTION
This PR adds the `apiKey` as a query param to calls to the Builder API. The reason to add this is that the builder `query` API expects an `apiKey` as a query param to properly set the context for execution of server side javascript code. 