### PR TITLE
reduce amount of tags used for Builder content

### DIFF
--- a/packages/react/src/blocks/Slot.tsx
+++ b/packages/react/src/blocks/Slot.tsx
@@ -21,8 +21,18 @@ export function Slot(props: DropzoneProps) {
   const context = useContext(BuilderStoreContext);
 
   const isEditingThisSlot = !context.context.symbolId;
+  const blocks = (
+    <BuilderBlocks
+      child
+      parentElementId={context.context.symbolId}
+      dataPath={`symbol.data.${name}`}
+      blocks={context.state[name] || []}
+    />
+  );
 
-  return (
+  return !Builder.isEditing ? (
+    <React.Fragment>{blocks}</React.Fragment>
+  ) : (
     <div
       css={{
         pointerEvents: 'auto',
@@ -31,12 +41,7 @@ export function Slot(props: DropzoneProps) {
         'builder-slot': name,
       })}
     >
-      <BuilderBlocks
-        child
-        parentElementId={context.context.symbolId}
-        dataPath={`symbol.data.${name}`}
-        blocks={context.state[name] || []}
-      />
+      {blocks}
     </div>
   );
 }

--- a/packages/react/src/components/builder-blocks.component.tsx
+++ b/packages/react/src/components/builder-blocks.component.tsx
@@ -78,7 +78,29 @@ export class BuilderBlocks extends React.Component<BuilderBlocksProps, BuilderBl
     const TagName = this.props.emailMode ? 'span' : 'div';
 
     // TODO: how deep check this automatically for mobx... hmmm optional / peer dependency?
-    return (
+    return !this.noBlocks ? (
+      <React.Fragment>
+        {/* TODO: if is react node (for react compatibility) render it */}
+        {/* TODO: maybe don't do this to preserve blocks always editable */}
+        {(blocks &&
+          Array.isArray(blocks) &&
+          (blocks as any[]).map((block, index) =>
+            block && block['@type'] === '@builder.io/sdk:Element' ? (
+              <BuilderBlock
+                key={block.id}
+                block={block}
+                index={index}
+                fieldName={this.props.fieldName}
+                child={this.props.child}
+                emailMode={this.props.emailMode}
+              />
+            ) : (
+              block
+            )
+          )) ||
+          blocks}
+      </React.Fragment>
+    ) : (
       // TODO: component <Stack direction="vertical">
       // TODO: react.fragment instead?
       <TagName

--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -73,11 +73,11 @@ const size = (thing: object) => Object.keys(thing).length;
 
 function debounce(func: Function, wait: number, immediate = false) {
   let timeout: any;
-  return function (this: any) {
+  return function(this: any) {
     const context = this;
     const args = arguments;
     clearTimeout(timeout);
-    timeout = setTimeout(function () {
+    timeout = setTimeout(function() {
       timeout = null;
       if (!immediate) func.apply(context, args);
     }, wait);
@@ -848,7 +848,8 @@ export class BuilderComponent extends React.Component<
     const contentId = this.useContent?.id;
 
     return (
-      // TODO: data attributes for model, id, etc?
+      // TODO: forward down to the content ref to just have one wrapper
+      // div for content + component
       <WrapComponent
         onClick={event => {
           // Prevent propagation from the root content component when editing to prevent issues
@@ -947,7 +948,7 @@ export class BuilderComponent extends React.Component<
                           const useBuilderState = (initialState: any) => {
                             const [, setTick] = React.useState(0);
                             const [state] = React.useState(() =>
-                              onChange(initialState, function () {
+                              onChange(initialState, function() {
                                 setTick(tick => tick + 1);
                               })
                             );
@@ -986,13 +987,7 @@ export class BuilderComponent extends React.Component<
                         // TODO: loading option - maybe that is what the children is or component prop
                         // TODO: get rid of all these wrapper divs
                         return data ? (
-                          <div
-                            data-builder-component={this.name}
-                            data-builder-content-id={fullData.id}
-                            data-builder-variation-id={
-                              fullData.testVariationId || fullData.variationId || fullData.id
-                            }
-                          >
+                          <>
                             {!codegen && this.getCss(data) && (
                               <style
                                 ref={ref => (this.styleRef = ref)}
@@ -1022,7 +1017,7 @@ export class BuilderComponent extends React.Component<
                                 />
                               )}
                             </BuilderStoreContext.Provider>
-                          </div>
+                          </>
                         ) : loading ? (
                           <div data-builder-component={this.name} className="builder-loading">
                             {this.props.children}

--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -73,11 +73,11 @@ const size = (thing: object) => Object.keys(thing).length;
 
 function debounce(func: Function, wait: number, immediate = false) {
   let timeout: any;
-  return function(this: any) {
+  return function (this: any) {
     const context = this;
     const args = arguments;
     clearTimeout(timeout);
-    timeout = setTimeout(function() {
+    timeout = setTimeout(function () {
       timeout = null;
       if (!immediate) func.apply(context, args);
     }, wait);
@@ -948,7 +948,7 @@ export class BuilderComponent extends React.Component<
                           const useBuilderState = (initialState: any) => {
                             const [, setTick] = React.useState(0);
                             const [state] = React.useState(() =>
-                              onChange(initialState, function() {
+                              onChange(initialState, function () {
                                 setTick(tick => tick + 1);
                               })
                             );

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -258,6 +258,9 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
           onClick={this.onClick}
           builder-content-id={useData?.id}
           builder-model={this.name}
+          data-builder-component={this.name}
+          data-builder-content-id={useData.id}
+          data-builder-variation-id={useData.testVariationId || useData.variationId || useData.id}
         >
           {this.props.children(useData?.data, this.props.inline ? false : loading, useData)}
         </TagName>
@@ -291,6 +294,9 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
                         onClick={this.onClick}
                         builder-content-id={content?.id}
                         builder-model={this.name}
+                        data-builder-component={this.name}
+                        data-builder-content-id={useData.id}
+                        data-builder-variation-id={content.id}
                       >
                         {this.props.children(
                           content?.data! as any,


### PR DESCRIPTION
currently every piece of Builder content adds 4 wrapping tags. e.g.a <BuilderComponent>, Symbol, etc

this reduces that down to 2, and we can ultimately get it down to 1 with additional work, but these were the obvious quick wins to remove excess