### PR TITLE
ensure apiKey is available on context, fixes symbols that rely on it …

### DIFF
--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -464,7 +464,10 @@ export class BuilderComponent extends React.Component<
 
     this.state = {
       // TODO: should change if this prop changes
-      context: props.context || {},
+      context: {
+        ...props.context,
+        apiKey: builder.apiKey || this.props.apiKey,
+      },
       state: Object.assign(this.rootState, {
         ...(this.inlinedContent && this.inlinedContent.data && this.inlinedContent.data.state),
         isBrowser: Builder.isBrowser, // !this.asServer,


### PR DESCRIPTION
…(instagram grid)

