### PR TITLE
Fix url encoded form submit

### DIFF
--- a/packages/react/src/blocks/forms/Form.tsx
+++ b/packages/react/src/blocks/forms/Form.tsx
@@ -30,6 +30,10 @@ export interface FormProps {
   errorMessagePath?: string;
 }
 
+const MULTIPART_CONTENT_TYPE = 'multipart/form-data';
+const JSON_CONTENT_TYPE = 'application/json';
+const ENCODED_CONTENT_TYPE = 'application/x-www-form-urlencoded';
+
 class FormComponent extends React.Component<FormProps> {
   ref: HTMLFormElement | null = null;
 
@@ -128,7 +132,7 @@ class FormComponent extends React.Component<FormProps> {
                   let contentType = this.props.contentType;
 
                   if (this.props.sendSubmissionsTo === 'email') {
-                    contentType = 'multipart/form-data';
+                    contentType = MULTIPART_CONTENT_TYPE;
                   }
 
                   Array.from(formPairs).forEach(({ value }) => {
@@ -137,13 +141,13 @@ class FormComponent extends React.Component<FormProps> {
                       (Array.isArray(value) && value[0] instanceof File) ||
                       value instanceof FileList
                     ) {
-                      contentType = 'multipart/form-data';
+                      contentType = MULTIPART_CONTENT_TYPE;
                     }
                   });
 
-                  if (contentType === 'multipart/form-data') {
+                  if (contentType === MULTIPART_CONTENT_TYPE) {
                     body = formData;
-                  } else if (contentType === 'application/json') {
+                  } else if (contentType === JSON_CONTENT_TYPE) {
                     const json = {};
 
                     Array.from(formPairs).forEach(({ value, key }) => {
@@ -151,7 +155,7 @@ class FormComponent extends React.Component<FormProps> {
                     });
 
                     body = JSON.stringify(json);
-                  } else if (contentType === 'application/x-www-form-urlencoded') {
+                  } else if (contentType === ENCODED_CONTENT_TYPE) {
                     body = Array.from(formPairs)
                       .map(({ value, key }) => {
                         return (
@@ -167,7 +171,7 @@ class FormComponent extends React.Component<FormProps> {
                     return;
                   }
 
-                  if (contentType && contentType !== 'multipart/form-data') {
+                  if (contentType && contentType !== MULTIPART_CONTENT_TYPE) {
                     if (
                       // Zapier doesn't allow content-type header to be sent from browsers
                       !(sendWithJs && this.props.action?.includes('zapier.com'))
@@ -210,7 +214,7 @@ class FormComponent extends React.Component<FormProps> {
                     async res => {
                       let body;
                       const contentType = res.headers.get('content-type');
-                      if (contentType && contentType.indexOf('application/json') !== -1) {
+                      if (contentType && contentType.indexOf(JSON_CONTENT_TYPE) !== -1) {
                         body = await res.json();
                       } else {
                         body = await res.text();
@@ -405,10 +409,10 @@ export const Form = withBuilder(FormComponent, {
     {
       name: 'contentType',
       type: 'string',
-      defaultValue: 'application/json',
+      defaultValue: JSON_CONTENT_TYPE,
       advanced: true,
       // TODO: do automatically if file input
-      enum: ['application/json', 'multipart/form-data', 'application/x-www-form-urlencoded'],
+      enum: [JSON_CONTENT_TYPE, MULTIPART_CONTENT_TYPE, ENCODED_CONTENT_TYPE],
       showIf: 'options.get("sendSubmissionsTo") === "custom" && options.get("sendWithJs") === true',
     },
     {

--- a/packages/react/src/blocks/forms/Form.tsx
+++ b/packages/react/src/blocks/forms/Form.tsx
@@ -141,13 +141,9 @@ class FormComponent extends React.Component<FormProps> {
                     }
                   });
 
-                  // TODO: send as urlEncoded or multipart by default
-                  // because of ease of use and reliability in browser API
-                  // for encoding the form?
-                  if (contentType !== 'application/json') {
+                  if (contentType === 'multipart/form-data') {
                     body = formData;
-                  } else {
-                    // Json
+                  } else if (contentType === 'application/json') {
                     const json = {};
 
                     Array.from(formPairs).forEach(({ value, key }) => {
@@ -155,6 +151,20 @@ class FormComponent extends React.Component<FormProps> {
                     });
 
                     body = JSON.stringify(json);
+                  } else if (contentType === 'application/x-www-form-urlencoded') {
+                    body = Array.from(formPairs)
+                      .map(({ value, key }) => {
+                        return (
+                          encodeURIComponent(key) +
+                          '=' +
+                          encodeURIComponent(value as boolean | number | string)
+                        );
+                      })
+                      .join('&');
+                  } else {
+                    // Unsupported content type
+                    console.error('Unsupported content type: ', contentType);
+                    return;
                   }
 
                   if (contentType && contentType !== 'multipart/form-data') {
@@ -405,6 +415,7 @@ export const Form = withBuilder(FormComponent, {
       name: 'method',
       type: 'string',
       showIf: 'options.get("sendSubmissionsTo") === "custom"',
+      defaultValue: 'POST',
       advanced: true,
     },
     {


### PR DESCRIPTION
## Description

Fixes when someone selects `content-type: application/x-www-form-urlencoded` in the Form component. Right now we just send multi part form data with the `application/x-www-form-urlencoded` header instead of sending an encoded string.


