### PR TITLE
utils: add ability to extend inline symbol data

### DIFF
--- a/packages/utils/package-lock.json
+++ b/packages/utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/utils",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/utils",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Utils for working with Builder.io content",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/utils/src/extend-async-props.test.ts
+++ b/packages/utils/src/extend-async-props.test.ts
@@ -8,10 +8,9 @@ async function getDataFromAPI(query: any) {
 async function getProductByHandle(productHandle: string) {
   return {
     title: 'mock',
-    handle: productHandle
+    handle: productHandle,
   };
 }
-
 
 test('Extends async props on custom components', async () => {
   const content: BuilderContent = {
@@ -47,18 +46,18 @@ test('Extends async props on inlined symbols', async () => {
       blocks: [
         {
           '@type': '@builder.io/sdk:Element',
-          "@version": 2,
-          "layerName": "Product Box",
-          "component": {
-            "name": "Symbol",
-            "options": {
-              "symbol": {
-                "data": {
-                  "loading": false,
-                  "productHandle": productHandle,
+          '@version': 2,
+          layerName: 'Product Box',
+          component: {
+            name: 'Symbol',
+            options: {
+              symbol: {
+                data: {
+                  loading: false,
+                  productHandle: productHandle,
                 },
-              }
-            }
+              },
+            },
           },
         },
       ],
@@ -70,9 +69,11 @@ test('Extends async props on inlined symbols', async () => {
       return {
         initialState: {
           product,
-        }
+        },
       };
     },
   });
-  expect(content.data!.blocks![0].component!.options.symbol.data.initialState.product.handle).toBe(productHandle);
+  expect(content.data!.blocks![0].component!.options.symbol.data.initialState.product.handle).toBe(
+    productHandle
+  );
 });

--- a/packages/utils/src/extend-async-props.test.ts
+++ b/packages/utils/src/extend-async-props.test.ts
@@ -5,7 +5,15 @@ async function getDataFromAPI(query: any) {
   return `searched for ${query.search}`;
 }
 
-test('Extends async props', async () => {
+async function getProductByHandle(productHandle: string) {
+  return {
+    title: 'mock',
+    handle: productHandle
+  };
+}
+
+
+test('Extends async props on custom components', async () => {
   const content: BuilderContent = {
     data: {
       blocks: [
@@ -30,4 +38,41 @@ test('Extends async props', async () => {
     },
   });
   expect(content.data!.blocks![0].component!.options.data).toBe('searched for green shoes');
+});
+
+test('Extends async props on inlined symbols', async () => {
+  const productHandle = '/test';
+  const content: BuilderContent = {
+    data: {
+      blocks: [
+        {
+          '@type': '@builder.io/sdk:Element',
+          "@version": 2,
+          "layerName": "Product Box",
+          "component": {
+            "name": "Symbol",
+            "options": {
+              "symbol": {
+                "data": {
+                  "loading": false,
+                  "productHandle": productHandle,
+                },
+              }
+            }
+          },
+        },
+      ],
+    },
+  };
+  await extendAsyncProps(content, {
+    async productHandle(props) {
+      const product = await getProductByHandle(props.productHandle);
+      return {
+        initialState: {
+          product,
+        }
+      };
+    },
+  });
+  expect(content.data!.blocks![0].component!.options.symbol.data.initialState.product.handle).toBe(productHandle);
 });

--- a/packages/utils/src/extend-async-props.ts
+++ b/packages/utils/src/extend-async-props.ts
@@ -5,7 +5,7 @@ type PropsMappers = { [key: string]: (props: any) => Promise<any> };
 export async function extendAsyncProps(content: BuilderContent, mappers: PropsMappers) {
   const promises: Promise<any>[] = [];
   traverse(content).forEach(function (field) {
-    const isComponentOptions = this.path.slice(-2).join('.') === 'component.options';
+    const isComponentOptions = ['component.options', 'symbol.data'].includes(this.path.slice(-2).join('.'));
     if (field && isComponentOptions) {
       const keys = Object.keys(field);
       keys.forEach(key => {

--- a/packages/utils/src/extend-async-props.ts
+++ b/packages/utils/src/extend-async-props.ts
@@ -5,7 +5,9 @@ type PropsMappers = { [key: string]: (props: any) => Promise<any> };
 export async function extendAsyncProps(content: BuilderContent, mappers: PropsMappers) {
   const promises: Promise<any>[] = [];
   traverse(content).forEach(function (field) {
-    const isComponentOptions = ['component.options', 'symbol.data'].includes(this.path.slice(-2).join('.'));
+    const isComponentOptions = ['component.options', 'symbol.data'].includes(
+      this.path.slice(-2).join('.')
+    );
     if (field && isComponentOptions) {
       const keys = Object.keys(field);
       keys.forEach(key => {


### PR DESCRIPTION
This makes it easy to SSR inlined symbols on headless sites