### PR TITLE
include model names in generated keys for getAll

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -610,6 +610,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "hash-sum": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg=="
+    },
     "hash.js": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -55,6 +55,12 @@
       "integrity": "sha512-F/v7t1LwS4vnXuPooJQGBRKRGIoxWUTmA4VHfqjOccFsNDThD5bfUNpITive6s352O7o384wcpEaDV8rHCehDA==",
       "dev": true
     },
+    "@types/hash-sum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/hash-sum/-/hash-sum-1.0.0.tgz",
+      "integrity": "sha512-FdLBT93h3kcZ586Aee66HPCVJ6qvxVjBlDWNmxSGSbCZe9hTsjRKdSsl4y1T+3zfujxo9auykQMnFsfyHWD7wg==",
+      "dev": true
+    },
     "@types/js-cookie": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.4.tgz",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -55,12 +55,6 @@
       "integrity": "sha512-F/v7t1LwS4vnXuPooJQGBRKRGIoxWUTmA4VHfqjOccFsNDThD5bfUNpITive6s352O7o384wcpEaDV8rHCehDA==",
       "dev": true
     },
-    "@types/hash-sum": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/hash-sum/-/hash-sum-1.0.0.tgz",
-      "integrity": "sha512-FdLBT93h3kcZ586Aee66HPCVJ6qvxVjBlDWNmxSGSbCZe9hTsjRKdSsl4y1T+3zfujxo9auykQMnFsfyHWD7wg==",
-      "dev": true
-    },
     "@types/js-cookie": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.4.tgz",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "hash-sum": "^2.0.0",
     "node-fetch": "^2.2.0",
     "tslib": "^1.10.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,6 @@
     "@medv/finder": "^1.1.1",
     "@types/axios": "^0.14.0",
     "@types/es6-promise": "^3.3.0",
-    "@types/hash-sum": "^1.0.0",
     "@types/js-cookie": "^2.1.0",
     "@types/json-stable-stringify": "^1.0.32",
     "@types/node": "^9.4.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,6 +28,7 @@
     "@medv/finder": "^1.1.1",
     "@types/axios": "^0.14.0",
     "@types/es6-promise": "^3.3.0",
+    "@types/hash-sum": "^1.0.0",
     "@types/js-cookie": "^2.1.0",
     "@types/json-stable-stringify": "^1.0.32",
     "@types/node": "^9.4.6",

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -15,7 +15,7 @@ import { getTopLevelDomain } from './functions/get-top-level-domain';
 import serverOnlyRequire from './functions/server-only-require.function';
 import { BuilderContent } from './types/content';
 import { uuid } from './functions/uuid';
-import hash from 'hash-sum';
+const hash = require('hash-sum');
 
 export type Url = any;
 

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -15,7 +15,7 @@ import { getTopLevelDomain } from './functions/get-top-level-domain';
 import serverOnlyRequire from './functions/server-only-require.function';
 import { BuilderContent } from './types/content';
 import { uuid } from './functions/uuid';
-const hash =  require('hash-sum');
+import * as hash from 'hash-sum';
 
 export type Url = any;
 

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -15,7 +15,7 @@ import { getTopLevelDomain } from './functions/get-top-level-domain';
 import serverOnlyRequire from './functions/server-only-require.function';
 import { BuilderContent } from './types/content';
 import { uuid } from './functions/uuid';
-import hash from 'hash-sum';
+import * as hash from 'hash-sum';
 
 export type Url = any;
 

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -15,7 +15,7 @@ import { getTopLevelDomain } from './functions/get-top-level-domain';
 import serverOnlyRequire from './functions/server-only-require.function';
 import { BuilderContent } from './types/content';
 import { uuid } from './functions/uuid';
-import * as hash from 'hash-sum';
+const hash =  require('hash-sum');
 
 export type Url = any;
 

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -15,7 +15,7 @@ import { getTopLevelDomain } from './functions/get-top-level-domain';
 import serverOnlyRequire from './functions/server-only-require.function';
 import { BuilderContent } from './types/content';
 import { uuid } from './functions/uuid';
-import * as hash from 'hash-sum';
+import hash from 'hash-sum';
 
 export type Url = any;
 

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -2106,7 +2106,8 @@ export class Builder {
           options.key ||
           // Make the key include all options so we don't reuse cache for the same conent fetched
           // with different options
-          (Builder.isBrowser && hash(omit(options, 'initialContent', 'req', 'res'))) ||
+          (Builder.isBrowser &&
+            `${modelName}:${hash(omit(options, 'initialContent', 'req', 'res'))}`) ||
           undefined,
       })
       .promise();

--- a/packages/core/src/typings/index.d.ts
+++ b/packages/core/src/typings/index.d.ts
@@ -1,2 +1,3 @@
 declare module '*.json';
 declare module 'es6-promise';
+declare module 'hash-sum';

--- a/packages/core/src/typings/index.d.ts
+++ b/packages/core/src/typings/index.d.ts
@@ -1,3 +1,2 @@
 declare module '*.json';
 declare module 'es6-promise';
-declare module 'hash-sum';

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -11,6 +11,7 @@
     "declarationDir": "dist",
     "lib": ["dom", "es5", "es2015.promise"],
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "typeRoots": ["./node_modules/@types"]
   },
   "include": ["./index.ts", "./src/**/*.ts", "./types.d.ts"]

--- a/packages/core/types.d.ts
+++ b/packages/core/types.d.ts
@@ -1,3 +1,4 @@
+declare module 'hash-sum';
 declare module 'unique-selector' {
   let unique: (key: Element) => string;
   export default unique;


### PR DESCRIPTION
otherwise there could be unwanted key overlaps with same options but different models