### PR TITLE
Prevent touch events from scrolling the page when dragging the page vertically in mobile devices

### DIFF
--- a/packages/widgets/package-lock.json
+++ b/packages/widgets/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/widgets",
-  "version": "1.2.19",
+  "version": "1.2.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2373,7 +2373,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -12308,7 +12309,8 @@
     "prettier": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "dev": true
     },
     "pretty-format": {
       "version": "3.8.0",
@@ -12570,15 +12572,14 @@
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
     },
     "react-slick": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.23.2.tgz",
-      "integrity": "sha512-fM6DXX7+22eOcYE9cgaXUfioZL/Zw6fwS6aPMDBt0kLHl4H4fFNEbp4JsJQdEWMLUNFtUytNcvd9KRml22Tp5w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.28.1.tgz",
+      "integrity": "sha512-JwRQXoWGJRbUTE7eZI1rGIHaXX/4YuwX6gn7ulfvUZ4vFDVQAA25HcsHSYaUiRCduTr6rskyIuyPMpuG6bbluw==",
       "requires": {
         "classnames": "^2.2.5",
         "enquire.js": "^2.1.6",
         "json2mq": "^0.2.0",
         "lodash.debounce": "^4.0.8",
-        "prettier": "^1.14.3",
         "resize-observer-polyfill": "^1.5.0"
       }
     },
@@ -14702,7 +14703,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/widgets",
-  "version": "1.2.19",
+  "version": "1.2.20",
   "description": "",
   "keywords": [],
   "main": "dist/builder-widgets.cjs.js",
@@ -92,7 +92,7 @@
     "@types/react": "^16.4.1",
     "@types/react-dom": "^16.0.7",
     "@types/react-loadable": "^5.5.1",
-    "@types/react-slick": "^0.23.3",
+    "@types/react-slick": "^0.23.4",
     "colors": "^1.1.2",
     "commitizen": "^2.9.6",
     "coveralls": "^3.0.0",
@@ -148,7 +148,7 @@
     "react-dom": ">=14",
     "react-loadable": "^5.5.0",
     "react-masonry-component": "^6.2.1",
-    "react-slick": "^0.23.2",
+    "react-slick": "^0.28.1",
     "tslib": "^1.10.0"
   },
   "gitHead": "4d96fbc32864698afbb355ab991c6d90be991951"

--- a/packages/widgets/src/components/Carousel.tsx
+++ b/packages/widgets/src/components/Carousel.tsx
@@ -29,26 +29,24 @@ interface CarouselProps {
 
 // TODO: change to slick grid
 export class CarouselComponent extends React.Component<CarouselProps> {
-  divRef: HTMLElement | null = null;
-  sliderRef: Slider | null = null;
+  divRef = React.createRef<HTMLDivElement>();
+  sliderRef = React.createRef<Slider>();
 
   private _errors?: Error[];
   private _logs?: string[];
 
   componentDidMount() {
     setTimeout(() => {
-      if (this.divRef) {
-        this.divRef.dispatchEvent(
-          new CustomEvent('builder:carousel:load', {
-            bubbles: true,
-            cancelable: false,
-            detail: {
-              block: this.props.builderBlock,
-              carousel: this.sliderRef,
-            },
-          })
-        );
-      }
+      this.divRef.current?.dispatchEvent(
+        new CustomEvent('builder:carousel:load', {
+          bubbles: true,
+          cancelable: false,
+          detail: {
+            block: this.props.builderBlock,
+            carousel: this.sliderRef.current,
+          },
+        })
+      );
     });
   }
 
@@ -68,7 +66,7 @@ export class CarouselComponent extends React.Component<CarouselProps> {
           return (
             <BuilderStoreContext.Consumer>
               {state => (
-                <div ref={ref => (this.divRef = ref)} className="builder-carousel">
+                <div ref={this.divRef} className="builder-carousel">
                   {/* Strange encoding issue workaround... */}
                   {Builder.isServer ? (
                     <style
@@ -80,18 +78,18 @@ export class CarouselComponent extends React.Component<CarouselProps> {
                   )}
                   <Slider
                     responsive={this.props.responsive}
-                    ref={ref => (this.sliderRef = ref)}
+                    ref={this.sliderRef}
                     afterChange={slide => {
                       // TODO; callbacks
                       if (this.divRef) {
-                        this.divRef.dispatchEvent(
+                        this.divRef.current?.dispatchEvent(
                           new CustomEvent('builder:carousel:change', {
                             bubbles: true,
                             cancelable: false,
                             detail: {
                               slide,
                               block: this.props.builderBlock,
-                              carousel: this.sliderRef,
+                              carousel: this.sliderRef.current,
                             },
                           })
                         );
@@ -160,9 +158,9 @@ export class CarouselComponent extends React.Component<CarouselProps> {
                                   // TODO: Builder state produce the data
                                   const childState = {
                                     ...state.state,
+                                    [itemName]: data,
                                     $index: index,
                                     $item: data,
-                                    [itemName]: data,
                                   };
 
                                   return (
@@ -176,7 +174,7 @@ export class CarouselComponent extends React.Component<CarouselProps> {
                                           repeat: null,
                                         }}
                                         index={index}
-                                        child={true} /* TODO: fieldname? */
+                                        child /* TODO: fieldname? */
                                       />
                                     </BuilderStoreContext.Provider>
                                   );
@@ -188,7 +186,7 @@ export class CarouselComponent extends React.Component<CarouselProps> {
                                 key={block.id}
                                 block={block}
                                 index={index}
-                                child={true} /* TODO: fieldname? */
+                                child /* TODO: fieldname? */
                               />
                             );
                           }
@@ -219,4 +217,5 @@ export class CarouselComponent extends React.Component<CarouselProps> {
 const slickStyles = `@charset 'UTF-8';
   .slick-list,.slick-slider,.slick-track{position:relative;display:block}.slick-loading .slick-slide,.slick-loading .slick-track{visibility:hidden}.slick-slider{box-sizing:border-box;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;-webkit-touch-callout:none;-khtml-user-select:none;-ms-touch-action:pan-y;touch-action:pan-y;-webkit-tap-highlight-color:transparent}.slick-list{overflow:hidden;margin:0;padding:0}.slick-list:focus{outline:0}.slick-list.dragging{cursor:pointer;cursor:hand}.slick-slider .slick-list,.slick-slider .slick-track{-webkit-transform:translate3d(0,0,0);-moz-transform:translate3d(0,0,0);-ms-transform:translate3d(0,0,0);-o-transform:translate3d(0,0,0);transform:translate3d(0,0,0)}.slick-track{top:0;left:0}.slick-track:after,.slick-track:before{display:table;content:''}.slick-track:after{clear:both}.slick-slide{display:none;float:left;height:auto;min-height:1px}[dir=rtl] .slick-slide{float:right}.slick-slide img{display:block}.slick-slide.slick-loading img{display:none}.slick-slide.dragging img{pointer-events:none}.slick-initialized .slick-slide{display:block}.slick-vertical .slick-slide{display:block;height:auto;border:1px solid transparent}.slick-arrow.slick-hidden{display:none}
   .slick-dots,.slick-next,.slick-prev{position:absolute;display:block;padding:0}.slick-dots li button:before,.slick-next:before,.slick-prev:before{font-family:slick;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}.slick-loading .slick-list{background:url(ajax-loader.gif) center center no-repeat #fff}@font-face{font-display:swap;font-family:slick;font-weight:400;font-style:normal;src:url(https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/fonts/slick.eot);src:local("slick"),url(https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/fonts/slick.eot?#iefix) format('embedded-opentype'),url(https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/fonts/slick.woff) format('woff'),url(https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/fonts/slick.ttf) format('truetype'),url(https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/fonts/slick.svg#slick) format('svg')}.slick-next,.slick-prev{font-size:0;line-height:0;top:50%;width:20px;height:20px;-webkit-transform:translate(0,-50%);-ms-transform:translate(0,-50%);transform:translate(0,-50%);cursor:pointer;color:transparent;border:none;outline:0;background:0 0}.slick-next:focus,.slick-next:hover,.slick-prev:focus,.slick-prev:hover{color:transparent;outline:0;background:0 0}.slick-next:focus:before,.slick-next:hover:before,.slick-prev:focus:before,.slick-prev:hover:before{opacity:1}.slick-next.slick-disabled:before,.slick-prev.slick-disabled:before{opacity:.25}.slick-next:before,.slick-prev:before{font-size:20px;line-height:1;opacity:.75;color:#fff}.slick-prev{left:-25px}[dir=rtl] .slick-prev{right:-25px;left:auto}.slick-prev:before{content:''}.slick-next:before,[dir=rtl] .slick-prev:before{content:''}.slick-next{right:-25px}[dir=rtl] .slick-next{right:auto;left:-25px}[dir=rtl] .slick-next:before{content:'•'}.slick-dotted.slick-slider{margin-bottom:30px}.slick-dots{bottom:-25px;width:100%;margin:0;list-style:none;text-align:center}.slick-dots li{position:relative;display:inline-block;width:20px;height:20px;margin:0 5px;padding:0;cursor:pointer}.slick-dots li button{font-size:0;line-height:0;display:block;width:20px;height:20px;padding:5px;cursor:pointer;color:transparent;border:0;outline:0;background:0 0}.slick-dots li button:focus,.slick-dots li button:hover{outline:0}.slick-dots li button:focus:before,.slick-dots li button:hover:before{opacity:1}.slick-dots li button:before{font-size:6px;line-height:20px;position:absolute;top:0;left:0;width:20px;height:20px;content:'•';text-align:center;opacity:.25;color:#000}.slick-dots li.slick-active button:before{opacity:.75;color:#000}
+  .builder-carousel img { pointer-events: none }
 `;


### PR DESCRIPTION
Some users are reporting that Builder content using our Carousel widget can't be scrolled up and down when the touch event starts on a carousel slide.

This is an attempt to fix it by using CSS's `pointer-events` on slide images.