### PR TITLE
fix(widgets): fix npm build

### DIFF
--- a/packages/widgets/rollup.config.ts
+++ b/packages/widgets/rollup.config.ts
@@ -47,6 +47,7 @@ const options = {
           'createElement',
           'forwardRef',
           'Fragment',
+          'useContext',
         ],
         'node_modules/react-dom/index.js': ['render', 'hydrate'],
         'node_modules/react-is/index.js': ['isElement', 'isValidElementType', 'ForwardRef'],


### PR DESCRIPTION
Allows the package to build.

see: https://github.com/rollup/rollup-plugin-commonjs/issues/290#issuecomment-537683484

