### PR TITLE
resolveDynamicEntries

### DIFF
--- a/packages/gatsby/README.md
+++ b/packages/gatsby/README.md
@@ -30,7 +30,19 @@ module.exports = {
             dataFromQuery: result.data
             /* ... */
           };
-        }
+        },
+        resolveDynamicEntries: async (entries) => {
+          const entriesToBuild = []
+          for entry of entries {
+            if (entry.data.myprop.isDynamic){
+               entriesToBuild.push(await myEntryResolver(entry))
+            }
+            else {
+               entriesToBuild.push(entry)
+            }
+          }
+          return entriesToBuild;
+        },
         templates: {
           // `page` can be any model of choice, camelCased
           page: path.resolve('templates/my-page.tsx'),

--- a/packages/gatsby/src/gatsby-node.js
+++ b/packages/gatsby/src/gatsby-node.js
@@ -135,6 +135,10 @@ const createPagesAsync = async (config, createPage, graphql, models, offsets) =>
       entries = entries.filter(config.filter);
     }
 
+    if (config.resolveDynamicEntries) {
+      entries = await config.resolveDynamicEntries(entries);
+    }
+
     for (const entry of entries) {
       if (entry.content.data.url && entry.content.published === `published`) {
         let mappedProps = {};


### PR DESCRIPTION
## Description

Proposal to add a feature that can convert a single entry into N entries. This allows us to use builder as a template system, having a single template in builder that can drive thousands of pages.

We have validated with a POC that this is what we need, in combination of using the data binding and storing data in the entry.content.data.state and resolving it at build time, we can build as many pages we want, as long as they are fed with the same data structure
