### PR TITLE
always pass both data and content on load

### DIFF
--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -5,7 +5,7 @@ import { applyPatchWithMinimalMutationChain } from '../functions/apply-patch-wit
 import { VariantsProvider } from './variants-provider.component';
 
 export interface BuilderContentProps<ContentType> {
-  contentLoaded?: (content: any) => void;
+  contentLoaded?: (data: any, content: any) => void;
   contentError?: (error: any) => void;
   modelName: string;
   options?: GetContentOptions;
@@ -90,7 +90,7 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
           data: this.state.data ? { ...this.state.data } : this.state.data,
         });
         if (this.props.contentLoaded) {
-          this.props.contentLoaded(this.state.data.data);
+          this.props.contentLoaded(this.state.data.data, this.state.data);
         }
 
         break;
@@ -171,7 +171,7 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
               this.firstLoad = false;
             }
             if (this.props.contentLoaded) {
-              this.props.contentLoaded(match && match.data);
+              this.props.contentLoaded(match && match.data, match);
             }
           },
           error => {

--- a/packages/react/src/components/builder-page.component.tsx
+++ b/packages/react/src/components/builder-page.component.tsx
@@ -34,11 +34,11 @@ const size = (thing: object) => Object.keys(thing).length;
 
 function debounce(func: Function, wait: number, immediate = false) {
   let timeout: any;
-  return function(this: any) {
+  return function (this: any) {
     const context = this;
     const args = arguments;
     clearTimeout(timeout);
-    timeout = setTimeout(function() {
+    timeout = setTimeout(function () {
       timeout = null;
       if (!immediate) func.apply(context, args);
     }, wait);

--- a/packages/react/src/components/builder-page.component.tsx
+++ b/packages/react/src/components/builder-page.component.tsx
@@ -34,11 +34,11 @@ const size = (thing: object) => Object.keys(thing).length;
 
 function debounce(func: Function, wait: number, immediate = false) {
   let timeout: any;
-  return function (this: any) {
+  return function(this: any) {
     const context = this;
     const args = arguments;
     clearTimeout(timeout);
-    timeout = setTimeout(function () {
+    timeout = setTimeout(function() {
       timeout = null;
       if (!immediate) func.apply(context, args);
     }, wait);
@@ -104,7 +104,7 @@ export interface BuilderPageProps {
   entry?: string;
   apiKey?: string;
   options?: GetContentOptions;
-  contentLoaded?: (data: any) => void;
+  contentLoaded?: (data: any, content: any) => void;
   renderLink?: (props: React.AnchorHTMLAttributes<any>) => React.ReactNode;
   contentError?: (error: any) => void;
   content?: Content;
@@ -285,11 +285,9 @@ export class BuilderPage extends React.Component<BuilderPageProps, BuilderPageSt
       }
 
       if (this.props.content) {
-        // TODO: this should be on didMount right bc of element ref??
-        // TODO: possibly observe for change or throw error if changes
-        this.onContentLoaded(
-          (this.props.content as any).content || this.props.content.data /*, this.props.content*/
-        );
+        // Sometimes with graphql we get the content as `content.content`
+        const content = (this.props.content as any).content || this.props.content;
+        this.onContentLoaded(content?.data, content);
       }
     }
   }
@@ -716,7 +714,7 @@ export class BuilderPage extends React.Component<BuilderPageProps, BuilderPageSt
 
     if (Builder.isEditing) {
       if (this.props.content && prevProps.content !== this.props.content) {
-        this.onContentLoaded(this.props.content);
+        this.onContentLoaded(this.props.content.data, this.props.content);
       }
     }
   }
@@ -805,7 +803,7 @@ export class BuilderPage extends React.Component<BuilderPageProps, BuilderPageSt
                       builder={this.builder}
                       ref={ref => (this.contentRef = ref)}
                       // TODO: pass entry in
-                      contentLoaded={this.onContentLoaded}
+                      contentLoaded={(data, content) => this.onContentLoaded(data, content)}
                       options={{
                         key,
                         entry: this.props.entry,
@@ -999,22 +997,8 @@ export class BuilderPage extends React.Component<BuilderPageProps, BuilderPageSt
     }
   }
 
-  onContentLoaded = (data: any) => {
-    if (data && data.meta && data.meta.kind === 'page') {
-      const future = new Date();
-      future.setDate(future.getDate() + 30);
-      this.builder.setCookie(
-        'builder.lastPageViewed',
-        [data.id, data.variationId || data.testVariationId || data.id].join(','),
-        future
-      );
-    }
-
-    // if (Builder.isBrowser) {
-    //   console.debug('Builder content load', data)
-    // }
-    // TODO: if model is page... hmm
-    if ((this.name === 'page' || this.name === 'docs-content') && Builder.isBrowser) {
+  onContentLoaded = (data: any, content: any) => {
+    if (this.name === 'page' && Builder.isBrowser) {
       if (data) {
         const { title, pageTitle, description, pageDescription } = data;
 
@@ -1042,7 +1026,7 @@ export class BuilderPage extends React.Component<BuilderPageProps, BuilderPageSt
 
     // Unsubscribe all? TODO: maybe don't continuous fire when editing.....
     if (this.props.contentLoaded) {
-      this.props.contentLoaded(data);
+      this.props.contentLoaded(data, content);
     }
 
     if (data && data.inputs && Array.isArray(data.inputs) && data.inputs.length) {


### PR DESCRIPTION
For use cases like this https://forum.builder.io/t/tracking-builder-data-to-other-analytics-providers/160