### PR TITLE
fix typo in its

### DIFF
--- a/packages/react/src/blocks/Image.tsx
+++ b/packages/react/src/blocks/Image.tsx
@@ -500,7 +500,7 @@ export const Image = withBuilder(ImageComponent, {
         {
           label: 'cover',
           value: 'cover',
-          helperText: `The image should fill it's box, cropping when needed`,
+          helperText: `The image should fill its box, cropping when needed`,
         },
         // TODO: add these options back
         // { label: 'auto', value: 'auto', helperText: '' },


### PR DESCRIPTION
## Description

Fixes typo in helper text in Builder UI in the Image edit modal. Currently, it says:

>          helperText: `The image should fill it's box, cropping when needed`,

Changes to:

>           helperText: `The image should fill its box, cropping when needed`,


_Screenshot of current state_
<img width="448" alt="Screen Shot 2022-01-20 at 4 40 00 PM" src="https://user-images.githubusercontent.com/4116963/150429888-378fb83a-c875-4b02-8c9f-47d21903de31.png">
This PR removes the apostrophe.
