### PR TITLE
Fix broken link to renamed dropdown selector and cleanup example url

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -4,7 +4,7 @@ Extend the Builder.io editor funcionality! Plugins can provide everything from e
 
 For an example plugin and docs on how to create and run one see our [Example plugin](rich-text)
 
-Or to see a fully fleshed out plugin examples take a look at our [Cloudinary](cloudinary), [Shopify](shopify), [dynamic dropdown](dynamic-dropdown), [rich text](rich-text), or [campaign app](https://github.com/BuilderIO/builder/tree/master/plugins/example-app-campaign-builder) plugins
+Or to see a fully fleshed out plugin examples take a look at our [Cloudinary](cloudinary), [Shopify](shopify), [async dropdown](async-dropdown), [rich text](rich-text), or [campaign app](example-app-campaign-builder) plugins
 
 See our [plugin docs](https://www.builder.io/c/docs/extending/plugins) for info on what plugins can do and how to create them
 


### PR DESCRIPTION
## Description
My entry for the trivial patch of the month club. Was just walking through the docs and hit a broken link. I know its alot to keep in sync so thought I might lend a quick hand. 