### PR TITLE
Core SDK logging

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,3 +1,8 @@
+### UPCOMING
+
+- improved logging during JSON.parse errors
+- deprecation notice on `Builder.VERSION`
+
 ### 1.1.26
 
 - fix: respect `builder.canTrack` for not setting the session cookie https://github.com/BuilderIO/builder/pull/900

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -2006,6 +2006,13 @@ export class Builder {
             try {
               resolve(JSON.parse(data));
             } catch (err) {
+              if ((err as any)?.name === 'SyntaxError') {
+                const jsonParseError = new Error(
+                  `[Builder.io] JSON parsing error: expected valid JSON content, instead received: ${data}`
+                );
+                reject(jsonParseError);
+              }
+
               reject(err);
             }
           });

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -2008,7 +2008,10 @@ export class Builder {
             } catch (err) {
               if ((err as any)?.name === 'SyntaxError') {
                 const jsonParseError = new Error(
-                  `[Builder.io] JSON parsing error: expected valid JSON content, instead received: ${data}`
+                  `[Builder.io] ERROR: invalid response.
+Request: ${JSON.stringify(requestOptions, null, 2)}
+Response Data: ${data}
+`
                 );
                 reject(jsonParseError);
               }

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -604,6 +604,9 @@ export interface Action {
 }
 
 export class Builder {
+  /**
+   * @deprecated. This is buggy, and always behind by a version.
+   */
   static VERSION = version;
 
   static components: Component[] = [];


### PR DESCRIPTION
## Description

- deprecation notice for `VERSION`
- add logging for requests that fail to return valid JSON, for easier debugging with customers.


Looks something like this:
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/1393142/156663547-3f7b3083-8ee7-42f1-bbba-5eadec67e584.png">
