### PR TITLE
Allow the usage of targeting attributes in the url

### DIFF
--- a/plugins/dynamic-dropdown/__tests__/dropdownPropsExtractor.test.ts
+++ b/plugins/dynamic-dropdown/__tests__/dropdownPropsExtractor.test.ts
@@ -99,6 +99,29 @@ describe('Get Massaged Props', () => {
       expect(actual.url).toBe(expectedUrl);
     });
 
+    it('replaces templated url with nested component tokens', () => {
+      const templatedUrl = 'https://www.domain.net/v2/{{targeting.locale.0}}/users';
+
+      const builderComponentVariables = { targeting: { locale: [ locale ] } };
+      const builderPluginObject = {
+        object: { get: (key: string): any => builderComponentVariables[key] },
+      };
+      const actual = getMassagedProps({
+        field: {
+          options: {
+            url: templatedUrl,
+            mapper: '() => {}',
+            dependencyComponentVariables: ['componentVariable'],
+          },
+        },
+        ...builderPluginContext,
+        ...builderPluginObject,
+      });
+
+      const expectedUrl = `https://www.domain.net/v2/${locale}/users`;
+      expect(actual.url).toBe(expectedUrl);
+    });
+
     it('mapper function as mapper', () => {
       const expected = '() => {}';
 

--- a/plugins/dynamic-dropdown/src/components/index.tsx
+++ b/plugins/dynamic-dropdown/src/components/index.tsx
@@ -12,7 +12,10 @@ export const Component = observer((props: any) => {
   const newDependenciesKey = getDependenciesKeyFrom(props);
   const dependenciesKeyRef = useRef(newDependenciesKey);
 
-  const newProps = { ...props, newDependenciesKey };
+  const targeting = props.context.designerState.editingContentModel.query.toJSON()
+      .reduce((accum: any, q: any) => ({ ...accum, [q.property]: q.value}), {})
+
+  const newProps = { ...props, newDependenciesKey, targeting };
 
   if (expectMultipleDropdowns) {
     return <MultipleDropdowns {...newProps} ref={dependenciesKeyRef} />;

--- a/plugins/dynamic-dropdown/src/helpers/dropdownPropsExtractor.ts
+++ b/plugins/dynamic-dropdown/src/helpers/dropdownPropsExtractor.ts
@@ -26,7 +26,7 @@ const isNullOrEmpty = (input: String) => {
 export { getMassagedProps };
 
 function getView(props: any, dependencyComponentVariables?: any[]) {
-  const view = Object.assign({}, props.context.designerState.editingContentModel.data.toJSON());
+  const view = Object.assign({}, props.context.designerState.editingContentModel.data.toJSON(), { targeting: props.targeting });
 
   if (dependencyComponentVariables && dependencyComponentVariables.length) {
     dependencyComponentVariables.forEach((key: string) => {
@@ -52,11 +52,16 @@ function renderTemplate(url: any, view: any) {
   return renderedUrl;
 }
 
+function resolve(path: string, view: any, separator= '.') {
+  const keys = path.split(separator)
+  return keys.reduce((value, key) => value?.[key], view)
+}
+
 function validateTemplateVariables(variablesToReplace: any, view: any) {
   let variablesWithError: string[] = [];
 
   variablesToReplace.forEach((variableToReplace: string) => {
-    if (!Object.keys(view).includes(variableToReplace)) {
+    if (!resolve(variableToReplace, view)) {
       variablesWithError.push(`{{${variableToReplace}}}`);
     }
   });


### PR DESCRIPTION
## Description

I wanted to use my targeting attributes in the url of the `dynamic-dropdown` but they weren't available.
![image](https://user-images.githubusercontent.com/2356776/105131848-a04e6100-5b4e-11eb-8f5d-5407a93b49d3.png)

I've stumbled my way through an implementation that looks like it does what I want and was going to publish my own plugin but realised this probably doesn't warrant a standalone plugin but would be better to enhance the existing one.

This allows me to use targeting properties in the `dynamic-dropdown` url like this:
```js
{
    name: "dropdown",
    type: "dynamic-dropdown",
    options: {
        url: `https://example.com/api/v1/users?locale={{targeting.locale.0}}`,
        mapper: mapper.toString(),
    },
},
```

I'd be keen to hear any feedback you've got to improve this.

_Screenshot_
(no visual changes)
