### PR TITLE
Fix for liquid render

### DIFF
--- a/packages/webcomponents/src/elements.ts
+++ b/packages/webcomponents/src/elements.ts
@@ -21,7 +21,7 @@ function wrapHistoryPropertyWithCustomEvent(property: 'pushState' | 'replaceStat
   try {
     const anyHistory = history;
     const originalFunction = anyHistory[property];
-    anyHistory[property] = function (this: History) {
+    anyHistory[property] = function(this: History) {
       var rv = originalFunction.apply(this, arguments as any);
       var event = new CustomEvent(property, {
         detail: {
@@ -120,8 +120,14 @@ if (Builder.isBrowser && !customElements.get(componentName)) {
         styles.replace(
           /(@font-face\s*{\s*font-family:\s*(.*?);[\s\S]+?url\((\S+)\)[\s\S]+?})/g,
           (fullMatch, fontMatch, fontName, fontUrl) => {
-            const trimmedFontUrl = fontUrl.replace(/(^"|"$)/g, '').replace(/(^'|'$)/g, '').trim();
-            const trimmedFontName = fontName.replace(/(^"|"$)/g, '').replace(/(^'|'$)/g, '').trim();
+            const trimmedFontUrl = fontUrl
+              .replace(/(^"|"$)/g, '')
+              .replace(/(^'|'$)/g, '')
+              .trim();
+            const trimmedFontName = fontName
+              .replace(/(^"|"$)/g, '')
+              .replace(/(^'|'$)/g, '')
+              .trim();
 
             let style = fullMatch.match(/font-style:\s*(.+)\s*;/gi)?.[1];
 


### PR DESCRIPTION
## Description
Turns out that content within a `<template>` tag is not findable via a top level `document.querySelectorAll`, so we need to query the content of each template tag to get the proper server rendered custom code block when variations are present. This also requires a few changes to the editor that will come in a separate PR.

Ticket: https://builder-io.atlassian.net/browse/ENG-974


