### PR TITLE
Auto assign issues

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,15 @@
+name: Issue assignment
+
+on:
+    issues:
+        types: [opened]
+
+jobs:
+    auto-assign:
+        runs-on: ubuntu-latest
+        steps:
+            - name: 'Auto-assign issue'
+              uses: pozil/auto-assign-issue@v1.1.0
+              with:
+                  assignees: mrkoreye,teleaziz,mandx,ca136,mhevery,manucorporat,adamdbradley,samijaber,Dkendal
+                  numOfAssignee: 1


### PR DESCRIPTION
Auto assign new issues to someone on the team so that they can investigate and triage

