### PR TITLE
Removed do not track check

### DIFF
--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -950,7 +950,7 @@ export class Builder {
 
   get browserTrackingDisabled() {
     return Boolean(
-      Builder.isBrowser && ((navigator as any).doNotTrack === '1' || (window as any).builderNoTrack)
+      Builder.isBrowser && (window as any).builderNoTrack
     );
   }
 

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -56,12 +56,6 @@ export type BuilderContentProps<ContentType> = {
  * and pass the winning variation down to the children function. If then content
  * prop was omitted it'll try to fetch matching content from your Builder
  * account based on the default user attributes and model.
- *
- * ## Notes
- *
- * A/B testing will show only the default content if DoNotTrack is enabled.
- *
- * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/DNT
  */
 export class BuilderContent<ContentType extends object = any> extends React.Component<
   BuilderContentProps<ContentType>


### PR DESCRIPTION
## Description

Remove `doNotTrack` check as this setting is deprecated: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack

