### PR TITLE
Export RenderBlock in the React Native SDK

### DIFF
--- a/packages/sdks/output/react-native/package.json
+++ b/packages/sdks/output/react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@builder.io/sdk-react-native",
   "description": "Builder.io SDK for React Native",
-  "version": "0.0.1-36",
+  "version": "0.0.1-37",
   "main": "src/index.js",
   "scripts": {
     "release:dev": "npm version prerelease --no-git-tag-version && npm publish --tag dev --access public"

--- a/packages/sdks/overrides/react-native/src/index.ts
+++ b/packages/sdks/overrides/react-native/src/index.ts
@@ -11,6 +11,7 @@ export { default as Symbol } from './blocks/symbol.lite';
 export { default as Section } from './blocks/section.lite';
 export { default as Fragment } from './blocks/fragment.lite';
 export { default as RenderContent } from './components/render-content.lite';
+export { default as RenderBlock } from './components/render-block.lite';
 
 export * from './functions/is-editing';
 export * from './functions/register-component';


### PR DESCRIPTION
## Export RenderBlock in the React Native SDK
RenderBlock is an important base construct that is needed in order to introduce higher level constructs such as containers.
Exposing it allows to build sophisticated custom containers.

