### PR TITLE
BuilderComponent -> RenderContent

### DIFF
--- a/packages/react/src/builder-react.ts
+++ b/packages/react/src/builder-react.ts
@@ -22,6 +22,7 @@ export { noWrap } from './functions/no-wrap';
 
 export { BuilderPage, onChange };
 export { BuilderPage as BuilderComponent };
+export { BuilderPage as RenderContent };
 
 export { Text } from './blocks/Text';
 export { Fragment } from './blocks/Fragment';


### PR DESCRIPTION
`Component` is far too vague, and causing confusion. We want to move away from using the word `component` for anything besides what you register to Builder. Even those we may change to Builder.registerBlock, to also make more clear

In the meantime, want to create this alias so we can start migrating

`<BuilderComponent ... />` -> `<RenderContent ... />

later going to move `component model` -> `section model`

and potentially `Builder.registerComponent` to `Builder.registerBlock` and keep using the word "Builder block" for the things you add to be dropped into the editor