### PR TITLE
option to force use of require to handle missing vm2 in nextjs serverless environment

### DIFF
--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/react",
-  "version": "1.1.44",
+  "version": "1.1.45-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/react",
-  "version": "1.1.44",
+  "version": "1.1.45-0",
   "description": "",
   "keywords": [],
   "main": "dist/builder-react.cjs.js",

--- a/packages/react/src/components/builder-block.component.tsx
+++ b/packages/react/src/components/builder-block.component.tsx
@@ -7,7 +7,7 @@ import { Size, sizeNames, sizes } from '../constants/device-sizes.constant';
 import { set } from '../functions/set';
 import { api, stringToFunction } from '../functions/string-to-function';
 import { BuilderAsyncRequestsContext, RequestOrPromise } from '../store/builder-async-requests';
-import { BuilderStoreContext } from '../store/builder-store';
+import { BuilderStore, BuilderStoreContext } from '../store/builder-store';
 import { applyPatchWithMinimalMutationChain } from '../functions/apply-patch-with-mutation';
 import { blockToHtmlString } from '../functions/block-to-html-string';
 import { Link } from './Link';
@@ -102,6 +102,7 @@ export class BuilderBlock extends React.Component<
   private _asyncRequests?: RequestOrPromise[];
   private _errors?: Error[];
   private _logs?: string[];
+  private _forceRequire?: boolean;
 
   state = {
     hasError: false,
@@ -132,7 +133,7 @@ export class BuilderBlock extends React.Component<
   // TODO: handle adding return if none provided
   // TODO: cache/memoize this (globally with LRU?)
   stringToFunction(str: string, expression = true) {
-    return stringToFunction(str, expression, this._errors, this._logs);
+    return stringToFunction(str, expression, this._errors, this._logs, this._forceRequire);
   }
 
   get block() {
@@ -622,8 +623,9 @@ export class BuilderBlock extends React.Component<
     return block.id!;
   }
 
-  contents(state: BuilderBlockState) {
+  contents(state: BuilderStore) {
     const block = this.block;
+    this._forceRequire = state.forceRequire;
 
     // this.setState(state);
     this.privateState = state;

--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -287,6 +287,10 @@ export interface BuilderComponentProps {
    * navigation to other pages unintended
    */
   stopClickPropagationWhenEditing?: boolean;
+  /**
+   * To workaround missing vm2 in serverless nextjs environment
+   */
+  forceRequire?: boolean;
 }
 
 export interface BuilderComponentState {
@@ -1150,6 +1154,7 @@ export class BuilderComponent extends React.Component<
                                 state: this.data,
                                 content: fullData,
                                 renderLink: this.props.renderLink,
+                                forceRequire: this.props.forceRequire,
                               }}
                             >
                               {codegen && this.Component ? (

--- a/packages/react/src/functions/string-to-function.ts
+++ b/packages/react/src/functions/string-to-function.ts
@@ -20,7 +20,8 @@ export function stringToFunction(
   str: string,
   expression = true,
   errors?: Error[],
-  logs?: string[]
+  logs?: string[],
+  forceRequire?: boolean,
 ): BuilderEvanFunction {
   /* TODO: objedct */
   if (!str || !str.trim()) {
@@ -118,7 +119,7 @@ export function stringToFunction(
         // for the server build
         // TODO: cache these for better performancs with new VmScript
         // tslint:disable:comment-format
-        const { VM } = safeDynamicRequire('vm2');
+        const { VM } = forceRequire ? require('vm2') : safeDynamicRequire('vm2');
         const [state, event] = args;
         return new VM({
           timeout: 100,

--- a/packages/react/src/store/builder-store.ts
+++ b/packages/react/src/store/builder-store.ts
@@ -15,4 +15,5 @@ export interface BuilderStore {
   context: any;
   update: (mutator: (state: any) => any) => any;
   renderLink?: (props: React.AnchorHTMLAttributes<any>) => React.ReactNode;
+  forceRequire?: boolean;
 }


### PR DESCRIPTION
This fixes an issue where binding was not running correctly in vercel/netlify serverless environment, adds an option to force the use of `require` 