### PR TITLE
Contentstack: fix include[] search params

### DIFF
--- a/plugins/contentstack/package-lock.json
+++ b/plugins/contentstack/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-contentstack",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/plugins/contentstack/package.json
+++ b/plugins/contentstack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-contentstack",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "",
   "keywords": [],
   "main": "dist/plugin.umd.js",

--- a/plugins/contentstack/src/plugin.ts
+++ b/plugins/contentstack/src/plugin.ts
@@ -210,7 +210,9 @@ registerDataPlugin(
         const augmentedContentTypes = contentTypes.map(contentType => {
           const references = contentType.schema.filter(field => field.data_type === 'reference');
           // https://www.contentstack.com/docs/developers/apis/content-delivery-api/#include-reference
-          const referenceSearchParams = references.map(field => field.uid);
+          const referenceSearchParams = references
+            .map(field => field.uid)
+            .map(includeId => ['include[]', includeId] as [string, string]);
 
           return { ...contentType, searchParams: { include: referenceSearchParams } };
         });
@@ -252,10 +254,7 @@ registerDataPlugin(
               ];
 
               if (options.entry) {
-                const query = new URLSearchParams([
-                  ...baseQuery,
-                  ['include[]', model.searchParams.include],
-                ]);
+                const query = new URLSearchParams([...baseQuery, ...model.searchParams.include]);
                 return buildUrl(`entries/${options.entry}?${query}`);
               } else {
                 const query = new URLSearchParams(baseQuery);


### PR DESCRIPTION
## Description

Realized while recording some looms that the `include[]` param was broken. `URLSearchParams` will concatenate the values e.g. `include[]=foo,bar,baz`, but what we want is to have them separated e.g. `include[]=foo&include[]=bar&include[]=baz`. This PR fixes this bug