### PR TITLE
hide intersection observer usage behind a flag

### DIFF
--- a/packages/react/src/blocks/Image.tsx
+++ b/packages/react/src/blocks/Image.tsx
@@ -193,7 +193,7 @@ class ImageComponent extends React.Component<any, { imageLoaded: boolean; load: 
         this.setState({
           load: true,
         });
-      } else if (this.props.useIO && typeof IntersectionObserver === 'function' && this.pictureRef) {
+      } else if (this.props.useIntersectionObserver && typeof IntersectionObserver === 'function' && this.pictureRef) {
         const observer = (this.intersectionObserver = new IntersectionObserver(
           (entries, observer) => {
             entries.forEach(entry => {

--- a/packages/react/src/blocks/Image.tsx
+++ b/packages/react/src/blocks/Image.tsx
@@ -193,7 +193,7 @@ class ImageComponent extends React.Component<any, { imageLoaded: boolean; load: 
         this.setState({
           load: true,
         });
-      } else if (typeof IntersectionObserver === 'function' && this.pictureRef) {
+      } else if (this.props.useIO && typeof IntersectionObserver === 'function' && this.pictureRef) {
         const observer = (this.intersectionObserver = new IntersectionObserver(
           (entries, observer) => {
             entries.forEach(entry => {


### PR DESCRIPTION
~Intersection observer was causing issues in carousels, can be fixed with setting a rootMargin but not when the users has entered negartive margins on the slide, even then it's for some reason not working when iframed ( only when used in carousel)~

The issue only occur when users have negative margins on a slide in a carousel

Related to:
https://github.com/w3c/IntersectionObserver/issues/301
https://github.com/w3c/IntersectionObserver/issues/266