### PR TITLE
Track inline content

### DIFF
--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -386,7 +386,7 @@ export interface Action {
 
 export class Builder {
   static VERSION = version;
-  
+
   static components: Component[] = [];
   static singletonInstance: Builder;
   static useNewApi = true;
@@ -531,8 +531,7 @@ export class Builder {
 
   static isPreviewing = Boolean(
     isBrowser &&
-      ((document.referrer && document.referrer.match(/builder\.io|localhost:1234/)) ||
-        location.search.indexOf('builder.preview=') !== -1 ||
+      (location.search.indexOf('builder.preview=') !== -1 ||
         location.search.indexOf('builder.frameEditing=') !== -1)
   );
 

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -88,6 +88,12 @@ export class BuilderContent<
     // this.builder.env = 'development';
     if (!this.props.inline || Builder.isEditing) {
       this.subscribeToContent()
+    } else if (
+      this.props.inline &&
+      this.props.options?.initialContent?.length
+    ) {
+      const contentData = this.props.options.initialContent[0]
+      this.builder.trackImpression(contentData.id, contentData.variationId)
     }
 
     if (Builder.isEditing) {


### PR DESCRIPTION
This PR adds logic so that if a component is inline (i.e. using the `content` prop) we still track it. It also removes some document referrer logic around whether or not the site is a preview.