### PR TITLE
[utils] add utility function to transform components

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -151,3 +151,61 @@ export async function getStaticProps(context) {
   return { props: { content } };
 }
 ```
+
+## transformComponents
+
+Transforms builder content usage of multiple components to another.
+
+### Example
+
+This example replaces all `ProductsGrid` components in a builder content into a `ProductsSlider` which accepts slightly different inputs.
+
+```tsx
+import { Builder } from '@builder.io/react';
+
+function ProductsGrid(props) {
+  // props: { category: string }
+  const data = useProductData(props.category);
+  return <Grid products={data} />;
+}
+
+Builder.registerComponent(ProductsGrid, {
+  name: 'ProductsGrid',
+  inputs: [{ name: 'category', type: 'string', enum: ['men', 'women'] }],
+});
+```
+
+```tsx
+import { Builder } from '@builder.io/react';
+
+function ProductsSlider(props) {
+  // props: { collection: string }
+  const data = useProductData(props.collection);
+  return <Slider products={data} />;
+}
+
+Builder.registerComponent(ProductsSlider, {
+  name: 'ProductsSlider',
+  inputs: [{ name: 'collection', type: 'string', enum: ['men', 'women'] }],
+});
+```
+
+Notice the different input name between both components, in order to replace `ProductsGrid` with `ProductsSlider` will need to run `transformComponents` specifiying how inputs of one map to the other.
+
+```tsx
+import { transformComponents } from '@builder.io/utils';
+
+function updateGridToSlider(builderContent) {
+  return transformComponents(builderContent, {
+    ProductsGrid: {
+      name: 'ProductsSlider',
+      props: {
+        // map productsSlider collection input to ProductsGrid category input
+        collection: 'category',
+      },
+    },
+  });
+}
+```
+
+note: This can break content if the transformation was incorrect, recommend duplicating content and testing on non-live duplicates.

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,2 +1,3 @@
 export * from './get-async-props';
 export * from './extend-async-props';
+export * from './transform-components';

--- a/packages/utils/src/transform-components.test.ts
+++ b/packages/utils/src/transform-components.test.ts
@@ -25,7 +25,6 @@ test('Transforms components name and options', async () => {
       },
     },
   });
-  console.log(result.data!);
   expect(result.data!.blocks![0].component!.options.collection).toBe('women');
   expect(result.data!.blocks![0].component!.name).toBe('ProductsV2');
 });

--- a/packages/utils/src/transform-components.test.ts
+++ b/packages/utils/src/transform-components.test.ts
@@ -1,0 +1,31 @@
+import { BuilderContent } from '@builder.io/sdk';
+import { transformComponents } from './transform-components';
+
+test('Migrate component props', async () => {
+  const content: BuilderContent = {
+    data: {
+      blocks: [
+        {
+          '@type': '@builder.io/sdk:Element',
+          component: {
+            name: 'Products',
+            options: {
+              category: 'women',
+            },
+          },
+        },
+      ],
+    },
+  };
+  const result = transformComponents(content, {
+    Products: {
+      name: 'ProductsV2',
+      props: {
+        collection: 'category',
+      },
+    },
+  });
+  console.log(result.data!);
+  expect(result.data!.blocks![0].component!.options.collection).toBe('women');
+  expect(result.data!.blocks![0].component!.name).toBe('ProductsV2');
+});

--- a/packages/utils/src/transform-components.test.ts
+++ b/packages/utils/src/transform-components.test.ts
@@ -1,7 +1,7 @@
 import { BuilderContent } from '@builder.io/sdk';
 import { transformComponents } from './transform-components';
 
-test('Migrate component props', async () => {
+test('Transforms components name and options', async () => {
   const content: BuilderContent = {
     data: {
       blocks: [

--- a/packages/utils/src/transform-components.ts
+++ b/packages/utils/src/transform-components.ts
@@ -1,0 +1,62 @@
+import { BuilderContent, BuilderElement } from '@builder.io/sdk';
+import traverse from 'traverse';
+
+const isBuilderElement = (item: unknown): item is BuilderElement => {
+  return Boolean((item as any)?.['@type'] === '@builder.io/sdk:Element');
+};
+
+type PropsMappers = { [key: string]: { name: string; props: Record<string, string> } };
+
+export function transformComponents(content: BuilderContent, mappers: PropsMappers) {
+  return traverse(content).map(function (item) {
+    if (isBuilderElement(item)) {
+      if (item.component) {
+        const mapper = mappers[item.component.name];
+        if (mapper) {
+          this.update({
+            ...item,
+            ...(item.code?.bindings
+              ? {
+                  code: {
+                    ...item.code,
+                    bindings: {
+                      ...item.code.bindings,
+                      ...Object.keys(mapper.props).reduce((acc, key) => {
+                        return {
+                          ...acc,
+                          [key]: item.code!.bindings![mapper.props[key]],
+                        };
+                      }, {}),
+                    },
+                  },
+                }
+              : {}),
+            ...(item.bindings
+              ? {
+                  bindings: {
+                    ...item.bindings,
+                    ...Object.keys(mapper.props).reduce((acc, key) => {
+                      return {
+                        ...acc,
+                        [key]: item.bindings![mapper.props[key]],
+                      };
+                    }, {}),
+                  },
+                }
+              : {}),
+            component: {
+              ...item.component,
+              name: mapper.name,
+              options: Object.keys(mapper.props).reduce((acc, key) => {
+                return {
+                  ...acc,
+                  [key]: item.component?.options[mapper.props[key]],
+                };
+              }, {}),
+            },
+          });
+        }
+      }
+    }
+  });
+}

--- a/packages/utils/src/transform-components.ts
+++ b/packages/utils/src/transform-components.ts
@@ -22,10 +22,14 @@ export function transformComponents(content: BuilderContent, mappers: PropsMappe
                     bindings: {
                       ...item.code.bindings,
                       ...Object.keys(mapper.props).reduce((acc, key) => {
-                        return {
-                          ...acc,
-                          [key]: item.code!.bindings![mapper.props[key]],
-                        };
+                        const binding = item.code!.bindings![mapper.props[key]];
+                        if (binding) {
+                          return {
+                            ...acc,
+                            [key]: binding
+                          };  
+                        }
+                        return acc;
                       }, {}),
                     },
                   },
@@ -36,10 +40,14 @@ export function transformComponents(content: BuilderContent, mappers: PropsMappe
                   bindings: {
                     ...item.bindings,
                     ...Object.keys(mapper.props).reduce((acc, key) => {
-                      return {
-                        ...acc,
-                        [key]: item.bindings![mapper.props[key]],
-                      };
+                      const binding = item.bindings![mapper.props[key]]
+                      if (binding) {
+                        return {
+                          ...acc,
+                          [key]: item.bindings![mapper.props[key]],
+                        };  
+                      }
+                      return acc;
                     }, {}),
                   },
                 }

--- a/packages/utils/src/transform-components.ts
+++ b/packages/utils/src/transform-components.ts
@@ -22,12 +22,14 @@ export function transformComponents(content: BuilderContent, mappers: PropsMappe
                     bindings: {
                       ...item.code.bindings,
                       ...Object.keys(mapper.props).reduce((acc, key) => {
-                        const binding = item.code!.bindings![mapper.props[key]];
+                        const binding = item.code!.bindings!![
+                          `component.options.${mapper.props[key]}`
+                        ];
                         if (binding) {
                           return {
                             ...acc,
-                            [key]: binding
-                          };  
+                            [key]: binding,
+                          };
                         }
                         return acc;
                       }, {}),
@@ -40,12 +42,12 @@ export function transformComponents(content: BuilderContent, mappers: PropsMappe
                   bindings: {
                     ...item.bindings,
                     ...Object.keys(mapper.props).reduce((acc, key) => {
-                      const binding = item.bindings![mapper.props[key]]
+                      const binding = item.bindings![`component.options.${mapper.props[key]}`];
                       if (binding) {
                         return {
                           ...acc,
-                          [key]: item.bindings![mapper.props[key]],
-                        };  
+                          [key]: binding,
+                        };
                       }
                       return acc;
                     }, {}),


### PR DESCRIPTION
## transformComponents

Transforms builder content usage of multiple components to another.

### Example

This example replaces all `ProductsGrid` components in a builder content into a `ProductsSlider` which accepts slightly different inputs.

```tsx
import { Builder } from '@builder.io/react';

function ProductsGrid(props) {
  // props: { category: string }
  const data = useProductData(props.category);
  return <Grid products={data} />;
}

Builder.registerComponent(ProductsGrid, {
  name: 'ProductsGrid',
  inputs: [{ name: 'category', type: 'string', enum: ['men', 'women'] }],
});
```

```tsx
import { Builder } from '@builder.io/react';

function ProductsSlider(props) {
  // props: { collection: string }
  const data = useProductData(props.collection);
  return <Slider products={data} />;
}

Builder.registerComponent(ProductsSlider, {
  name: 'ProductsSlider',
  inputs: [{ name: 'collection', type: 'string', enum: ['men', 'women'] }],
});
```

Notice the different input name between both components, in order to replace `ProductsGrid` with `ProductsSlider` will need to run `transformComponents` specifiying how inputs of one map to the other.

```tsx
import { transformComponents } from '@builder.io/utils';

function updateGridToSlider(builderContent) {
  return transformComponents(builderContent, {
    ProductsGrid: {
      name: 'ProductsSlider',
      props: {
        // map productsSlider collection input to ProductsGrid category input
        collection: 'category',
      },
    },
  });
}
```