### PR TITLE
fix impression tracking

### DIFF
--- a/packages/angular/src/app/modules/builder/directives/builder-content.directive.ts
+++ b/packages/angular/src/app/modules/builder/directives/builder-content.directive.ts
@@ -316,7 +316,9 @@ export class BuilderContentDirective implements OnInit, OnDestroy {
             viewRef.context.$implicit = match.data;
             // viewRef.context.results = result.map(item => ({ ...item.data, $id: item.id }));
             if (!hydrate && this.builder.autoTrack) {
-              this.builder.trackImpression(match.id, match.variationId, { content: match });
+              this.builder.trackImpression(match.id, match.variationId, undefined, {
+                content: match,
+              });
             }
           }
           if (!viewRef.destroyed) {

--- a/packages/react-native/src/components/builder-content.component.tsx
+++ b/packages/react-native/src/components/builder-content.component.tsx
@@ -50,7 +50,9 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
               // TODO: autoTrack
               if (builder.autoTrack) {
                 this.trackedImpression = true;
-                builder.trackImpression(match.id!, (match as any).variationId, { content: match });
+                builder.trackImpression(match.id!, (match as any).variationId, undefined, {
+                  content: match,
+                });
               }
               this.firstLoad = false;
             }

--- a/packages/react-native/src/components/builder-simple.component.tsx
+++ b/packages/react-native/src/components/builder-simple.component.tsx
@@ -121,7 +121,9 @@ export class BuilderSimpleComponent extends React.Component<BuilderSimpleCompone
           });
           if (builder.canTrack) {
             // TODO: track unique vs not as well
-            builder.trackImpression(data.id, data.testVariationId || data.id, { content: data });
+            builder.trackImpression(data.id, data.testVariationId || data.id, undefined, {
+              content: data,
+            });
           }
           if (data.data && data.data.html) {
             if (this.props.onLoad) {

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -116,7 +116,7 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
     } else if (this.props.inline && this.options?.initialContent?.length) {
       const contentData = this.options.initialContent[0];
       // TODO: intersectionobserver like in subscribetocontent - reuse the logic
-      this.builder.trackImpression(contentData.id, this.renderedVairantId, {
+      this.builder.trackImpression(contentData.id, this.renderedVairantId, undefined, {
         content: contentData,
       });
     }
@@ -150,9 +150,14 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
                         entries.forEach(entry => {
                           // In view
                           if (entry.intersectionRatio > 0 && !this.trackedImpression) {
-                            this.builder.trackImpression(match.id!, this.renderedVairantId, {
-                              content: this.data,
-                            }),
+                            this.builder.trackImpression(
+                              match.id!,
+                              this.renderedVairantId,
+                              undefined,
+                              {
+                                content: this.data,
+                              }
+                            ),
                               { content: this.data };
                             this.trackedImpression = true;
                             if (this.ref) {
@@ -171,7 +176,7 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
                 }
                 if (!addedObserver) {
                   this.trackedImpression = true;
-                  this.builder.trackImpression(match.id!, this.renderedVairantId, {
+                  this.builder.trackImpression(match.id!, this.renderedVairantId, undefined, {
                     content: match,
                   });
                 }


### PR DESCRIPTION
I believe our issues was accidentally sending `context` which includes the entire `content` document (huge JSON tree) as `customProperties` (which go into our query string, logs, and DB) causing some area to fail for tracking - either at the S3 level (failure to log the entire request being too large) or at the parsing level (long request maybe gets truncated and events JSON could not be parsed) or at the saving level (bigQuery string field max length exceeded)