### PR TITLE
fix a/b tests on data model in static mode

### DIFF
--- a/packages/react/src/components/variants-provider.component.tsx
+++ b/packages/react/src/components/variants-provider.component.tsx
@@ -6,9 +6,11 @@ function getData(content: BuilderContentVariation) {
     return undefined;
   }
 
+  const { blocks, blocksString } = content.data;
+  const hasBlocks = Array.isArray(blocks) || typeof blocksString === 'string';
   const newData: any = {
     ...content.data,
-    blocks: content.data.blocks || JSON.parse(content.data.blocksString),
+    ...(hasBlocks && { blocks: blocks || JSON.parse(blocksString) }),
   };
 
   delete newData.blocksString;


### PR DESCRIPTION
With this fix users will be able to a/b test data models when static generation or in the server.

```
  <BuilderContent
      isStatic
      modelName="shopify-product"
      // passing the override data this way will allow you to edit while previewing, and a/b testing product data
      content={productOverride}
    >
      {(data, _, full) => (
      )}
    </BuilderContent>


```