### PR TITLE
fix(sdk): fix statement in getLocation()

### DIFF
--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -1501,10 +1501,7 @@ export class Builder {
     // in ssr mode
     if (this.request) {
       parsedLocation = parse(this.request.url);
-    }
-
-    // in the browser
-    if (typeof location === 'object') {
+    } else if (typeof location === 'object') {  // in the browser
       parsedLocation = parse(location.href);
     }
 


### PR DESCRIPTION
## Issue
When the app is rendered on serverside the `urlPath` in API request is wrong - always `/` (SSR with mocked window/location)

## Description
When using SSR there is no need to check the `location` object 'cause if someone will mock `window`/`location` on the server side then `parsedLocation` will be overwritten by the second statement - which IMO shouldn't happen.

_Screenshot_
Behavior on SSR before the change(when  `window`/`location` are mocked):
![image](https://user-images.githubusercontent.com/22659410/94331728-4dfd9900-ffcf-11ea-81f8-70757b123551.png)
