### PR TITLE
[FIX] typo in catchallBuilderPage class

### DIFF
--- a/examples/next-js/README.md
+++ b/examples/next-js/README.md
@@ -100,7 +100,7 @@ class CatchallBuilderPage extends React.Component {
           <BuilderComponent model="page" content={this.props.builderPage} />
         ) : (
           // Render your 404 page (or redirect to it)
-          <NotFound>
+          <NotFound/>
         )}
       </div>
     );


### PR DESCRIPTION
Fixed a typo in **catchallBuilderPage** resulting by an error at compilation.
