### PR TITLE
ensure we fetch shopify sections if missing contents

### DIFF
--- a/packages/shopify/react/components/SectionRef.tsx
+++ b/packages/shopify/react/components/SectionRef.tsx
@@ -12,7 +12,9 @@ const cache: { [key: string]: string } = {};
 const refs =
   Builder.isBrowser &&
   Array.from(document.querySelectorAll('[builder-shopify-section]')).reduce((memo, item) => {
-    memo[item.getAttribute('builder-shopify-section')!] = item;
+    if (item.innerHTML) {
+      memo[item.getAttribute('builder-shopify-section')!] = item;
+    }
     return memo;
   }, {} as { [key: string]: Element });
 
@@ -43,9 +45,11 @@ export const SectionRef = (props: SectionRefProps) => {
       // specifically with /shopify/v1/data etc
       fetch(
         `https://cdn.builder.io/api/v1/proxy-api?url=${encodeURIComponent(
-          `https://${
-            location.host + location.pathname.replace('/apps/builder/preview', '')
-          }?section_id=${sectionName}&${location.search.replace('?', '')}`
+          `https://${location.host +
+            location.pathname.replace(
+              '/apps/builder/preview',
+              ''
+            )}?section_id=${sectionName}&${location.search.replace('?', '')}`
         )}`
       )
         .then(res => res.text())

--- a/packages/shopify/react/components/SectionRef.tsx
+++ b/packages/shopify/react/components/SectionRef.tsx
@@ -54,8 +54,10 @@ export const SectionRef = (props: SectionRefProps) => {
       )
         .then(res => res.text())
         .then(text => {
-          cache[sectionName] = text;
-          setHtml(text);
+          // to ensure we don't keep fetching content for empty sections, we need to insert something
+          const safeText = text || '<span></span>';
+          cache[sectionName] = safeText;
+          setHtml(safeText);
           setTimeout(() => {
             if (ref.current) {
               findAndRunScripts(ref.current);


### PR DESCRIPTION
Not sure if this is the best fix, but the issue is that the SDK is rendering empty divs for shopify sections, and the `SectionRef` component was seeing those divs and deciding not to fetch the contents:
![image](https://user-images.githubusercontent.com/581205/89219727-308af080-d585-11ea-8d2a-c423b3c9208b.png)

fixes: https://app.asana.com/0/1166097513754419/1186760367446164