### PR TITLE
Don't use variations if DNT is set or tracking is disallowed

### DIFF
--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -2021,7 +2021,7 @@ export class Builder {
           testVariationName: cookieVariation.name,
         };
       }
-      if (item.variations && size(item.variations)) {
+      if (this.canTrack && item.variations && size(item.variations)) {
         let n = 0;
         const random = Math.random();
         for (const id in item.variations) {

--- a/packages/react/src/components/variants-provider.component.tsx
+++ b/packages/react/src/components/variants-provider.component.tsx
@@ -20,7 +20,7 @@ function getData(content: BuilderContentVariation) {
 const variantsScript = (variantsString: string, contentId: string) =>
   `
 (function() {
-  if (window.builderNoTrack) {
+  if (window.builderNoTrack || window.navigator.doNotTrack === '1') {
     return;
   }
 
@@ -104,6 +104,8 @@ export const VariantsProvider: React.SFC<VariantsProviderProps> = ({
   initialContent,
   children,
 }) => {
+  if (!builder.canTrack) return children([initialContent]);
+
   const hasTests = Boolean(Object.keys(initialContent?.variations || {}).length);
 
   // when it's not isStatic variants are already elected by the sdk


### PR DESCRIPTION
## Description

This changes attempt to skip all the testing/variation selection code if we can detect that DoNotTrack is set in the browser or if the internal `window.builderNoTrack` flag is set. The idea is to provide a consistent user experience when tracking is disallowed/disabled, which in this case only the default variation should always be used.