### PR TITLE
custom tracking hooks

### DIFF
--- a/packages/angular/src/app/modules/builder/directives/builder-content.directive.ts
+++ b/packages/angular/src/app/modules/builder/directives/builder-content.directive.ts
@@ -129,7 +129,8 @@ export class BuilderContentDirective implements OnInit, OnDestroy {
           this.matchId,
           match && match.variationId,
           this.clickTracked,
-          event
+          event,
+          { content: match }
         );
       }
       this.clickTracked = true;
@@ -315,7 +316,7 @@ export class BuilderContentDirective implements OnInit, OnDestroy {
             viewRef.context.$implicit = match.data;
             // viewRef.context.results = result.map(item => ({ ...item.data, $id: item.id }));
             if (!hydrate && this.builder.autoTrack) {
-              this.builder.trackImpression(match.id, match.variationId);
+              this.builder.trackImpression(match.id, match.variationId, { content: match });
             }
           }
           if (!viewRef.destroyed) {

--- a/packages/react-native/src/components/builder-content.component.tsx
+++ b/packages/react-native/src/components/builder-content.component.tsx
@@ -50,7 +50,7 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
               // TODO: autoTrack
               if (builder.autoTrack) {
                 this.trackedImpression = true;
-                builder.trackImpression(match.id!, (match as any).variationId);
+                builder.trackImpression(match.id!, (match as any).variationId, { content: match });
               }
               this.firstLoad = false;
             }

--- a/packages/react-native/src/components/builder-simple.component.tsx
+++ b/packages/react-native/src/components/builder-simple.component.tsx
@@ -37,7 +37,8 @@ export class BuilderSimpleComponent extends React.Component<BuilderSimpleCompone
           data.id,
           data.testVariationId || data.id,
           this.trackedClick,
-          event.nativeEvent
+          event.nativeEvent,
+          { content: data }
         );
         if (!this.trackedClick) {
           this.trackedClick = true;
@@ -120,7 +121,7 @@ export class BuilderSimpleComponent extends React.Component<BuilderSimpleCompone
           });
           if (builder.canTrack) {
             // TODO: track unique vs not as well
-            builder.trackImpression(data.id, data.testVariationId || data.id);
+            builder.trackImpression(data.id, data.testVariationId || data.id, { content: data });
           }
           if (data.data && data.data.html) {
             if (this.props.onLoad) {

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -115,7 +115,10 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
       this.subscribeToContent();
     } else if (this.props.inline && this.options?.initialContent?.length) {
       const contentData = this.options.initialContent[0];
-      this.builder.trackImpression(contentData.id, this.renderedVairantId);
+      // TODO: intersectionobserver like in subscribetocontent - reuse the logic
+      this.builder.trackImpression(contentData.id, this.renderedVairantId, {
+        content: contentData,
+      });
     }
 
     if (Builder.isEditing) {
@@ -147,7 +150,10 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
                         entries.forEach(entry => {
                           // In view
                           if (entry.intersectionRatio > 0 && !this.trackedImpression) {
-                            this.builder.trackImpression(match.id!, this.renderedVairantId);
+                            this.builder.trackImpression(match.id!, this.renderedVairantId, {
+                              content: this.data,
+                            }),
+                              { content: this.data };
                             this.trackedImpression = true;
                             if (this.ref) {
                               observer.unobserve(this.ref);
@@ -165,7 +171,9 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
                 }
                 if (!addedObserver) {
                   this.trackedImpression = true;
-                  this.builder.trackImpression(match.id!, this.renderedVairantId);
+                  this.builder.trackImpression(match.id!, this.renderedVairantId, {
+                    content: match,
+                  });
                 }
               }
               this.firstLoad = false;
@@ -204,7 +212,9 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
       return;
     }
     if (builder.autoTrack) {
-      this.builder.trackInteraction(content.id, this.renderedVairantId, this.clicked, event);
+      this.builder.trackInteraction(content.id, this.renderedVairantId, this.clicked, event, {
+        content,
+      });
     }
     if (!this.clicked) {
       this.clicked = true;


### PR DESCRIPTION
for adding additional properties to events tracked by Builder

```ts
  /**
   * Set a hook to modify events being tracked from builder, such as impressions and clicks
   *
   * For example, to track the model ID of each event associated with content for querying
   * by mode, you can do
   *
   *    builder.setTrackingHook((event, context) => {
   *      if (context.content) {
   *        event.data.metadata.modelId = context.content.modelId
   *      }
   *    })
   */
```