### PR TITLE
Update to allow repeats on custom code blocks

### DIFF
--- a/packages/react/src/blocks/CustomCode.tsx
+++ b/packages/react/src/blocks/CustomCode.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 // TODO: settings context to pass this down. do in shopify-specific generated code
-const globalReplaceNodes = ({} as { [key: string]: Element }) || null
+const globalReplaceNodes = ({} as { [key: string]: Element[] }) || null
 
 const isShopify = Builder.isBrowser && 'Shopify' in window
 
@@ -24,12 +24,12 @@ if (Builder.isBrowser && globalReplaceNodes) {
           ? '.builder-custom-code'
           : '.builder-custom-code.replace-nodes'
       )
-    ).forEach(el => {
+    ).forEach((el, index) => {
       const parent = el.parentElement
       const id = parent && parent.getAttribute('builder-id')
       if (id) {
-        // TODO: keep array of these for lists
-        globalReplaceNodes[id] = el
+        globalReplaceNodes[id] = globalReplaceNodes[id] || []
+        globalReplaceNodes[id].push(el)
       }
     })
   } catch (err) {
@@ -65,14 +65,16 @@ class CustomCodeComponent extends React.Component<Props> {
       this.props.builderBlock
     ) {
       if (id && globalReplaceNodes?.[id]) {
-        const el = globalReplaceNodes[id]
+        const el = globalReplaceNodes[id].shift() || null
         this.originalRef = el
-        delete globalReplaceNodes[id]
+        if (globalReplaceNodes[id].length === 0) {
+          delete globalReplaceNodes[id]
+        }
       } else {
-        // How do if multiple...
         const existing = document.querySelectorAll(
           `.${this.props.builderBlock.id} .builder-custom-code`
         )
+
         if (existing.length === 1) {
           const node = existing[0]
           this.originalRef = node as HTMLElement

--- a/packages/react/src/blocks/CustomCode.tsx
+++ b/packages/react/src/blocks/CustomCode.tsx
@@ -24,7 +24,7 @@ if (Builder.isBrowser && globalReplaceNodes) {
           ? '.builder-custom-code'
           : '.builder-custom-code.replace-nodes'
       )
-    ).forEach((el, index) => {
+    ).forEach(el => {
       const parent = el.parentElement
       const id = parent && parent.getAttribute('builder-id')
       if (id) {
@@ -74,7 +74,6 @@ class CustomCodeComponent extends React.Component<Props> {
         const existing = document.querySelectorAll(
           `.${this.props.builderBlock.id} .builder-custom-code`
         )
-
         if (existing.length === 1) {
           const node = existing[0]
           this.originalRef = node as HTMLElement


### PR DESCRIPTION
This change makes it so we can use a custom code block with `replaceNodes` set to true within a repeated element. An example is putting in judge.me reviews on product cells in a collection page:

<img width="754" alt="Screen Shot 2020-07-17 at 4 39 26 PM" src="https://user-images.githubusercontent.com/4028730/87838647-8ef96480-c84c-11ea-88cf-bd76b55847ca.png">
