### PR TITLE
Fix: editable dynamic cols

### DIFF
--- a/examples/react-design-system/src/builder-settings.js
+++ b/examples/react-design-system/src/builder-settings.js
@@ -38,6 +38,7 @@ Builder.register('insertMenu', {
     { name: 'Double Columns' },
     { name: 'Triple Columns' },
     { name: 'Dynamic Columns' },
+    { name: 'Custom Columns' },
   ],
 });
 

--- a/examples/react-design-system/src/components/CustomColumns/CustomColumns.builder.js
+++ b/examples/react-design-system/src/components/CustomColumns/CustomColumns.builder.js
@@ -12,58 +12,12 @@ Builder.registerComponent(CustomColumns, {
         {
           image:
             'https://cdn.builder.io/api/v1/image/assets%2Fpwgjf0RoYWbdnJSbpBAjXNRMe9F2%2Ffb27a7c790324294af8be1c35fe30f4d',
-          blocks: [
-            {
-              '@type': '@builder.io/sdk:Element',
-              component: {
-                name: 'Text',
-                options: {
-                  text: 'Enter some text...',
-                },
-              },
-              responsiveStyles: {
-                large: {
-                  display: 'flex',
-                  flexDirection: 'column',
-                  position: 'relative',
-                  flexShrink: '0',
-                  boxSizing: 'border-box',
-                  marginTop: '20px',
-                  lineHeight: 'normal',
-                  height: 'auto',
-                  textAlign: 'center',
-                },
-              },
-            },
-          ],
+          blocks: [],
         },
         {
           image:
             'https://cdn.builder.io/api/v1/image/assets%2Fpwgjf0RoYWbdnJSbpBAjXNRMe9F2%2Ffb27a7c790324294af8be1c35fe30f4d',
-          blocks: [
-            {
-              '@type': '@builder.io/sdk:Element',
-              component: {
-                name: 'Text',
-                options: {
-                  text: 'Enter some text...',
-                },
-              },
-              responsiveStyles: {
-                large: {
-                  display: 'flex',
-                  flexDirection: 'column',
-                  position: 'relative',
-                  flexShrink: '0',
-                  boxSizing: 'border-box',
-                  marginTop: '20px',
-                  lineHeight: 'normal',
-                  height: 'auto',
-                  textAlign: 'center',
-                },
-              },
-            },
-          ],
+          blocks: [],
         },
       ],
       subFields: [
@@ -74,34 +28,6 @@ Builder.registerComponent(CustomColumns, {
           required: true,
           defaultValue:
             'https://cdn.builder.io/api/v1/image/assets%2Fpwgjf0RoYWbdnJSbpBAjXNRMe9F2%2Ffb27a7c790324294af8be1c35fe30f4d',
-        },
-        {
-          name: 'blocks',
-          type: 'blocks',
-          defaultValue: [
-            {
-              '@type': '@builder.io/sdk:Element',
-              component: {
-                name: 'Text',
-                options: {
-                  text: 'Enter some text...',
-                },
-              },
-              responsiveStyles: {
-                large: {
-                  display: 'flex',
-                  flexDirection: 'column',
-                  position: 'relative',
-                  flexShrink: '0',
-                  boxSizing: 'border-box',
-                  marginTop: '20px',
-                  lineHeight: 'normal',
-                  height: 'auto',
-                  textAlign: 'center',
-                },
-              },
-            },
-          ],
         },
       ],
     },

--- a/examples/react-design-system/src/components/DynamicColumns/DynamicColumns.builder.js
+++ b/examples/react-design-system/src/components/DynamicColumns/DynamicColumns.builder.js
@@ -3,6 +3,7 @@ import { DynamicColumns } from './DynamicColumns';
 
 Builder.registerComponent(DynamicColumns, {
   name: 'Dynamic Columns',
+  description: 'Example of repeatable columns',
   image:
     'https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fd8ed37ba1bc143c0bb76008caff4b0da',
   inputs: [


### PR DESCRIPTION
@teleaziz Removed default text objects from block inputs to make regions editable (otherwise only a text object is rendered and can't add more blocks to column). No need for blocks subfield.