### PR TITLE
pass content options in the getContent method

### DIFF
--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -2033,6 +2033,6 @@ export class Builder {
     if (!this.apiKey) {
       throw new Error('Builder needs to be initialized with an API key!');
     }
-    return this.queueGetContent(modelName);
+    return this.queueGetContent(modelName, options);
   }
 }


### PR DESCRIPTION
We've had a few people request a method in the SDK to fetch all pages for a model. The current `builder.get` method only fetches the first match. You can currently use something like `builder.queueGetContent('page', {limit: 50})`, but this change fixes the `getContent` method to pass through the options. It's slightly more developer friendly than `queueGetContent`.