### PR TITLE
use more specific class name for dialog main container

### DIFF
--- a/plugins/cloudinary/src/CloudinaryMediaLibraryDialog.tsx
+++ b/plugins/cloudinary/src/CloudinaryMediaLibraryDialog.tsx
@@ -50,7 +50,7 @@ export class CloudinaryMediaLibraryDialog extends React.Component<
       {
         cloud_name: this.props.cloudName ? this.props.cloudName : '',
         api_key: this.props.apiKey ? this.props.apiKey : '',
-        inline_container: '.container',
+        inline_container: '.cloudinaryContainer',
       },
       {
         insertHandler: (data: any) => {
@@ -80,7 +80,7 @@ export class CloudinaryMediaLibraryDialog extends React.Component<
             this.openCloudinaryMediaLibrary();
           }}
         >
-          <div className="container" css={{ height: '90vh' }} />
+          <div className="cloudinaryContainer" css={{ height: '90vh' }} />
           <DialogActions>
             <Button autoFocus onClick={this.props.closeDialog} color="primary">
               Close media library


### PR DESCRIPTION
## Description

The plugin for cloudinary images is using a classname to identify the html containing which is too generic (.container).
This can easily lead to errors, in case any other html component on the page uses the same className.
Indeed, in our case, it is clashing with another plugin we are using.

With this MR we are updating the className to be more specific
