### PR TITLE
Add an index to maintain order

### DIFF
--- a/plugins/memsource-connector/__tests__/plugin.spec.tsx
+++ b/plugins/memsource-connector/__tests__/plugin.spec.tsx
@@ -256,11 +256,13 @@ describe('Memsource connector', () => {
                   {
                     "__id": "list-1",
                     "__optionKey": "list",
+                    "__listIndex": 0,
                     "toTranslate": "list item 1",
                   },
                   {
                     "__id": "list-1",
                     "__optionKey": "list",
+                    "__listIndex": 1,
                     "toTranslate": "list item 2",
                   },
                   {

--- a/plugins/memsource-connector/src/services/payloadBuilder.ts
+++ b/plugins/memsource-connector/src/services/payloadBuilder.ts
@@ -177,10 +177,12 @@ const mapMultipleValueOptions = (
       .map((each: any) => each.name)
   ).forEach((each: any) => {
     if (options[each]) {
-      return options[each].map(({ item }: { item: string }) => {
+      return options[each].map(({ item }: { item: string }, index: number) => {
+        console.log('Addind index', index);
         multipleValues.push({
           __id: id,
           __optionKey: each,
+          __listIndex: index,
           toTranslate: item
         });
       });


### PR DESCRIPTION
## Description

In order to preserve the order of a list, I'm adding a new key to the translation payload called `listIndex`

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
