### PR TITLE
Remove Liquid render args serialization

### DIFF
--- a/packages/shopify/react/components/LiquidBlock.tsx
+++ b/packages/shopify/react/components/LiquidBlock.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Builder, BuilderElement, BuilderStore, builder } from '@builder.io/react';
 import { findAndRunScripts } from '../functions/find-and-run-scripts';
-import { serializeLiquidArgs } from '../functions/serialize-liquid-args';
 
 interface LiquidBlockProps {
   options?: Record<string, number | boolean | string>;
@@ -28,19 +27,19 @@ export const LiquidBlock = ({
   const [loading, setLoading] = useState(0);
   const ref = useRef<HTMLDivElement | null>(null);
   const blockName = templatePath?.split('/')[1].replace(/\.liquid$/, '')!;
+  const renderArgs = JSON.stringify(options);
 
   useEffect(() => {
     const blockId = builderBlock?.id;
     const node = blockId && refs && refs[blockId];
-    const args = serializeLiquidArgs(options);
-    const cacheKey = blockName + args;
+
+    const cacheKey = blockName + renderArgs;
 
     if (!node || Builder.isEditing || Builder.isPreviewing) {
       if (cache[cacheKey]) {
         return;
       }
 
-      // Convert `sections/foo.liquid` -> `foo`
       if (!blockName) {
         return;
       }
@@ -57,10 +56,11 @@ export const LiquidBlock = ({
       const previewThemeID =
         (Builder.isBrowser && (window as any).Shopify?.theme?.id) ||
         builderState?.state?.location?.query?.preview_theme_id;
+
       fetch(
         `${builder.host}/api/v1/shopify/data/render-liquid-snippet?snippet=${blockName}&apiKey=${
           builderState?.context.apiKey
-        }&args=${encodeURIComponent(args)}${
+        }&args=${encodeURIComponent(renderArgs)}${
           previewThemeID ? `&preview_theme_id=${previewThemeID}` : ''
         }`
       )
@@ -133,7 +133,7 @@ export const LiquidBlock = ({
         builder-liquid-block={builderBlock?.id}
         className="builder-liquid-block"
         dangerouslySetInnerHTML={{
-          __html: html || cache[blockName + serializeLiquidArgs(options)] || '',
+          __html: html || cache[blockName + renderArgs] || '',
         }}
       />
     </>

--- a/packages/shopify/react/functions/serialize-liquid-args.ts
+++ b/packages/shopify/react/functions/serialize-liquid-args.ts
@@ -1,12 +1,28 @@
+/**
+ * Determines if the `s` param can be used as a Liquid variable identifier
+ * It must be just letters, numbers, and underscores (`_`)
+ */
+export function isValidLiquidIdentifier(s: string): boolean {
+  // TODO: Reject strings that start with digits
+  return /^[a-z_0-9]+$/i.test(s);
+}
+
+/**
+ * Determines if the `v` param can be used as a Liquid variable value in a variable assignment
+ * Currently booleans, numbers and strings are supported
+ */
+export function canSerializeLiquidValue(v: unknown): boolean {
+  return ['boolean', 'number', 'string'].includes(typeof v);
+}
+
 export function serializeLiquidArgs(data?: Record<string, any>) {
   const argStrings: string[] = [];
   if (data) {
     for (const key in data) {
       const value = data[key];
-      // Key must be just letters, numbers, _
-      if (/^[a-z_0-9]+$/i.test(key)) {
+      if (isValidLiquidIdentifier(key)) {
         // For now just support boolean, number, string
-        if (['boolean', 'number', 'string'].includes(typeof value)) {
+        if (canSerializeLiquidValue(value)) {
           const json = JSON.stringify(
             typeof value === 'string' ? value.replace(/"/g, '&quot;') : value
           );
@@ -16,4 +32,50 @@ export function serializeLiquidArgs(data?: Record<string, any>) {
     }
   }
   return argStrings.join(', ');
+}
+
+/**
+ * From a mapping of `keys` -> `scalars`, generates a series of `assign`/`capture`
+ * Liquid tags to be used later with a `render/include` tag. For example:
+ *
+ * ```
+ * {% assign boolean_arg = true %}
+ * {% assign number_arg = 5 %}
+ * {% capture string_arg %}
+ * Some text here, maybe with HTML code
+ * {% endcapture %}
+ * ```
+ *
+ * This code will be available in the `assignments` field of the return value.
+ * The other field, `renderArgs`, will contain a parameter list of these `keys`,
+ * ready to be used as part of a `{% render %}`/`{% include %}` invocation.
+ *
+ * Capture is arguably better for strings to properly handle multiline strings, HTML quotes, etc.
+ */
+export function generateLiquidAssignCaptureTags(data?: Record<string, any>, scopePrefix: string = ''): {
+  renderArgs: string;
+  assignments: string;
+} {
+  const args = Object.entries(data || {}).filter(
+    ([argName, value]) => isValidLiquidIdentifier(argName) && canSerializeLiquidValue(value)
+  );
+
+  function withPrefix(argName: string): string {
+    return `${scopePrefix}_${argName}`;
+  }
+
+  return {
+    assignments: args.length
+      ? args
+          .map(([argName, value]) => {
+            if (typeof value === 'string' && value) {
+              return `{% capture ${withPrefix(argName)} %}${value}{% endcapture %}`;
+            }
+
+            return `{% assign ${withPrefix(argName)} = ${JSON.stringify(value)} %}`;
+          })
+          .join('\n')
+      : '',
+    renderArgs: args.length ? args.map(([argName]) => `${argName}: ${withPrefix(argName)}`).join(', ') : '',
+  };
 }


### PR DESCRIPTION
Our API endpoint to preview Liquid blocks will soon accept JSON, which will be properly handled when generating previews of Liquid blocks