### PR TITLE
Remove throttle

### DIFF
--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -121,8 +121,6 @@ function decorator(fn: Function) {
   };
 }
 
-const Throttle = decorator(throttle);
-
 const fetchCache: { [key: string]: any } = {};
 
 export interface BuilderComponentProps {
@@ -1192,7 +1190,6 @@ export class BuilderComponent extends React.Component<
   }
 
   // TODO: customizable hm
-  @Throttle(100, { leading: true, trailing: true })
   throttledHandleRequest(propertyName: string, url: string) {
     return this.handleRequest(propertyName, url);
   }

--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -1189,10 +1189,6 @@ export class BuilderComponent extends React.Component<
     return expression.replace(/{{([^}]+)}}/g, (match, group) => tryEval(group, data, this._errors));
   }
 
-  // TODO: customizable hm
-  throttledHandleRequest(propertyName: string, url: string) {
-    return this.handleRequest(propertyName, url);
-  }
 
   async handleRequest(propertyName: string, url: string) {
     // TODO: Builder.isEditing = just checks if iframe and parent page is this.builder.io or localhost:1234
@@ -1448,7 +1444,7 @@ export class BuilderComponent extends React.Component<
               const builderModelMatch = url.match(builderModelRe);
               const model = builderModelMatch && builderModelMatch[1];
               if (false && Builder.isEditing && model && this.builder.editingModel === model) {
-                this.throttledHandleRequest(key, finalUrl);
+                this.handleRequest(key, finalUrl)
                 // TODO: fix this
                 // this.subscriptions.add(
                 //   this.builder.get(model).subscribe(data => {
@@ -1458,7 +1454,7 @@ export class BuilderComponent extends React.Component<
                 //   })
                 // )
               } else {
-                this.throttledHandleRequest(key, finalUrl);
+                this.handleRequest(key, finalUrl)
                 const currentSubscription = this.httpSubscriptionPerKey[key];
                 if (currentSubscription) {
                   currentSubscription.unsubscribe();
@@ -1470,7 +1466,7 @@ export class BuilderComponent extends React.Component<
                 ] = this.onStateChange.subscribe(() => {
                   const newUrl = this.evalExpression(url);
                   if (newUrl !== finalUrl) {
-                    this.throttledHandleRequest(key, newUrl);
+                    this.handleRequest(key, newUrl)
                     this.lastHttpRequests[key] = newUrl;
                   }
                 }));


### PR DESCRIPTION
## Description

Fix the bug that data from multiple sources are not displayed. Removed @Throttle, because it was invoking the function once every 100ms and we were missing some calls to the datasources (if two different calls within 100ms, the second one was skipped, hence data missing).
