### PR TITLE
Add filter img url and Srcset logic

### DIFF
--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -446,6 +446,15 @@
 				}
 			}
 		},
+		"@builder.io/sdk": {
+			"version": "1.1.12-alpha.0",
+			"resolved": "https://registry.npmjs.org/@builder.io/sdk/-/sdk-1.1.12-alpha.0.tgz",
+			"integrity": "sha512-1GPxEuq+W9Xo/XVo0PRqjbwq6Xwvfj/eY6OA5i/ncpFlE6Y4Hg5GEfmezqckd0MB1s15sf7qeWT6qTnrtedX6A==",
+			"requires": {
+				"node-fetch": "^2.2.0",
+				"tslib": "^1.10.0"
+			}
+		},
 		"@comandeer/babel-plugin-banner": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@comandeer/babel-plugin-banner/-/babel-plugin-banner-5.0.0.tgz",

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -446,15 +446,6 @@
 				}
 			}
 		},
-		"@builder.io/sdk": {
-			"version": "1.1.11-alpha.0",
-			"resolved": "https://registry.npmjs.org/@builder.io/sdk/-/sdk-1.1.11-alpha.0.tgz",
-			"integrity": "sha512-9raHP/N1nKQEN/5Uo2v7dN6QlKDCHQ5AqRWHpT/xmT+LXMpesABqAHIO3RisFlVVHcFKrKZve31xgazxqtps9A==",
-			"requires": {
-				"node-fetch": "^2.2.0",
-				"tslib": "^1.10.0"
-			}
-		},
 		"@comandeer/babel-plugin-banner": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@comandeer/babel-plugin-banner/-/babel-plugin-banner-5.0.0.tgz",
@@ -1280,6 +1271,15 @@
 			"version": "16.9.4",
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.4.tgz",
 			"integrity": "sha512-fya9xteU/n90tda0s+FtN5Ym4tbgxpq/hb/Af24dvs6uYnYn+fspaxw5USlw0R8apDNwxsqumdRoCoKitckQqw==",
+			"dev": true,
+			"requires": {
+				"@types/react": "*"
+			}
+		},
+		"@types/react-test-renderer": {
+			"version": "16.9.2",
+			"resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-16.9.2.tgz",
+			"integrity": "sha512-4eJr1JFLIAlWhzDkBCkhrOIWOvOxcCAfQh+jiKg7l/nNZcCIL2MHl2dZhogIFKyHzedVWHaVP1Yydq/Ruu4agw==",
 			"dev": true,
 			"requires": {
 				"@types/react": "*"
@@ -12677,6 +12677,30 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
 			"integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
 		},
+		"react-test-renderer": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.13.1.tgz",
+			"integrity": "sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==",
+			"dev": true,
+			"requires": {
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2",
+				"react-is": "^16.8.6",
+				"scheduler": "^0.19.1"
+			},
+			"dependencies": {
+				"scheduler": {
+					"version": "0.19.1",
+					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+					"integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+					"dev": true,
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1"
+					}
+				}
+			}
+		},
 		"read": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -13006,9 +13030,9 @@
 					"dev": true
 				},
 				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"version": "6.0.3",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+					"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
 					"dev": true
 				},
 				"micromatch": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -143,6 +143,7 @@
     "prop-types": "^15.7.2"
   },
   "dependencies": {
+    "@builder.io/sdk": "^1.1.12-alpha.0",
     "@emotion/core": "^10.0.17",
     "hash-sum": "^2.0.0",
     "preact": "^10.1.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -96,6 +96,7 @@
     "@types/object-hash": "^1.3.0",
     "@types/react": "^16.4.1",
     "@types/react-dom": "^16.0.7",
+    "@types/react-test-renderer": "^16.9.2",
     "@types/rollup-plugin-commonjs": "^9.2.0",
     "@types/rollup-plugin-json": "^3.0.1",
     "@types/rollup-plugin-node-resolve": "^4.1.0",
@@ -110,6 +111,7 @@
     "lint-staged": "^7.0.0",
     "prettier": "^1.4.4",
     "prompt": "^1.0.0",
+    "react-test-renderer": "^16.13.1",
     "replace-in-file": "^3.0.0-beta.2",
     "rimraf": "^2.6.1",
     "rollup": "^1.32.1",
@@ -125,7 +127,7 @@
     "rollup-plugin-typescript2": "^0.11.1",
     "rollup-plugin-uglify": "^6.0.4",
     "semantic-release": "^15.0.0",
-    "ts-jest": "^22.0.0",
+    "ts-jest": "^22.4.6",
     "ts-node": "^6.0.0",
     "tslint": "^5.8.0",
     "tslint-config-prettier": "^1.1.0",
@@ -141,7 +143,6 @@
     "prop-types": "^15.7.2"
   },
   "dependencies": {
-    "@builder.io/sdk": "^1.1.11-alpha.1",
     "@emotion/core": "^10.0.17",
     "hash-sum": "^2.0.0",
     "preact": "^10.1.0",

--- a/packages/react/test/__snapshots__/image.test.tsx.snap
+++ b/packages/react/test/__snapshots__/image.test.tsx.snap
@@ -1,0 +1,82 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Image Amp image 1`] = `"<div class=\\"builder-component \\" data-name=\\"page\\" ><div class=\\"builder-content\\" builder-model=\\"page\\"><div data-builder-component=\\"page\\"><div class=\\"builder-blocks css-h47494\\" builder-type=\\"blocks\\"><div class=\\"builder-block builder-1234 css-5gq5mq\\" builder-id=\\"builder-1234\\"><amp-img layout=\\"responsive\\" role=\\"presentation\\" className=\\"builder-image css-yue2ks\\" src=\\"https://cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash.jpg?v=1592506853\\" srcSet=\\"//cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_100x100.jpg?v=1592506853 100w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_200x200.jpg?v=1592506853 200w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_400x400.jpg?v=1592506853 400w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_800x800.jpg?v=1592506853 800w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_1200x1200.jpg?v=1592506853 1200w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_1600x1600.jpg?v=1592506853 1600w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_2000x2000.jpg?v=1592506853 2000w, https://cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash.jpg?v=1592506853\\"></amp-img></div></div></div></div></div>"`;
+
+exports[`Image Builder image url 1`] = `
+<picture>
+  <source
+    srcSet="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=100 100w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=200 200w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=400 400w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=800 800w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=1200 1200w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=1600 1600w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=2000 2000w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=1003 1003w"
+    type="image/webp"
+  />
+  <img
+    alt={undefined}
+    className="builder-image css-2qdlcf"
+    onLoad={[Function]}
+    role="presentation"
+    sizes={undefined}
+    src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=1003"
+    srcSet="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=100 100w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=200 200w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=400 400w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=800 800w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=1200 1200w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=1600 1600w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=2000 2000w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=1003 1003w"
+  />
+</picture>
+`;
+
+exports[`Image Builder image url with width 1`] = `
+<picture>
+  <source
+    srcSet="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=100 100w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=200 200w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=400 400w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=800 800w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=1200 1200w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=1600 1600w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=2000 2000w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=1003 1003w"
+    type="image/webp"
+  />
+  <img
+    alt={undefined}
+    className="builder-image css-2qdlcf"
+    onLoad={[Function]}
+    role="presentation"
+    sizes={undefined}
+    src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=1003"
+    srcSet="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=100 100w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=200 200w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=400 400w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=800 800w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=1200 1200w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=1600 1600w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=2000 2000w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=1003 1003w"
+  />
+</picture>
+`;
+
+exports[`Image Lazy load 1`] = `
+<picture>
+  <source
+    srcSet="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=100 100w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=200 200w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=400 400w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=800 800w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=1200 1200w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=1600 1600w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=2000 2000w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=1003 1003w"
+    type="image/webp"
+  />
+</picture>
+`;
+
+exports[`Image Shopify image url 1`] = `
+<picture>
+  <img
+    alt={undefined}
+    className="builder-image css-2qdlcf"
+    onLoad={[Function]}
+    role="presentation"
+    sizes={undefined}
+    src="https://cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash.jpg?v=1592506853"
+    srcSet="//cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_100x100.jpg?v=1592506853 100w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_200x200.jpg?v=1592506853 200w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_400x400.jpg?v=1592506853 400w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_800x800.jpg?v=1592506853 800w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_1200x1200.jpg?v=1592506853 1200w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_1600x1600.jpg?v=1592506853 1600w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_2000x2000.jpg?v=1592506853 2000w, https://cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash.jpg?v=1592506853"
+  />
+</picture>
+`;
+
+exports[`Image with responsive styles 1`] = `"<div class=\\"builder-component \\" data-name=\\"page\\" ><div class=\\"builder-content\\" builder-model=\\"page\\"><div data-builder-component=\\"page\\"><div class=\\"builder-blocks css-h47494\\" builder-type=\\"blocks\\"><div class=\\"builder-block builder-1234 css-5gq5mq\\" builder-id=\\"builder-1234\\"><picture><img role=\\"presentation\\" class=\\"builder-image css-2qdlcf\\" src=\\"https://cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash.jpg?v=1592506853\\" srcSet=\\"//cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_100x100.jpg?v=1592506853 100w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_200x200.jpg?v=1592506853 200w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_400x400.jpg?v=1592506853 400w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_800x800.jpg?v=1592506853 800w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_1200x1200.jpg?v=1592506853 1200w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_1600x1600.jpg?v=1592506853 1600w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_2000x2000.jpg?v=1592506853 2000w, https://cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash.jpg?v=1592506853\\" sizes=\\"(max-width: 999px) 100vw, 345px\\"/></picture></div></div></div></div></div>"`;
+
+exports[`Image with sizes, srcset, and alt 1`] = `
+<picture>
+  <source
+    srcSet="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=100 100w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=200 200w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=400 400w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=800 800w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=1200 1200w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=1600 1600w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=2000 2000w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?format=webp&width=1003 1003w"
+    type="image/webp"
+  />
+  <img
+    alt="this great image"
+    className="builder-image css-2qdlcf"
+    onLoad={[Function]}
+    role={undefined}
+    sizes="(max-width: 600px) 67vw, 92vw"
+    src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=1003"
+    srcSet="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=100 100w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=200 200w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=400 400w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=800 800w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=1200 1200w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=1600 1600w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=2000 2000w, https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=1003 1003w"
+  />
+</picture>
+`;

--- a/packages/react/test/basic.test.tsx
+++ b/packages/react/test/basic.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react'
 import { renderToString } from 'react-dom/server'
 import { render } from '@testing-library/react'
-import { BuilderElement, Builder, builder } from '@builder.io/sdk'
+import { Builder, builder } from '@builder.io/sdk'
 import { BuilderPage } from '../src/builder-react'
+import { el, block } from './functions/render-block'
 
 builder.init('null')
 
@@ -13,29 +14,6 @@ describe('Dummy test', () => {
     expect(true).toBeTruthy()
   })
 })
-
-const el = (options?: Partial<BuilderElement>): BuilderElement => ({
-  '@type': '@builder.io/sdk:Element',
-  id:
-    'builder-' +
-    Math.random()
-      .toString()
-      .split('.')[1],
-  ...options
-})
-
-const block = (
-  name: string,
-  options?: any,
-  elOptions?: Partial<BuilderElement>
-) =>
-  el({
-    ...elOptions,
-    component: {
-      name,
-      options
-    }
-  })
 
 const server = (cb: () => void) => {
   Builder.isServer = true
@@ -87,7 +65,7 @@ describe('Renders tons of components', () => {
     const testApi = render(getRenderExampleElement())
   })
   it('works with SSR', () => {
-    const string = renderToString(getRenderExampleElement())
+    renderToString(getRenderExampleElement())
   })
 })
 
@@ -121,8 +99,8 @@ describe('Data rendering', () => {
 
   it('works with SSR', () => {
     server(() => {
-      const string = renderToString(getBindingExampleElement())
-      expect(string).toContain(TEXT_STRING)
+      const renderedString = renderToString(getBindingExampleElement())
+      expect(renderedString).toContain(TEXT_STRING)
     })
   })
 })

--- a/packages/react/test/functions/render-block.ts
+++ b/packages/react/test/functions/render-block.ts
@@ -1,0 +1,33 @@
+import { BuilderElement } from '@builder.io/sdk'
+
+export const el = (
+  options?: Partial<BuilderElement>,
+  useId?: number
+): BuilderElement => ({
+  '@type': '@builder.io/sdk:Element',
+  id: `builder-${
+    useId
+      ? useId
+      : Math.random()
+          .toString()
+          .split('.')[1]
+  }`,
+  ...options
+})
+
+export const block = (
+  name: string,
+  options?: any,
+  elOptions?: Partial<BuilderElement>,
+  useId?: number
+) =>
+  el(
+    {
+      ...elOptions,
+      component: {
+        name,
+        options
+      }
+    },
+    useId
+  )

--- a/packages/react/test/image.test.tsx
+++ b/packages/react/test/image.test.tsx
@@ -1,0 +1,133 @@
+import * as React from 'react'
+import { Image } from '../src/blocks/Image'
+import * as reactTestRenderer from 'react-test-renderer'
+import { block } from './functions/render-block'
+import { BuilderPage } from '../src/builder-react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+const removeRenderIdRegex = /data-source="[\s\S]*?"/g
+
+describe('Image', () => {
+  it('Builder image url', () => {
+    const tree = reactTestRenderer
+      .create(
+        <Image image="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=1003" />
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('Builder image url with width', () => {
+    const tree = reactTestRenderer
+      .create(
+        <Image image="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=1003" />
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('Shopify image url', () => {
+    const tree = reactTestRenderer
+      .create(
+        <Image image="https://cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash.jpg?v=1592506853" />
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('Amp image', () => {
+    const imageBlock = block(
+      'Image',
+      {
+        image:
+          'https://cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash.jpg?v=1592506853'
+      },
+      {
+        responsiveStyles: {
+          large: {
+            width: '345px'
+          },
+          medium: {
+            width: '100%'
+          }
+        }
+      },
+      1234
+    )
+
+    const renderedBlock = renderToStaticMarkup(
+      <BuilderPage
+        model="page"
+        ampMode
+        content={{
+          data: {
+            blocks: [imageBlock]
+          }
+        }}
+      />
+    ).replace(removeRenderIdRegex, '')
+
+    expect(renderedBlock).toMatchSnapshot()
+  })
+
+  it('Lazy load', () => {
+    const tree = reactTestRenderer
+      .create(
+        <Image
+          image="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=1003"
+          lazy
+        />
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('with sizes, srcset, and alt', () => {
+    const tree = reactTestRenderer
+      .create(
+        <Image
+          sizes="(max-width: 600px) 67vw, 92vw"
+          srcset="nosrcset"
+          altText="this great image"
+          image="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=1003"
+          amp="true"
+        />
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('with responsive styles', () => {
+    const imageBlock = block(
+      'Image',
+      {
+        image:
+          'https://cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash.jpg?v=1592506853'
+      },
+      {
+        responsiveStyles: {
+          large: {
+            width: '345px'
+          },
+          medium: {
+            width: '100%'
+          }
+        }
+      },
+      1234
+    )
+
+    const renderedBlock = renderToStaticMarkup(
+      <BuilderPage
+        model="page"
+        content={{
+          data: {
+            blocks: [imageBlock]
+          }
+        }}
+      />
+    ).replace(removeRenderIdRegex, '')
+
+    expect(renderedBlock).toMatchSnapshot()
+  })
+})

--- a/packages/shopify/js.js
+++ b/packages/shopify/js.js
@@ -1,1 +1,1 @@
-export * from './js/index.js'
+export * from './js/index.js';

--- a/packages/shopify/js.js
+++ b/packages/shopify/js.js
@@ -1,1 +1,1 @@
-export * from './js/index.js
+export * from './js/index.js'

--- a/packages/shopify/js.js
+++ b/packages/shopify/js.js
@@ -1,1 +1,1 @@
-export * from './js/index.js';
+export * from './js/index.js

--- a/packages/shopify/js/index.ts
+++ b/packages/shopify/js/index.ts
@@ -1,32 +1,9 @@
 import { Context, Liquid as LLiquid, Expression } from 'liquidjs';
 import { toValue } from './utils/async';
+import { registerLiquidFilters } from './utils/register-liquid-filters';
 
 const liquid = new LLiquid();
-
-liquid.registerFilter('money', value => {
-  const str = String(value);
-  // TODO: locales
-  return ('$' + str.slice(0, -2) + '.' + str.slice(-2)).replace('..', '.');
-});
-
-liquid.registerFilter('handle', item =>
-  item
-    .toLowerCase()
-    .replace(/[&!%]/g, '')
-    .replace(/\s+/g, '-')
-);
-
-liquid.registerFilter('strip_html', (item = '') => item.replace(/<[^>]+>/g, ''));
-
-liquid.registerFilter('truncatewords', (item, numWords) => {
-  const words = item.split(/\s+/g);
-  return `${words.slice(0, numWords).join(' ')}...`;
-});
-
-const tempNoopFilters = ['img_url', 't'];
-for (const tempNoopFilter of tempNoopFilters) {
-  liquid.registerFilter(tempNoopFilter, value => value);
-}
+registerLiquidFilters(liquid);
 
 interface State {
   [key: string]: any;

--- a/packages/shopify/js/utils/get-shopify-img-url.ts
+++ b/packages/shopify/js/utils/get-shopify-img-url.ts
@@ -1,0 +1,30 @@
+export const getShopifyImageUrl = (src: string, size: string) => {
+  if (!src) {
+    return src;
+  }
+
+  // Taken from (and modified) the shopify theme script repo
+  // https://github.com/Shopify/theme-scripts/blob/bcfb471f2a57d439e2f964a1bb65b67708cc90c3/packages/theme-images/images.js#L59
+  function removeProtocol(path: string) {
+    return path.replace(/http(s)?:/, '');
+  }
+
+  if (!size) {
+    return src;
+  }
+
+  if (size === 'master') {
+    return removeProtocol(src);
+  }
+
+  const match = src.match(/(_\d+x(\d+)?)?(\.(jpg|jpeg|gif|png|bmp|bitmap|tiff|tif)(\?v=\d+)?)$/i);
+
+  if (match) {
+    const prefix = src.split(match[0]);
+    const suffix = match[4];
+
+    return removeProtocol(`${prefix[0]}_${size}${suffix}`);
+  } else {
+    return null;
+  }
+};

--- a/packages/shopify/js/utils/register-liquid-filters.ts
+++ b/packages/shopify/js/utils/register-liquid-filters.ts
@@ -1,0 +1,52 @@
+import { Liquid } from 'liquidjs';
+
+const filters = [
+  {
+    name: 'money',
+    action(value: any) {
+      const str = String(value);
+      return ('$' + str.slice(0, -2) + '.' + str.slice(-2)).replace('..', '.');
+    },
+  },
+  {
+    name: 'handle',
+    action(item: any) {
+      return item
+        .toLowerCase()
+        .replace(/[&!%]/g, '')
+        .replace(/\s+/g, '-');
+    },
+  },
+  {
+    name: 'strip_html',
+    action(item: any) {
+      return item.replace(/<[^>]+>/g, '');
+    },
+  },
+  {
+    name: 'img_url',
+    action(item: any, size: any) {
+      return item.replace(/\.jpg|\.png|\.gif|\.jpeg/g, function(match: string) {
+        return `_${size}${match}`;
+      });
+    },
+  },
+  {
+    name: 'truncatewords',
+    action(item: any, numWords: any) {
+      const words = item.split(/\s+/g);
+      return `${words.slice(0, numWords).join(' ')}...`;
+    },
+  },
+];
+
+export const registerLiquidFilters = (liquid: Liquid) => {
+  for (const filter of filters) {
+    liquid.registerFilter(filter.name, filter.action);
+  }
+
+  const tempNoopFilters = ['t'];
+  for (const tempNoopFilter of tempNoopFilters) {
+    liquid.registerFilter(tempNoopFilter, value => value);
+  }
+};

--- a/packages/shopify/js/utils/register-liquid-filters.ts
+++ b/packages/shopify/js/utils/register-liquid-filters.ts
@@ -1,4 +1,5 @@
 import { Liquid } from 'liquidjs';
+import { getShopifyImageUrl } from './get-shopify-img-url';
 
 const filters = [
   {
@@ -25,31 +26,8 @@ const filters = [
   },
   {
     name: 'img_url',
-    action(src: any, size: any) {
-      // Taken from the shopify theme script repo
-      // https://github.com/Shopify/theme-scripts/blob/bcfb471f2a57d439e2f964a1bb65b67708cc90c3/packages/theme-images/images.js#L59
-      function removeProtocol(path: string) {
-        return path.replace(/http(s)?:/, '');
-      }
-
-      if (size === null) {
-        return src;
-      }
-
-      if (size === 'master') {
-        return removeProtocol(src);
-      }
-
-      const match = src.match(/\.(jpg|jpeg|gif|png|bmp|bitmap|tiff|tif)(\?v=\d+)?$/i);
-
-      if (match) {
-        const prefix = src.split(match[0]);
-        const suffix = match[0];
-
-        return removeProtocol(`${prefix[0]}_${size}${suffix}`);
-      } else {
-        return null;
-      }
+    action(src: string, size: string) {
+      return getShopifyImageUrl(src, size);
     },
   },
   {

--- a/packages/shopify/js/utils/register-liquid-filters.ts
+++ b/packages/shopify/js/utils/register-liquid-filters.ts
@@ -25,10 +25,31 @@ const filters = [
   },
   {
     name: 'img_url',
-    action(item: any, size: any) {
-      return item.replace(/\.jpg|\.png|\.gif|\.jpeg/g, function(match: string) {
-        return `_${size}${match}`;
-      });
+    action(src: any, size: any) {
+      // Taken from the shopify theme script repo
+      // https://github.com/Shopify/theme-scripts/blob/bcfb471f2a57d439e2f964a1bb65b67708cc90c3/packages/theme-images/images.js#L59
+      function removeProtocol(path: string) {
+        return path.replace(/http(s)?:/, '');
+      }
+
+      if (size === null) {
+        return src;
+      }
+
+      if (size === 'master') {
+        return removeProtocol(src);
+      }
+
+      const match = src.match(/\.(jpg|jpeg|gif|png|bmp|bitmap|tiff|tif)(\?v=\d+)?$/i);
+
+      if (match) {
+        const prefix = src.split(match[0]);
+        const suffix = match[0];
+
+        return removeProtocol(`${prefix[0]}_${size}${suffix}`);
+      } else {
+        return null;
+      }
     },
   },
   {

--- a/packages/shopify/package-lock.json
+++ b/packages/shopify/package-lock.json
@@ -834,6 +834,34 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@builder.io/react": {
+			"version": "1.1.22",
+			"resolved": "https://registry.npmjs.org/@builder.io/react/-/react-1.1.22.tgz",
+			"integrity": "sha512-IHgR+0xD1sfGNgnR5htxjzWzZb85pXdP8u8wZ5lSSH05jusBC9WZwNEL8e6yO7CAr8z4l4kpYbnR2BrAgmvnDA==",
+			"dev": true,
+			"requires": {
+				"@builder.io/sdk": "^1.1.11",
+				"@emotion/core": "^10.0.17",
+				"create-react-context": "^0.2.3",
+				"hash-sum": "^2.0.0",
+				"node-fetch": "^2.3.0",
+				"preact": "^10.1.0",
+				"prop-types": "^15.7.2",
+				"react": ">=14",
+				"react-dom": ">=14",
+				"tslib": "^1.10.0",
+				"vm2": "^3.6.4"
+			}
+		},
+		"@builder.io/sdk": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/@builder.io/sdk/-/sdk-1.1.11.tgz",
+			"integrity": "sha512-DCG1h6Ki2szX4AsTYWooi8ON4QEVZ+GW13fh9PBQX4ZzW8ZtiPDLheLKW3UKsmxoCPMmcFetmbF1plTu76JO9g==",
+			"requires": {
+				"node-fetch": "^2.2.0",
+				"tslib": "^1.10.0"
+			}
+		},
 		"@cnakazawa/watch": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
@@ -1564,6 +1592,13 @@
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 			"dev": true
+		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+			"dev": true,
+			"optional": true
 		},
 		"asn1": {
 			"version": "0.2.4",
@@ -2323,6 +2358,13 @@
 			"integrity": "sha1-YFiWYkBTr4wo775zXCWjAaYcZcU=",
 			"dev": true
 		},
+		"core-js": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+			"dev": true,
+			"optional": true
+		},
 		"core-js-compat": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.0.tgz",
@@ -2412,6 +2454,17 @@
 				"ripemd160": "^2.0.0",
 				"safe-buffer": "^5.0.1",
 				"sha.js": "^2.4.8"
+			}
+		},
+		"create-react-context": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
+			"integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"fbjs": "^0.8.0",
+				"gud": "^1.0.0"
 			}
 		},
 		"cross-spawn": {
@@ -2709,6 +2762,16 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
 			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
 			"dev": true
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"iconv-lite": "~0.4.13"
+			}
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
@@ -3030,6 +3093,22 @@
 			"dev": true,
 			"requires": {
 				"bser": "^2.0.0"
+			}
+		},
+		"fbjs": {
+			"version": "0.8.17",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"core-js": "^1.0.0",
+				"isomorphic-fetch": "^2.1.1",
+				"loose-envify": "^1.0.0",
+				"object-assign": "^4.1.0",
+				"promise": "^7.1.1",
+				"setimmediate": "^1.0.5",
+				"ua-parser-js": "^0.7.18"
 			}
 		},
 		"fill-range": {
@@ -3807,6 +3886,13 @@
 			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
 			"dev": true
 		},
+		"gud": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
+			"dev": true,
+			"optional": true
+		},
 		"handlebars": {
 			"version": "4.5.3",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
@@ -3895,6 +3981,12 @@
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
+		},
+		"hash-sum": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+			"integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
+			"dev": true
 		},
 		"hash.js": {
 			"version": "1.1.7",
@@ -4264,6 +4356,30 @@
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"node-fetch": "^1.0.1",
+				"whatwg-fetch": ">=0.10.0"
+			},
+			"dependencies": {
+				"node-fetch": {
+					"version": "1.7.3",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+					"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"encoding": "^0.1.11",
+						"is-stream": "^1.0.1"
+					}
+				}
+			}
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -5854,6 +5970,12 @@
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
 			"dev": true
 		},
+		"preact": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.4.5.tgz",
+			"integrity": "sha512-/GyQOM44xNbM1nx1NWWdEO9RFjOVl3Ji6HTnEP+y9OkfyvJDHXnWJPQnuknrslzu5lZfAtFavS8gka91fbFAPg==",
+			"dev": true
+		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -5895,6 +6017,16 @@
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
+		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"asap": "~2.0.3"
+			}
 		},
 		"prompts": {
 			"version": "2.3.0",
@@ -5993,6 +6125,18 @@
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2"
+			}
+		},
+		"react-dom": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+			"integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2",
+				"scheduler": "^0.19.1"
 			}
 		},
 		"react-is": {
@@ -6629,6 +6773,13 @@
 				}
 			}
 		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+			"dev": true,
+			"optional": true
+		},
 		"sha.js": {
 			"version": "2.4.11",
 			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
@@ -7245,6 +7396,13 @@
 			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
+		"ua-parser-js": {
+			"version": "0.7.21",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+			"integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
+			"dev": true,
+			"optional": true
+		},
 		"uglify-js": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.1.tgz",
@@ -7410,6 +7568,12 @@
 			"integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
 			"dev": true
 		},
+		"vm2": {
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.2.tgz",
+			"integrity": "sha512-nzyFmHdy2FMg7mYraRytc2jr4QBaUY3TEGe3q3bK8EgS9WC98wxn2jrPxS/ruWm+JGzrEIIeufKweQzVoQEd+Q==",
+			"dev": true
+		},
 		"vue-template-compiler": {
 			"version": "2.6.10",
 			"resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.10.tgz",
@@ -7457,6 +7621,13 @@
 			"requires": {
 				"iconv-lite": "0.4.24"
 			}
+		},
+		"whatwg-fetch": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.1.0.tgz",
+			"integrity": "sha512-pgmbsVWKpH9GxLXZmtdowDIqtb/rvPyjjQv3z9wLcmgWKFHilKnZD3ldgrOlwJoPGOUluQsRPWd52yVkPfmI1A==",
+			"dev": true,
+			"optional": true
 		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",

--- a/packages/shopify/package-lock.json
+++ b/packages/shopify/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@builder.io/shopify",
-	"version": "1.3.27-alpha.2",
+	"version": "1.3.28-alpha.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -834,34 +834,6 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@builder.io/react": {
-			"version": "1.1.22",
-			"resolved": "https://registry.npmjs.org/@builder.io/react/-/react-1.1.22.tgz",
-			"integrity": "sha512-IHgR+0xD1sfGNgnR5htxjzWzZb85pXdP8u8wZ5lSSH05jusBC9WZwNEL8e6yO7CAr8z4l4kpYbnR2BrAgmvnDA==",
-			"dev": true,
-			"requires": {
-				"@builder.io/sdk": "^1.1.11",
-				"@emotion/core": "^10.0.17",
-				"create-react-context": "^0.2.3",
-				"hash-sum": "^2.0.0",
-				"node-fetch": "^2.3.0",
-				"preact": "^10.1.0",
-				"prop-types": "^15.7.2",
-				"react": ">=14",
-				"react-dom": ">=14",
-				"tslib": "^1.10.0",
-				"vm2": "^3.6.4"
-			}
-		},
-		"@builder.io/sdk": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/@builder.io/sdk/-/sdk-1.1.11.tgz",
-			"integrity": "sha512-DCG1h6Ki2szX4AsTYWooi8ON4QEVZ+GW13fh9PBQX4ZzW8ZtiPDLheLKW3UKsmxoCPMmcFetmbF1plTu76JO9g==",
-			"requires": {
-				"node-fetch": "^2.2.0",
-				"tslib": "^1.10.0"
-			}
-		},
 		"@cnakazawa/watch": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
@@ -1592,13 +1564,6 @@
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 			"dev": true
-		},
-		"asap": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-			"dev": true,
-			"optional": true
 		},
 		"asn1": {
 			"version": "0.2.4",
@@ -2358,13 +2323,6 @@
 			"integrity": "sha1-YFiWYkBTr4wo775zXCWjAaYcZcU=",
 			"dev": true
 		},
-		"core-js": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-			"dev": true,
-			"optional": true
-		},
 		"core-js-compat": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.0.tgz",
@@ -2454,17 +2412,6 @@
 				"ripemd160": "^2.0.0",
 				"safe-buffer": "^5.0.1",
 				"sha.js": "^2.4.8"
-			}
-		},
-		"create-react-context": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
-			"integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"fbjs": "^0.8.0",
-				"gud": "^1.0.0"
 			}
 		},
 		"cross-spawn": {
@@ -2762,16 +2709,6 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
 			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
 			"dev": true
-		},
-		"encoding": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"iconv-lite": "~0.4.13"
-			}
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
@@ -3093,22 +3030,6 @@
 			"dev": true,
 			"requires": {
 				"bser": "^2.0.0"
-			}
-		},
-		"fbjs": {
-			"version": "0.8.17",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"core-js": "^1.0.0",
-				"isomorphic-fetch": "^2.1.1",
-				"loose-envify": "^1.0.0",
-				"object-assign": "^4.1.0",
-				"promise": "^7.1.1",
-				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.18"
 			}
 		},
 		"fill-range": {
@@ -3886,13 +3807,6 @@
 			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
 			"dev": true
 		},
-		"gud": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
-			"dev": true,
-			"optional": true
-		},
 		"handlebars": {
 			"version": "4.5.3",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
@@ -3981,12 +3895,6 @@
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
-		},
-		"hash-sum": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
-			"integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
-			"dev": true
 		},
 		"hash.js": {
 			"version": "1.1.7",
@@ -4356,30 +4264,6 @@
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
-		},
-		"isomorphic-fetch": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"node-fetch": "^1.0.1",
-				"whatwg-fetch": ">=0.10.0"
-			},
-			"dependencies": {
-				"node-fetch": {
-					"version": "1.7.3",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-					"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"encoding": "^0.1.11",
-						"is-stream": "^1.0.1"
-					}
-				}
-			}
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -5970,12 +5854,6 @@
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
 			"dev": true
 		},
-		"preact": {
-			"version": "10.4.5",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.4.5.tgz",
-			"integrity": "sha512-/GyQOM44xNbM1nx1NWWdEO9RFjOVl3Ji6HTnEP+y9OkfyvJDHXnWJPQnuknrslzu5lZfAtFavS8gka91fbFAPg==",
-			"dev": true
-		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -6017,16 +5895,6 @@
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
-		},
-		"promise": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"asap": "~2.0.3"
-			}
 		},
 		"prompts": {
 			"version": "2.3.0",
@@ -6125,18 +5993,6 @@
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2"
-			}
-		},
-		"react-dom": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
-			"integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
-			"dev": true,
-			"requires": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2",
-				"scheduler": "^0.19.1"
 			}
 		},
 		"react-is": {
@@ -6773,13 +6629,6 @@
 				}
 			}
 		},
-		"setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true,
-			"optional": true
-		},
 		"sha.js": {
 			"version": "2.4.11",
 			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
@@ -7396,13 +7245,6 @@
 			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
-		"ua-parser-js": {
-			"version": "0.7.21",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-			"integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
-			"dev": true,
-			"optional": true
-		},
 		"uglify-js": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.1.tgz",
@@ -7568,12 +7410,6 @@
 			"integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
 			"dev": true
 		},
-		"vm2": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.2.tgz",
-			"integrity": "sha512-nzyFmHdy2FMg7mYraRytc2jr4QBaUY3TEGe3q3bK8EgS9WC98wxn2jrPxS/ruWm+JGzrEIIeufKweQzVoQEd+Q==",
-			"dev": true
-		},
 		"vue-template-compiler": {
 			"version": "2.6.10",
 			"resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.10.tgz",
@@ -7621,13 +7457,6 @@
 			"requires": {
 				"iconv-lite": "0.4.24"
 			}
-		},
-		"whatwg-fetch": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.1.0.tgz",
-			"integrity": "sha512-pgmbsVWKpH9GxLXZmtdowDIqtb/rvPyjjQv3z9wLcmgWKFHilKnZD3ldgrOlwJoPGOUluQsRPWd52yVkPfmI1A==",
-			"dev": true,
-			"optional": true
 		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",


### PR DESCRIPTION
This PR adds the `img_url` filter to our version of liquidjs, as well as refactors how those filters are added.

Edit: I added in extra support for dynamically generating `srcset` values for shopify urls, as well as support to add `sizes` if none are set and we find a width set on the element.