### PR TITLE
fix: support ssr rendering

### DIFF
--- a/packages/angular/src/app/modules/builder/polyfills/custom-elements-es5-adapter.ts
+++ b/packages/angular/src/app/modules/builder/polyfills/custom-elements-es5-adapter.ts
@@ -10,16 +10,18 @@ if (typeof window !== 'undefined') {
       anyWindow.customElements.polyfillWrapFlushCallback
     )
   ) {
-    const ModifiedHTMLElement = HTMLElement;
-    // https://github.com/webcomponents/custom-elements/blame/c078ea4201c82551462ccace1ae91e22b576beb8/src/native-shim.js#L37
-    const wrapperForTheName = {
-      HTMLElement: function HTMLElement() {
-        return Reflect.construct(ModifiedHTMLElement, [], this.constructor);
-      },
-    };
-    anyWindow.HTMLElement = wrapperForTheName['HTMLElement'];
-    HTMLElement.prototype = ModifiedHTMLElement.prototype;
-    HTMLElement.prototype.constructor = HTMLElement;
-    Object.setPrototypeOf(HTMLElement, ModifiedHTMLElement);
+    try {
+      const ModifiedHTMLElement = HTMLElement;
+      // https://github.com/webcomponents/custom-elements/blame/c078ea4201c82551462ccace1ae91e22b576beb8/src/native-shim.js#L37
+      const wrapperForTheName = {
+        HTMLElement: function HTMLElement() {
+          return Reflect.construct(ModifiedHTMLElement, [], this.constructor);
+        },
+      };
+      anyWindow.HTMLElement = wrapperForTheName['HTMLElement'];
+      HTMLElement.prototype = ModifiedHTMLElement.prototype;
+      HTMLElement.prototype.constructor = HTMLElement;
+      Object.setPrototypeOf(HTMLElement, ModifiedHTMLElement);
+    } catch (e) { }
   }
 }


### PR DESCRIPTION
## Description

This block of code is throwing an error on the server side with universal because it says that you cannot redefine `HTMLElement.prototype` as it is read only.
Adding the try catch allows me to use BuilderIo on the server side (by using `prerender` on your servers).