### PR TITLE
Add form support

### DIFF
--- a/packages/shopify/package-lock.json
+++ b/packages/shopify/package-lock.json
@@ -834,6 +834,34 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@builder.io/react": {
+			"version": "1.1.21",
+			"resolved": "https://registry.npmjs.org/@builder.io/react/-/react-1.1.21.tgz",
+			"integrity": "sha512-4T1t3D9tdk2FISE+g0IfodeHTuwvwSSbL8kQbWbpJB13jFLw9BD1PTH9/w79zxNKkfJZ2+0eXbGSaC3H2mrKVg==",
+			"dev": true,
+			"requires": {
+				"@builder.io/sdk": "^1.1.10",
+				"@emotion/core": "^10.0.17",
+				"create-react-context": "^0.2.3",
+				"hash-sum": "^2.0.0",
+				"node-fetch": "^2.3.0",
+				"preact": "^10.1.0",
+				"prop-types": "^15.7.2",
+				"react": ">=14",
+				"react-dom": ">=14",
+				"tslib": "^1.10.0",
+				"vm2": "^3.6.4"
+			}
+		},
+		"@builder.io/sdk": {
+			"version": "1.1.10",
+			"resolved": "https://registry.npmjs.org/@builder.io/sdk/-/sdk-1.1.10.tgz",
+			"integrity": "sha512-aINMw8vyRjRXNuaqWhFZJdcNlpg2SEBOCBFe2f+SQVFU9OGxpFLbtxkKWbIJsjFSQsgMKs/nAIrYdBd0bsARfQ==",
+			"requires": {
+				"node-fetch": "^2.2.0",
+				"tslib": "^1.10.0"
+			}
+		},
 		"@cnakazawa/watch": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
@@ -1564,6 +1592,13 @@
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 			"dev": true
+		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+			"dev": true,
+			"optional": true
 		},
 		"asn1": {
 			"version": "0.2.4",
@@ -2323,6 +2358,13 @@
 			"integrity": "sha1-YFiWYkBTr4wo775zXCWjAaYcZcU=",
 			"dev": true
 		},
+		"core-js": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+			"dev": true,
+			"optional": true
+		},
 		"core-js-compat": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.0.tgz",
@@ -2412,6 +2454,17 @@
 				"ripemd160": "^2.0.0",
 				"safe-buffer": "^5.0.1",
 				"sha.js": "^2.4.8"
+			}
+		},
+		"create-react-context": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
+			"integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"fbjs": "^0.8.0",
+				"gud": "^1.0.0"
 			}
 		},
 		"cross-spawn": {
@@ -2709,6 +2762,16 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
 			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
 			"dev": true
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"iconv-lite": "~0.4.13"
+			}
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
@@ -3030,6 +3093,22 @@
 			"dev": true,
 			"requires": {
 				"bser": "^2.0.0"
+			}
+		},
+		"fbjs": {
+			"version": "0.8.17",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"core-js": "^1.0.0",
+				"isomorphic-fetch": "^2.1.1",
+				"loose-envify": "^1.0.0",
+				"object-assign": "^4.1.0",
+				"promise": "^7.1.1",
+				"setimmediate": "^1.0.5",
+				"ua-parser-js": "^0.7.18"
 			}
 		},
 		"fill-range": {
@@ -3807,6 +3886,13 @@
 			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
 			"dev": true
 		},
+		"gud": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
+			"dev": true,
+			"optional": true
+		},
 		"handlebars": {
 			"version": "4.5.3",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
@@ -3895,6 +3981,12 @@
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
+		},
+		"hash-sum": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+			"integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
+			"dev": true
 		},
 		"hash.js": {
 			"version": "1.1.7",
@@ -4264,6 +4356,30 @@
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"node-fetch": "^1.0.1",
+				"whatwg-fetch": ">=0.10.0"
+			},
+			"dependencies": {
+				"node-fetch": {
+					"version": "1.7.3",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+					"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"encoding": "^0.1.11",
+						"is-stream": "^1.0.1"
+					}
+				}
+			}
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -5854,6 +5970,12 @@
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
 			"dev": true
 		},
+		"preact": {
+			"version": "10.4.4",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.4.4.tgz",
+			"integrity": "sha512-EaTJrerceyAPatQ+vfnadoopsMBZAOY7ak9ogVdUi5xbpR8SoHgtLryXnW+4mQOwt21icqoVR1brkU2dq7pEBA==",
+			"dev": true
+		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -5895,6 +6017,16 @@
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
+		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"asap": "~2.0.3"
+			}
 		},
 		"prompts": {
 			"version": "2.3.0",
@@ -5993,6 +6125,18 @@
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2"
+			}
+		},
+		"react-dom": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+			"integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2",
+				"scheduler": "^0.19.1"
 			}
 		},
 		"react-is": {
@@ -6629,6 +6773,13 @@
 				}
 			}
 		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"dev": true,
+			"optional": true
+		},
 		"sha.js": {
 			"version": "2.4.11",
 			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
@@ -7245,6 +7396,13 @@
 			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
+		"ua-parser-js": {
+			"version": "0.7.21",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+			"integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
+			"dev": true,
+			"optional": true
+		},
 		"uglify-js": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.1.tgz",
@@ -7410,6 +7568,12 @@
 			"integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
 			"dev": true
 		},
+		"vm2": {
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.2.tgz",
+			"integrity": "sha512-nzyFmHdy2FMg7mYraRytc2jr4QBaUY3TEGe3q3bK8EgS9WC98wxn2jrPxS/ruWm+JGzrEIIeufKweQzVoQEd+Q==",
+			"dev": true
+		},
 		"vue-template-compiler": {
 			"version": "2.6.10",
 			"resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.10.tgz",
@@ -7457,6 +7621,13 @@
 			"requires": {
 				"iconv-lite": "0.4.24"
 			}
+		},
+		"whatwg-fetch": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+			"dev": true,
+			"optional": true
 		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",

--- a/packages/shopify/package-lock.json
+++ b/packages/shopify/package-lock.json
@@ -834,34 +834,6 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@builder.io/react": {
-			"version": "1.1.21",
-			"resolved": "https://registry.npmjs.org/@builder.io/react/-/react-1.1.21.tgz",
-			"integrity": "sha512-4T1t3D9tdk2FISE+g0IfodeHTuwvwSSbL8kQbWbpJB13jFLw9BD1PTH9/w79zxNKkfJZ2+0eXbGSaC3H2mrKVg==",
-			"dev": true,
-			"requires": {
-				"@builder.io/sdk": "^1.1.10",
-				"@emotion/core": "^10.0.17",
-				"create-react-context": "^0.2.3",
-				"hash-sum": "^2.0.0",
-				"node-fetch": "^2.3.0",
-				"preact": "^10.1.0",
-				"prop-types": "^15.7.2",
-				"react": ">=14",
-				"react-dom": ">=14",
-				"tslib": "^1.10.0",
-				"vm2": "^3.6.4"
-			}
-		},
-		"@builder.io/sdk": {
-			"version": "1.1.10",
-			"resolved": "https://registry.npmjs.org/@builder.io/sdk/-/sdk-1.1.10.tgz",
-			"integrity": "sha512-aINMw8vyRjRXNuaqWhFZJdcNlpg2SEBOCBFe2f+SQVFU9OGxpFLbtxkKWbIJsjFSQsgMKs/nAIrYdBd0bsARfQ==",
-			"requires": {
-				"node-fetch": "^2.2.0",
-				"tslib": "^1.10.0"
-			}
-		},
 		"@cnakazawa/watch": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
@@ -1592,13 +1564,6 @@
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 			"dev": true
-		},
-		"asap": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-			"dev": true,
-			"optional": true
 		},
 		"asn1": {
 			"version": "0.2.4",
@@ -2358,13 +2323,6 @@
 			"integrity": "sha1-YFiWYkBTr4wo775zXCWjAaYcZcU=",
 			"dev": true
 		},
-		"core-js": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-			"dev": true,
-			"optional": true
-		},
 		"core-js-compat": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.0.tgz",
@@ -2454,17 +2412,6 @@
 				"ripemd160": "^2.0.0",
 				"safe-buffer": "^5.0.1",
 				"sha.js": "^2.4.8"
-			}
-		},
-		"create-react-context": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
-			"integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"fbjs": "^0.8.0",
-				"gud": "^1.0.0"
 			}
 		},
 		"cross-spawn": {
@@ -2762,16 +2709,6 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
 			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
 			"dev": true
-		},
-		"encoding": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"iconv-lite": "~0.4.13"
-			}
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
@@ -3093,22 +3030,6 @@
 			"dev": true,
 			"requires": {
 				"bser": "^2.0.0"
-			}
-		},
-		"fbjs": {
-			"version": "0.8.17",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"core-js": "^1.0.0",
-				"isomorphic-fetch": "^2.1.1",
-				"loose-envify": "^1.0.0",
-				"object-assign": "^4.1.0",
-				"promise": "^7.1.1",
-				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.18"
 			}
 		},
 		"fill-range": {
@@ -3886,13 +3807,6 @@
 			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
 			"dev": true
 		},
-		"gud": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
-			"dev": true,
-			"optional": true
-		},
 		"handlebars": {
 			"version": "4.5.3",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
@@ -3981,12 +3895,6 @@
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
-		},
-		"hash-sum": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
-			"integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
-			"dev": true
 		},
 		"hash.js": {
 			"version": "1.1.7",
@@ -4356,30 +4264,6 @@
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
-		},
-		"isomorphic-fetch": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"node-fetch": "^1.0.1",
-				"whatwg-fetch": ">=0.10.0"
-			},
-			"dependencies": {
-				"node-fetch": {
-					"version": "1.7.3",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-					"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"encoding": "^0.1.11",
-						"is-stream": "^1.0.1"
-					}
-				}
-			}
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -5970,12 +5854,6 @@
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
 			"dev": true
 		},
-		"preact": {
-			"version": "10.4.4",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.4.4.tgz",
-			"integrity": "sha512-EaTJrerceyAPatQ+vfnadoopsMBZAOY7ak9ogVdUi5xbpR8SoHgtLryXnW+4mQOwt21icqoVR1brkU2dq7pEBA==",
-			"dev": true
-		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -6017,16 +5895,6 @@
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
-		},
-		"promise": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"asap": "~2.0.3"
-			}
 		},
 		"prompts": {
 			"version": "2.3.0",
@@ -6125,18 +5993,6 @@
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2"
-			}
-		},
-		"react-dom": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
-			"integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
-			"dev": true,
-			"requires": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2",
-				"scheduler": "^0.19.1"
 			}
 		},
 		"react-is": {
@@ -6773,13 +6629,6 @@
 				}
 			}
 		},
-		"setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true,
-			"optional": true
-		},
 		"sha.js": {
 			"version": "2.4.11",
 			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
@@ -7396,13 +7245,6 @@
 			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
-		"ua-parser-js": {
-			"version": "0.7.21",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-			"integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
-			"dev": true,
-			"optional": true
-		},
 		"uglify-js": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.1.tgz",
@@ -7568,12 +7410,6 @@
 			"integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
 			"dev": true
 		},
-		"vm2": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.2.tgz",
-			"integrity": "sha512-nzyFmHdy2FMg7mYraRytc2jr4QBaUY3TEGe3q3bK8EgS9WC98wxn2jrPxS/ruWm+JGzrEIIeufKweQzVoQEd+Q==",
-			"dev": true
-		},
 		"vue-template-compiler": {
 			"version": "2.6.10",
 			"resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.10.tgz",
@@ -7621,13 +7457,6 @@
 			"requires": {
 				"iconv-lite": "0.4.24"
 			}
-		},
-		"whatwg-fetch": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
-			"dev": true,
-			"optional": true
 		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",

--- a/packages/shopify/react/components/form.tsx
+++ b/packages/shopify/react/components/form.tsx
@@ -1,0 +1,146 @@
+import { withBuilder, BuilderStoreContext, BuilderBlockComponent } from '@builder.io/react';
+import * as React from 'react';
+import { FormBlockProps } from '../interfaces/component-props';
+
+export function FormBlock(props: FormBlockProps) {
+  const { type, builderState, parameter, customAttributes, builderBlock, showErrors } = props;
+  let form: any = {};
+  let formAttributes: any = {
+    method: 'post',
+    acceptCharset: 'UTF-8',
+  };
+
+  // This looks for a global variable that we have server rendered by Shopify.
+  // The goal is to get the Shopify form object and allow anything that needs data from
+  // that form object to get it from the Builder state. https://shopify.dev/docs/themes/liquid/reference/objects/form
+  if (window && (window as any).BuilderShopifyData && builderBlock?.id) {
+    const formData = (window as any).BuilderShopifyData[builderBlock.id]?.form;
+
+    if (formData) {
+      Object.assign(form, formData);
+    }
+  }
+
+  // Specific logic for each type of form tag, from https://shopify.dev/docs/themes/liquid/reference/tags/theme-tags#form
+  if (type === 'activate_customer_password') {
+    formAttributes.action = '/account/activate';
+  } else if (type === 'contact') {
+    formAttributes.action = '/contact#contact_form';
+    formAttributes.id = 'contact_form';
+    formAttributes.className = 'contact-form';
+  } else if (type === 'currency') {
+    formAttributes.action = '/cart/update';
+    formAttributes.id = 'currency_form';
+    formAttributes.encType = 'multipart/form-data';
+    formAttributes.className = 'shopify-currency-form';
+  } else if (type === 'customer') {
+    formAttributes.action = '/contact#contact_form';
+    formAttributes.id = 'contact_form';
+    formAttributes.className = 'contact-form';
+  } else if (type === 'create_customer') {
+    formAttributes.action = '/account';
+    formAttributes.id = 'create_customer';
+  } else if (type === 'customer_address') {
+    formAttributes.action = '/account/addresses';
+    formAttributes.id = 'address_form_new';
+  } else if (type === 'customer_login') {
+    formAttributes.action = '/account/login';
+  } else if (type === 'guest_login') {
+    formAttributes.action = '/account/login';
+    formAttributes.id = 'customer_login_guest';
+  } else if (type === 'product') {
+    const product = builderState?.context.shopify.liquid.get(parameter, builderState.state);
+    formAttributes.action = '/cart/add';
+    formAttributes.id = `product_form_${product?.id}`;
+    formAttributes.className = 'shopify-product-form';
+    formAttributes.encType = 'multipart/form-data';
+  } else if (type === 'recover_customer_password') {
+    formAttributes.action = '/account/recover';
+  } else if (type === 'reset_customer_password') {
+    formAttributes.action = '/account/reset';
+  } else if (type === 'storefront_password') {
+    formAttributes.action = '/password';
+    formAttributes.id = 'login_form';
+    formAttributes.className = 'storefront-password-form';
+  } else if (type === 'new_comment') {
+    formAttributes.action = '/blogs/news/my-blog-post/comments#comment_form';
+    formAttributes.id = 'comment_form';
+    formAttributes.className = 'comment-form';
+  }
+
+  if (customAttributes?.length) {
+    customAttributes.forEach(attribute => {
+      const [key, value] = attribute.split(':');
+      let useValue = value?.trim();
+
+      if (useValue && builderState?.state) {
+        useValue = builderState.context.shopify.liquid.render(
+          `{{${useValue}}}`,
+          builderState.state
+        );
+      }
+
+      if (key === 'class' && formAttributes.className && useValue) {
+        formAttributes.className = `${formAttributes.className} ${useValue?.trim() || ''}`;
+      } else if (useValue) {
+        formAttributes[key] = useValue;
+      } else if (key && !useValue) {
+        // This is an attribute that does not have a value but should be added to the attribute list (e.g. boolean attribute)
+        formAttributes[key] = true;
+      }
+    });
+  }
+
+  return (
+    <BuilderStoreContext.Consumer>
+      {store => (
+        <BuilderStoreContext.Provider
+          value={{
+            ...store,
+            state: {
+              ...store.state,
+              form,
+            },
+          }}
+        >
+          <form {...formAttributes}>
+            <input type="hidden" name="form_type" value={type} />
+            <input type="hidden" name="utf8" value="✓" />
+            {type === 'currency' && (
+              <input
+                type="hidden"
+                name="return_to"
+                value={builderState?.state?.location?.pathname}
+              />
+            )}
+            {showErrors && form?.errors && <span>{form.errors}</span>}
+            {type === 'guest_login' && <input type="hidden" name="guest" value="true" />}
+            {props.builderBlock?.children?.map(item => (
+              <BuilderBlockComponent block={item} key={item.id} />
+            ))}
+          </form>
+        </BuilderStoreContext.Provider>
+      )}
+    </BuilderStoreContext.Consumer>
+  );
+}
+
+withBuilder(FormBlock, {
+  name: 'Shopify:Form',
+  hideFromInsertMenu: true,
+  noWrap: true,
+  inputs: [
+    {
+      name: 'type',
+      type: 'string',
+    },
+    {
+      name: 'parameter',
+      type: 'string',
+    },
+    {
+      name: 'customAttributes',
+      type: 'array',
+    },
+  ],
+});

--- a/packages/shopify/react/interfaces/component-props.ts
+++ b/packages/shopify/react/interfaces/component-props.ts
@@ -35,3 +35,12 @@ export interface StateProviderProps {
   state: any;
   context?: any;
 }
+
+export interface FormBlockProps {
+  customAttributes?: string[];
+  type: string;
+  parameter?: string;
+  builderState?: BuilderStore;
+  builderBlock?: BuilderElement;
+  showErrors?: boolean;
+}

--- a/packages/shopify/react/react.ts
+++ b/packages/shopify/react/react.ts
@@ -7,3 +7,4 @@ export { ShopifySection } from './components/ShopifySection';
 export { PaginateBlock } from './components/Paginate';
 export { ForBlock } from './components/For';
 export { ThemeProvider } from './components/ThemeProvider';
+export { FormBlock } from './components/Form';

--- a/packages/shopify/test/components/Form.test.tsx
+++ b/packages/shopify/test/components/Form.test.tsx
@@ -1,0 +1,170 @@
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import { FormBlock } from '../../react/components/Form';
+import { mockStateWithShopify } from '../modules/helpers';
+import * as reactTestRenderer from 'react-test-renderer';
+
+describe('Form', () => {
+  test('Basic contact form creation', () => {
+    const ref = render(
+      <FormBlock
+        type="contact"
+        customAttributes={['class: product_class_name', "data-testid: 'form-block-1'"]}
+        builderState={mockStateWithShopify({
+          product_class_name: 'product-test-class-1',
+        })}
+      />
+    );
+    expect(ref.queryByTestId('form-block-1')).toBeTruthy();
+    expect(ref.container.querySelector('#contact_form')).toBeTruthy();
+  });
+
+  it('renders contact form snapshot correctly', () => {
+    const tree = reactTestRenderer
+      .create(
+        <FormBlock
+          type="contact"
+          customAttributes={['class: product_class_name', "data-testid: 'form-block-1'"]}
+          builderState={mockStateWithShopify({
+            product_class_name: 'product-test-class-1',
+          })}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('Basic product form creation', () => {
+    const ref = render(
+      <FormBlock
+        type="product"
+        parameter="product"
+        customAttributes={['class: product_class_name', "data-testid: 'form-block-2'"]}
+        builderState={mockStateWithShopify({
+          product_class_name: 'product-test-class-1',
+          product: {
+            id: 123,
+          },
+        })}
+      />
+    );
+    expect(ref.queryByTestId('form-block-2')).toBeTruthy();
+    expect(ref.container.querySelector('#product_form_123')).toBeTruthy();
+    expect(ref.container.querySelector('.shopify-product-form')).toBeTruthy();
+    expect(ref.container.querySelector('[action="/cart/add"')).toBeTruthy();
+    expect(ref.container.querySelector('[enctype="multipart/form-data"')).toBeTruthy();
+  });
+
+  it('renders product form snapshot correctly', () => {
+    const tree = reactTestRenderer
+      .create(
+        <FormBlock
+          type="product"
+          parameter="product"
+          customAttributes={['class: product_class_name', "data-testid: 'form-block-2'"]}
+          builderState={mockStateWithShopify({
+            product_class_name: 'product-test-class-1',
+            product: {
+              id: 123,
+            },
+          })}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('Basic storefront password form creation', () => {
+    const ref = render(
+      <FormBlock
+        type="storefront_password"
+        customAttributes={['class: password_form_class', "data-testid: 'form-block-password'"]}
+        builderState={mockStateWithShopify({
+          password_form_class: 'password-class',
+        })}
+      />
+    );
+    expect(ref.queryByTestId('form-block-password')).toBeTruthy();
+    expect(ref.container.querySelector('#login_form')).toBeTruthy();
+  });
+
+  it('renders storefront password form snapshot correctly', () => {
+    const tree = reactTestRenderer
+      .create(
+        <FormBlock
+          type="storefront_password"
+          customAttributes={['class: password_form_class', "data-testid: 'form-block-password'"]}
+          builderState={mockStateWithShopify({
+            password_form_class: 'password-class',
+          })}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('Basic currency form creation', () => {
+    const ref = render(
+      <FormBlock
+        type="currency"
+        customAttributes={['class: currency_form_class', "data-testid: 'form-block-currency'"]}
+        builderState={mockStateWithShopify({
+          currency_form_class: 'currency-class',
+          location: {
+            pathname: '/some-path',
+          },
+        })}
+      />
+    );
+    expect(ref.queryByTestId('form-block-currency')).toBeTruthy();
+    expect(ref.container.querySelector('#currency_form')).toBeTruthy();
+    expect(ref.container.querySelector('[enctype="multipart/form-data"')).toBeTruthy();
+    expect(ref.container.querySelector('[action="/cart/update"')).toBeTruthy();
+  });
+
+  it('renders currency form snapshot correctly', () => {
+    const tree = reactTestRenderer
+      .create(
+        <FormBlock
+          type="currency"
+          customAttributes={['class: currency_form_class', "data-testid: 'form-block-currency'"]}
+          builderState={mockStateWithShopify({
+            currency_form_class: 'currency-class',
+            location: {
+              pathname: '/some-path',
+            },
+          })}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('handles form object from window correctly', () => {
+    (window as any).BuilderShopifyData = {
+      '1235': {
+        form: {
+          id: 1765,
+          errors: ['form', 'other-error'],
+        },
+      },
+    };
+    const tree = reactTestRenderer
+      .create(
+        <FormBlock
+          type="currency"
+          customAttributes={["data-testid: 'form-block-currency'"]}
+          showErrors={true}
+          builderBlock={{
+            '@type': '@builder.io/sdk:Element',
+            id: '1235',
+          }}
+          builderState={mockStateWithShopify({
+            currency_form_class: 'currency-class',
+          })}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/shopify/test/components/__snapshots__/Form.test.tsx.snap
+++ b/packages/shopify/test/components/__snapshots__/Form.test.tsx.snap
@@ -1,0 +1,127 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Form handles form object from window correctly 1`] = `
+<form
+  acceptCharset="UTF-8"
+  action="/cart/update"
+  className="shopify-currency-form"
+  data-testid="form-block-currency"
+  encType="multipart/form-data"
+  id="currency_form"
+  method="post"
+>
+  <input
+    name="form_type"
+    type="hidden"
+    value="currency"
+  />
+  <input
+    name="utf8"
+    type="hidden"
+    value="✓"
+  />
+  <input
+    name="return_to"
+    type="hidden"
+  />
+  <span>
+    form
+    other-error
+  </span>
+</form>
+`;
+
+exports[`Form renders contact form snapshot correctly 1`] = `
+<form
+  acceptCharset="UTF-8"
+  action="/contact#contact_form"
+  className="contact-form product-test-class-1"
+  data-testid="form-block-1"
+  id="contact_form"
+  method="post"
+>
+  <input
+    name="form_type"
+    type="hidden"
+    value="contact"
+  />
+  <input
+    name="utf8"
+    type="hidden"
+    value="✓"
+  />
+</form>
+`;
+
+exports[`Form renders currency form snapshot correctly 1`] = `
+<form
+  acceptCharset="UTF-8"
+  action="/cart/update"
+  className="shopify-currency-form currency-class"
+  data-testid="form-block-currency"
+  encType="multipart/form-data"
+  id="currency_form"
+  method="post"
+>
+  <input
+    name="form_type"
+    type="hidden"
+    value="currency"
+  />
+  <input
+    name="utf8"
+    type="hidden"
+    value="✓"
+  />
+  <input
+    name="return_to"
+    type="hidden"
+    value="/some-path"
+  />
+</form>
+`;
+
+exports[`Form renders product form snapshot correctly 1`] = `
+<form
+  acceptCharset="UTF-8"
+  action="/cart/add"
+  className="shopify-product-form product-test-class-1"
+  data-testid="form-block-2"
+  encType="multipart/form-data"
+  id="product_form_123"
+  method="post"
+>
+  <input
+    name="form_type"
+    type="hidden"
+    value="product"
+  />
+  <input
+    name="utf8"
+    type="hidden"
+    value="✓"
+  />
+</form>
+`;
+
+exports[`Form renders storefront password form snapshot correctly 1`] = `
+<form
+  acceptCharset="UTF-8"
+  action="/password"
+  className="storefront-password-form password-class"
+  data-testid="form-block-password"
+  id="login_form"
+  method="post"
+>
+  <input
+    name="form_type"
+    type="hidden"
+    value="storefront_password"
+  />
+  <input
+    name="utf8"
+    type="hidden"
+    value="✓"
+  />
+</form>
+`;


### PR DESCRIPTION
This PR adds support for the React SDK to support Shopify `form` tag builder blocks. The docs on the form tag can be found [here](https://shopify.dev/docs/themes/liquid/reference/tags/theme-tags#form). Note: there is some funky logic in the component that looks at a global window variable in order to get the data from the shopify `form` [object](https://shopify.dev/docs/themes/liquid/reference/objects/form). The export step of liquid code generation on the Builder side of things adds a script tag that gets the data from the form object and writes it to the global variable.