### PR TITLE
Cleanup warnings & update method to fetch the slug

### DIFF
--- a/examples/next-js/components/nav.js
+++ b/examples/next-js/components/nav.js
@@ -13,7 +13,7 @@ const Nav = () => (
   <nav>
     <ul>
       <li>
-        <Link prefetch href="/">
+        <Link href="/">
           <a>Home</a>
         </Link>
       </li>

--- a/examples/next-js/pages/[...slug].js
+++ b/examples/next-js/pages/[...slug].js
@@ -8,10 +8,10 @@ import Nav from '../components/nav';
 const BUILDER_API_KEY = 'YOUR_KEY';
 builder.init(BUILDER_API_KEY);
 
-const getServerSideProps = async ({ req, res }) => {
+const getServerSideProps = async ({ req, res, params }) => {
   // Get the upcoming route full location path and set that for Builder.io page targeting
-  const [path] = req.url.split('?');
-
+  const path = ['/', params?.slug].join('');
+  
   // 'page' is the model name for your pages. If you made a new model with a different name,
   // such as 'my-page', use `builder.get('my-page', ...)
   const page = await builder.get('page', { req, res, userAttributes: { urlPath: path } }).promise();


### PR DESCRIPTION
## Description

This pull request updates 2 things in the Next JS example - 

1. Cleans up warning for the prefetch syntax update.

```
event - compiled successfully
Next.js auto-prefetches automatically based on viewport. The prefetch attribute is no longer needed. More: https://err.sh/vercel/next.js/prefetch-true-deprecated
Next.js auto-prefetches automatically based on viewport. The prefetch attribute is no longer needed. More: https://err.sh/vercel/next.js/prefetch-true-deprecated
```

2. Update how we fetch slug from the dynamic route generated by Next JS. The newer versions of next js make the dynamic slug available as a param attribute in the `getServerSideProps`. The updated code, makes use of this as opposed to reading from the url. Following is what we get when we to fetch `params` in `getServerSideProps` :

```
{ slug: [ 'dynamic-page-slug' ] }
```