### PR TITLE
Add include url

### DIFF
--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -187,6 +187,7 @@ export interface GetContentOptions {
   userAttributes?: UserAttributes;
   // Alias for userAttributes.urlPath
   url?: string;
+  includeUrl?: boolean;
   cacheSeconds?: number;
   limit?: number;
   query?: any;
@@ -1749,6 +1750,14 @@ export class Builder {
         : {
             urlPath: this.getLocation().pathname,
           };
+
+    const fullUrlQueueItem = queue.find((item) => !!item.includeUrl);
+    if (fullUrlQueueItem) {
+      const location = this.getLocation();
+      if (location.origin) {
+        queryParams.url = `${location.origin}${location.pathname}${location.search}`;
+      }
+    }
 
     const urlQueueItem = useQueue?.find((item) => item.url);
     if (urlQueueItem?.url) {


### PR DESCRIPTION
This PR adds a new parameter option to Builder components called `includeUrl`. If set to true, `includeUrl` will add a `url=` query param to the content API request in order to have the content (query) API set the proper query params for use in any custom content code (i.e. use `state.location.query` in content built with Builder)