### PR TITLE
Fix for using inline symbols

### DIFF
--- a/packages/react/src/components/builder-page.component.tsx
+++ b/packages/react/src/components/builder-page.component.tsx
@@ -573,6 +573,11 @@ export class BuilderPage extends React.Component<
         )
       })
     }
+
+    console.log({
+      propsContent: this.props.content,
+      content: this.content
+    })
   }
 
   updateState = (fn?: (state: any) => void) => {
@@ -853,8 +858,8 @@ export class BuilderPage extends React.Component<
                         ...this.props.options
                       }}
                       inline={
-                        !Builder.isEditing &&
-                        (this.props.inlineContent || 'content' in this.props)
+                        this.props.inlineContent ||
+                        (!Builder.isEditing && 'content' in this.props)
                       }
                       contentError={this.props.contentError}
                       modelName={this.name || 'page'}

--- a/packages/react/src/components/builder-page.component.tsx
+++ b/packages/react/src/components/builder-page.component.tsx
@@ -573,11 +573,6 @@ export class BuilderPage extends React.Component<
         )
       })
     }
-
-    console.log({
-      propsContent: this.props.content,
-      content: this.content
-    })
   }
 
   updateState = (fn?: (state: any) => void) => {


### PR DESCRIPTION
We should show the inline content of a symbol in the editor, not only on render. The previous logic caused the editor to display the same content for repeated symbols that rely on inline content. In this case, one user made a "container" symbol and used inline content to change the contents of each one. Here is a screenshot of the issue this fixes.

Before:
<img width="1309" alt="Screen Shot 2020-05-20 at 1 56 15 PM" src="https://user-images.githubusercontent.com/4028730/82496728-08214900-9aa2-11ea-8844-d0c861b93750.png">

After:
<img width="1254" alt="Screen Shot 2020-05-20 at 2 00 45 PM" src="https://user-images.githubusercontent.com/4028730/82496932-559db600-9aa2-11ea-8ca8-11dd8e3d36b5.png">
