### PR TITLE
remove shopify gif from readme

### DIFF
--- a/plugins/bigcommerce/README.md
+++ b/plugins/bigcommerce/README.md
@@ -1,9 +1,6 @@
 # Builder.io Bigcommerce plugin
 
 Easily connect your BigCommerce catalog to your Builder.io content!
-
-<img alt="Vtex data example" src="https://imgur.com/BhtUeqK.gif" >
-
 ## Installation
 
 Go to [builder.io/account/organization](https://builder.io/account/organization) and type `@builder.io/plugin-bigcommerce` , then hit save, a prompt will ask you for your Store Hash / Access Token.

--- a/plugins/commercetools/README.md
+++ b/plugins/commercetools/README.md
@@ -1,9 +1,6 @@
 # Builder.io Commercetools plugin
 
 Easily connect your Commercetools data to your Builder.io content!
-
-<img alt="Commercetools data example" src="https://imgur.com/BhtUeqK.gif" >
-
 ## Installation
 
 Go to [builder.io/account/organization](https://builder.io/account/organization) and press on `@builder.io/plugin-commercetools` in the list of plugins, then hit save, you'll be prompted for storeId and secretKey next.

--- a/plugins/elasticpath/README.md
+++ b/plugins/elasticpath/README.md
@@ -2,8 +2,6 @@
 
 Easily connect your Elasticpath catalog to your Builder.io content!
 
-<img alt="Elasticpath data example" src="https://imgur.com/BhtUeqK.gif" >
-
 ## Installation
 
 Go to [builder.io/account/organization](https://builder.io/account/organization) and press on `@builder.io/plugin-elasticpath` in the list of plugins, then hit save, a prompt will ask you for your client ID.

--- a/plugins/magento2/README.md
+++ b/plugins/magento2/README.md
@@ -2,8 +2,6 @@
 
 Easily connect your Magento data to your Builder.io content!
 
-<img alt="Magento data example" src="https://imgur.com/BhtUeqK.gif" >
-
 ## Installation
 
 Go to [builder.io/integrations](https://builder.io/account/organization) and enable the magento integration in the list of integrations, then hit save, you'll be prompted for store URL.

--- a/plugins/swell/README.md
+++ b/plugins/swell/README.md
@@ -1,9 +1,6 @@
 # Builder.io Swell plugin
 
 Easily connect your Swell data to your Builder.io content!
-
-<img alt="Swell data example" src="https://imgur.com/BhtUeqK.gif" >
-
 ## Installation
 
 Go to [builder.io/account/organization](https://builder.io/account/organization) and press on `@builder.io/plugin-swell` in the list of plugins, then hit save, you'll be prompted for storeId and secretKey next.

--- a/plugins/vtex/README.md
+++ b/plugins/vtex/README.md
@@ -1,9 +1,6 @@
 # Builder.io Vtex plugin
 
 Easily connect your Vtex catalog to your Builder.io content!
-
-<img alt="Vtex data example" src="https://imgur.com/BhtUeqK.gif" >
-
 ## Installation
 
 Go to [builder.io/account/organization](https://builder.io/account/organization) and type `@builder.io/plugin-vtex` , then hit save, a prompt will ask you for your client ID / Secret Key / Account Name.


### PR DESCRIPTION
Removed Shopify gif from plugin docs for Magento, Elasticpath, Commercetools, Bigcommerce, Swell, and Vtex. The gif may be confusing to users using plugins unrelated to Shopify