### PR TITLE
Try extracting the current Shopify Theme ID out of `state.location.query`

### DIFF
--- a/packages/shopify/react/components/LiquidBlock.tsx
+++ b/packages/shopify/react/components/LiquidBlock.tsx
@@ -49,7 +49,7 @@ export const LiquidBlock = ({
         return;
       }
 
-      const previewThemeID = builderState?.state?.location?.query?.preview_theme_id;
+      const previewThemeID = Builder.isBrowser && window.Shopify?.theme?.id || builderState?.state?.location?.query?.preview_theme_id;
       fetch(
         `${builder.host}/api/v1/shopify/data/render-liquid-snippet?snippet=${blockName}&apiKey=${
           builderState?.context.apiKey

--- a/packages/shopify/react/components/LiquidBlock.tsx
+++ b/packages/shopify/react/components/LiquidBlock.tsx
@@ -27,6 +27,7 @@ export const LiquidBlock = ({
   const [html, setHtml] = useState<string | null>(null);
   const ref = useRef<HTMLDivElement | null>(null);
   const blockName = templatePath?.split('/')[1].replace(/\.liquid$/, '')!;
+
   useEffect(() => {
     const blockId = builderBlock?.id;
     const node = blockId && refs && refs[blockId];
@@ -37,19 +38,24 @@ export const LiquidBlock = ({
       if (cache[cacheKey]) {
         return;
       }
+
       // Convert `sections/foo.liquid` -> `foo`
       if (!blockName) {
         return;
       }
+
       if (cache[cacheKey]) {
         setHtml(cache[cacheKey]);
         return;
       }
 
+      const previewThemeID = builderState?.state?.location?.query?.preview_theme_id;
       fetch(
         `${builder.host}/api/v1/shopify/data/render-liquid-snippet?snippet=${blockName}&apiKey=${
           builderState?.context.apiKey
-        }&args=${encodeURIComponent(args)}`
+        }&args=${encodeURIComponent(args)}${
+          previewThemeID ? `&preview_theme_id=${previewThemeID}` : ''
+        }`
       )
         .then(res => res.json())
         .then(json => {


### PR DESCRIPTION
... And use it to remotely render Liquid blocks. This allows for working
with these Liquid blocks in non-live themes without having to add them
to the main/live theme.