### PR TITLE
[@builder.io/react] fix a/b test SSR

### DIFF
--- a/packages/react/src/components/variants-provider.component.tsx
+++ b/packages/react/src/components/variants-provider.component.tsx
@@ -104,7 +104,9 @@ export const VariantsProvider: React.SFC<VariantsProviderProps> = ({
   initialContent,
   children,
 }) => {
-  if (!builder.canTrack) return children([initialContent]);
+  if (Builder.isBrowser && !builder.canTrack) {
+    return children([initialContent]);
+  }
 
   const hasTests = Boolean(Object.keys(initialContent?.variations || {}).length);
 


### PR DESCRIPTION
Rendering templates on the server has been busted since 1.1.36