### PR TITLE
Support pixel for native

### DIFF
--- a/packages/react/src/blocks/Image.tsx
+++ b/packages/react/src/blocks/Image.tsx
@@ -283,6 +283,7 @@ class ImageComponent extends React.Component<any, { imageLoaded: boolean; load: 
       srcset = this.getSrcSet();
     }
 
+    const isPixel = this.props.builderBlock?.id.startsWith('builder-pixel-');
     const { fitContent } = this.props;
 
     return (
@@ -331,7 +332,7 @@ class ImageComponent extends React.Component<any, { imageLoaded: boolean; load: 
                   },
                 }),
               }}
-              loading="lazy"
+              loading={isPixel ? 'eager' : 'lazy'}
               className={'builder-image' + (this.props.className ? ' ' + this.props.className : '')}
               src={this.image}
               {...(!amp && {

--- a/packages/sdks/overrides/react-native/src/functions/transform-block.ts
+++ b/packages/sdks/overrides/react-native/src/functions/transform-block.ts
@@ -1,7 +1,8 @@
 import type { BuilderBlock } from '../types/builder-block';
 
 export function transformBlock(block: BuilderBlock): BuilderBlock {
-  // Map the DOM-based pixel format to a native compatible one
+  // Map the DOM-based pixel format to a native compatible one.
+  // react-native doesn't support DOM specific fields like `tagName` and `properties`, but any browser framework (e.g. Vue, etc.) do
   if (block.id.startsWith('builder-pixel-')) {
     return {
       ...block,

--- a/packages/sdks/overrides/react-native/src/functions/transform-block.ts
+++ b/packages/sdks/overrides/react-native/src/functions/transform-block.ts
@@ -1,4 +1,6 @@
-export function transformBlock(block: any) {
+import type { BuilderBlock } from '../types/builder-block';
+
+export function transformBlock(block: BuilderBlock): BuilderBlock {
   // Map the DOM-based pixel format to a native compatible one
   if (block.id.startsWith('builder-pixel-')) {
     return {

--- a/packages/sdks/overrides/react-native/src/functions/transform-block.ts
+++ b/packages/sdks/overrides/react-native/src/functions/transform-block.ts
@@ -1,0 +1,15 @@
+export function transformBlock(block: any) {
+  // Map the DOM-based pixel format to a native compatible one
+  if (block.id.startsWith('builder-pixel-')) {
+    return {
+      ...block,
+      component: {
+        name: 'Image',
+        options: {
+          image: block.properties.src,
+        },
+      },
+    };
+  }
+  return block;
+}

--- a/packages/sdks/src/functions/get-block-actions.ts
+++ b/packages/sdks/src/functions/get-block-actions.ts
@@ -1,3 +1,4 @@
+import { BuilderBlock } from '../types/builder-block';
 import { evaluate } from './evaluate';
 
 function capitalizeFirstLetter(string: string) {
@@ -5,7 +6,7 @@ function capitalizeFirstLetter(string: string) {
 }
 
 export function getBlockActions(options: {
-  block: any;
+  block: BuilderBlock;
   context: any;
   state: any;
 }): any {

--- a/packages/sdks/src/functions/get-processed-block.ts
+++ b/packages/sdks/src/functions/get-processed-block.ts
@@ -1,9 +1,10 @@
+import { BuilderBlock } from '../types/builder-block';
 import { evaluate } from './evaluate';
 import { set } from './set';
 import { transformBlock } from './transform-block';
 
 export function getProcessedBlock(options: {
-  block: any;
+  block: BuilderBlock;
   state: any;
   context: any;
 }) {

--- a/packages/sdks/src/functions/get-processed-block.ts
+++ b/packages/sdks/src/functions/get-processed-block.ts
@@ -1,12 +1,15 @@
 import { evaluate } from './evaluate';
 import { set } from './set';
+import { transformBlock } from './transform-block';
 
 export function getProcessedBlock(options: {
   block: any;
   state: any;
   context: any;
 }) {
-  const { block, state, context } = options;
+  const { state, context } = options;
+  const block = transformBlock(options.block);
+
   if (!block.bindings) {
     return block;
   }

--- a/packages/sdks/src/functions/transform-block.ts
+++ b/packages/sdks/src/functions/transform-block.ts
@@ -1,4 +1,6 @@
+import { BuilderBlock } from '../types/builder-block';
+
 // Noope way for targets to make modifications to the block object if/as needed
-export function transformBlock(block: any) {
+export function transformBlock(block: BuilderBlock): BuilderBlock {
   return block;
 }

--- a/packages/sdks/src/functions/transform-block.ts
+++ b/packages/sdks/src/functions/transform-block.ts
@@ -1,0 +1,4 @@
+// Noope way for targets to make modifications to the block object if/as needed
+export function transformBlock(block: any) {
+  return block;
+}


### PR DESCRIPTION
Our current pixel object assumes the environment is the DOM and sends it as

```
{ tagName: 'img', properties: { src: '..' } }
```

but we need a native compatible one for native SDKs, so this PR adds that and also gives us the option to move all pixels to a naive compatible one