### PR TITLE
add/remove boolean attributes for html video

### DIFF
--- a/packages/react/src/blocks/Video.tsx
+++ b/packages/react/src/blocks/Video.tsx
@@ -40,9 +40,18 @@ class VideoComponent extends React.Component<{
 
   updateVideo() {
     if (this.video) {
-      this.video.setAttribute('muted', String(this.props.muted));
-      this.video.setAttribute('playsinline', String(this.props.playsInline));
-      this.video.setAttribute('autoplay', String(this.props.autoPlay));
+      const attributes: Array<'muted' | 'playsInline' | 'autoPlay'> = [
+        'muted',
+        'playsInline',
+        'autoPlay',
+      ];
+      attributes.forEach(attr => {
+        if (this.props[attr]) {
+          this.video?.setAttribute(attr.toLowerCase(), 'true');
+        } else {
+          this.video?.removeAttribute(attr.toLowerCase());
+        }
+      });
     }
   }
 


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes

>The values "true" and "false" are not allowed on boolean attributes. To represent a false value, the attribute has to be omitted altogether.

React is smart and will remove if we're binding to the attributes, but in this case we're using `setAttribute` so we need to handle ourselves.