### PR TITLE
Also use server-side rendered state when rendering symbols

### DIFF
--- a/packages/react/src/blocks/Symbol.tsx
+++ b/packages/react/src/blocks/Symbol.tsx
@@ -136,7 +136,11 @@ class SymbolComponent extends React.Component<SymbolProps> {
                   context={{ ...state.context }}
                   modelName={model}
                   entry={entry}
-                  data={this.props.inheritState ? { ...data, ...state.state } : data}
+                  data={{
+                    ...data,
+                    ...(!!this.props.inheritState && state),
+                    ...this.props.builderBlock?.component?.options?.symbol?.content?.data?.state,
+                  }}
                   inlineContent={symbol?.inline}
                   {...(content && { content })}
                   options={{ key }}

--- a/packages/react/src/blocks/Symbol.tsx
+++ b/packages/react/src/blocks/Symbol.tsx
@@ -138,7 +138,7 @@ class SymbolComponent extends React.Component<SymbolProps> {
                   entry={entry}
                   data={{
                     ...data,
-                    ...(!!this.props.inheritState && state),
+                    ...(!!this.props.inheritState && state.state),
                     ...this.props.builderBlock?.component?.options?.symbol?.content?.data?.state,
                   }}
                   inlineContent={symbol?.inline}


### PR DESCRIPTION
When rendering on the server, new state generated by running symbol's JS on the server ends up in a different location. This changes makes `Symbol` blocks to _also_ use the state data in that location when rendering.

Currently this data takes precedence, that is, it will override existing keys (for example, input data). I believe this should be fine, as we want the symbol JS code to have the last word on the shape of the symbol's state.
