### PR TITLE
SDKs: fix "+ add block" button

### DIFF
--- a/examples/vue/vue-storefront-2/pages/_path.vue
+++ b/examples/vue/vue-storefront-2/pages/_path.vue
@@ -43,7 +43,6 @@ export default Vue.extend({
     }
     this.content = content;
     this.canShowContent = content || isEditing();
-    console.log({ canShowContent: this.canShowContent, isEditing: isEditing(), content });
   },
 });
 </script>

--- a/examples/vue/vue-storefront-2/pages/_path.vue
+++ b/examples/vue/vue-storefront-2/pages/_path.vue
@@ -1,8 +1,9 @@
 <template>
   <div id="home">
     <div>Hello world from your Vue project. Below is Builder Content:</div>
-    <div>page: {{ content.data.title }}</div>
+
     <div v-if="canShowContent">
+      <div>page: {{ content.data.title }}</div>
       <builder-render-content model="page" :content="content" />
     </div>
   </div>
@@ -42,6 +43,7 @@ export default Vue.extend({
     }
     this.content = content;
     this.canShowContent = content || isEditing();
+    console.log({ canShowContent: this.canShowContent, isEditing: isEditing(), content });
   },
 });
 </script>

--- a/packages/sdks/output/react-native/src/blocks/columns.lite.tsx
+++ b/packages/sdks/output/react-native/src/blocks/columns.lite.tsx
@@ -53,9 +53,9 @@ export default function Columns(props) {
   }
 
   return (
-    <View className="builder-columns" style={styles.view1}>
+    <View style={styles.view1}>
       {props.columns?.map((column) => (
-        <View className="builder-column" style={styles.view2}>
+        <View style={styles.view2}>
           <RenderBlocks blocks={column.blocks} />
         </View>
       ))}

--- a/packages/sdks/output/react-native/src/blocks/custom-code.lite.tsx
+++ b/packages/sdks/output/react-native/src/blocks/custom-code.lite.tsx
@@ -55,13 +55,5 @@ export default function CustomCode(props) {
     findAndRunScripts();
   }, []);
 
-  return (
-    <View
-      ref={elem}
-      className={
-        'builder-custom-code' + (props.replaceNodes ? ' replace-nodes' : '')
-      }
-      dangerouslySetInnerHTML={{ __html: 'props.code' }}
-    />
-  );
+  return <View ref={elem} dangerouslySetInnerHTML={{ __html: 'props.code' }} />;
 }

--- a/packages/sdks/output/react-native/src/blocks/embed.lite.tsx
+++ b/packages/sdks/output/react-native/src/blocks/embed.lite.tsx
@@ -56,10 +56,6 @@ export default function Embed(props) {
   }, []);
 
   return (
-    <View
-      className="builder-embed"
-      ref={elem}
-      dangerouslySetInnerHTML={{ __html: 'props.content' }}
-    />
+    <View ref={elem} dangerouslySetInnerHTML={{ __html: 'props.content' }} />
   );
 }

--- a/packages/sdks/output/react-native/src/blocks/form.lite.tsx
+++ b/packages/sdks/output/react-native/src/blocks/form.lite.tsx
@@ -231,7 +231,7 @@ export default function FormComponent(props) {
       ) : null}{' '}
       {submissionState() === 'error' && responseData ? (
         <>
-          <View className="builder-form-error-text" style={styles.view1}>
+          <View style={styles.view1}>
             {' '}
             <Text>{JSON.stringify(responseData, null, 2)}</Text>{' '}
           </View>

--- a/packages/sdks/output/react-native/src/blocks/image.lite.tsx
+++ b/packages/sdks/output/react-native/src/blocks/image.lite.tsx
@@ -10,7 +10,6 @@ export default function Image(props) {
           alt={props.altText}
           aria-role={props.altText ? 'presentation' : undefined}
           style={styles.view2}
-          className={'builder-image' + (props.class ? ' ' + props.class : '')}
           src={props.image}
           srcset={props.srcset}
           sizes={props.sizes}
@@ -21,7 +20,7 @@ export default function Image(props) {
 
       {props.aspectRatio &&
       !(props.fitContent && props.builderBlock?.children?.length) ? (
-        <View className="builder-image-sizer" style={styles.view3}>
+        <View style={styles.view3}>
           <Text> </Text>
         </View>
       ) : null}

--- a/packages/sdks/output/react-native/src/blocks/raw-text.lite.tsx
+++ b/packages/sdks/output/react-native/src/blocks/raw-text.lite.tsx
@@ -2,10 +2,5 @@ import * as React from 'react';
 import { View, StyleSheet, Image, Text } from 'react-native';
 
 export default function RawText(props) {
-  return (
-    <View
-      className={props.attributes?.class || props.attributes?.className}
-      dangerouslySetInnerHTML={{ __html: "props.text || ''" }}
-    />
-  );
+  return <View dangerouslySetInnerHTML={{ __html: "props.text || ''" }} />;
 }

--- a/packages/sdks/output/react-native/src/blocks/symbol.lite.tsx
+++ b/packages/sdks/output/react-native/src/blocks/symbol.lite.tsx
@@ -8,7 +8,7 @@ export default function Symbol(props) {
   const builderContext = useContext(BuilderContext);
 
   return (
-    <View className="builder-symbol">
+    <View>
       <RenderContent
         context={builderContext.context}
         data={props.symbol?.data}

--- a/packages/sdks/output/react-native/src/blocks/text.lite.tsx
+++ b/packages/sdks/output/react-native/src/blocks/text.lite.tsx
@@ -2,10 +2,5 @@ import * as React from 'react';
 import { View, StyleSheet, Image, Text } from 'react-native';
 
 export default function Text(props) {
-  return (
-    <View
-      className="builder-text"
-      dangerouslySetInnerHTML={{ __html: 'props.text' }}
-    />
-  );
+  return <View dangerouslySetInnerHTML={{ __html: 'props.text' }} />;
 }

--- a/packages/sdks/output/react-native/src/components/render-blocks.lite.tsx
+++ b/packages/sdks/output/react-native/src/components/render-blocks.lite.tsx
@@ -4,6 +4,10 @@ import { isEditing } from '../functions/is-editing';
 import RenderBlock from './render-block.lite';
 
 export default function RenderBlocks(props) {
+  function className() {
+    return 'builder-blocks' + (!props.blocks?.length ? ' no-blocks' : '');
+  }
+
   function onClick() {
     if (isEditing() && !props.blocks?.length) {
       window.parent?.postMessage(
@@ -38,16 +42,20 @@ export default function RenderBlocks(props) {
     <View
       builder-path={props.path}
       builder-parent-id={props.parent}
-      onClick={(event) => onClick}
-      onMouseEnter={(event) => onMouseEnter}
-      className={'builder-blocks' + (!props.blocks?.length ? ' no-blocks' : '')}
+      dataSet={{
+        class: className(),
+      }}
+      onClick={(event) => onClick()}
+      onMouseEnter={(event) => onMouseEnter()}
       style={styles.view1}
     >
       {props.blocks ? (
         <>
-          {props.blocks?.map((block) => (
-            <RenderBlock block={block} />
-          ))}
+          <>
+            {props.blocks?.map((block) => (
+              <RenderBlock block={block} />
+            ))}
+          </>
         </>
       ) : null}
     </View>

--- a/packages/sdks/output/react-native/src/components/render-blocks.lite.tsx
+++ b/packages/sdks/output/react-native/src/components/render-blocks.lite.tsx
@@ -51,11 +51,9 @@ export default function RenderBlocks(props) {
     >
       {props.blocks ? (
         <>
-          <>
-            {props.blocks?.map((block) => (
-              <RenderBlock block={block} />
-            ))}
-          </>
+          {props.blocks?.map((block) => (
+            <RenderBlock block={block} />
+          ))}
         </>
       ) : null}
     </View>

--- a/packages/sdks/output/react-native/src/components/render-content.lite.tsx
+++ b/packages/sdks/output/react-native/src/components/render-content.lite.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { View, StyleSheet, Image, Text } from 'react-native';
 import { useState, useContext, useEffect } from 'react';
 import { isBrowser } from '../functions/is-browser';
-import RenderBlock from './render-block.lite';
 import BuilderContext from '../context/builder.context.lite';
 import { track } from '../functions/track';
 import { ifTarget } from '../functions/if-target';
@@ -16,6 +15,7 @@ import {
   convertSearchParamsToQueryObject,
   getBuilderSearchParams,
 } from '../functions/get-builder-search-params';
+import RenderBlocks from './render-blocks.lite';
 
 export default function RenderContent(props) {
   function useContent() {
@@ -151,6 +151,14 @@ export default function RenderContent(props) {
     }
   }, []);
 
+  useEffect(() => {
+    return () => {
+      if (isBrowser()) {
+        window.removeEventListener('message', processMessage);
+      }
+    };
+  }, []);
+
   return (
     <BuilderContext.Provider
       value={{
@@ -189,9 +197,7 @@ export default function RenderContent(props) {
               </View>
             ) : null}
 
-            {useContent?.()?.data?.blocks?.map((block) => (
-              <RenderBlock key={block.id} block={block} />
-            ))}
+            <RenderBlocks blocks={useContent?.()?.data?.blocks} />
           </View>
         </>
       ) : null}

--- a/packages/sdks/output/vue/nuxt2/src/blocks/columns.vue
+++ b/packages/sdks/output/vue/nuxt2/src/blocks/columns.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="builder-columns div-21azgz5avex" :style="columnsCssVars">
+  <div class="builder-columns div-t9spj7joih" :style="columnsCssVars">
     <div
-      class="builder-column div-21azgz5avex-2"
+      class="builder-column div-t9spj7joih-2"
       v-for="(column, index) in columns"
       :style="{
         width: getColumnCssWidth(index),
@@ -292,32 +292,32 @@ export default registerComponent(
 );
 </script>
 <style scoped>
-.div-21azgz5avex {
+.div-t9spj7joih {
   display: flex;
   align-items: stretch;
   line-height: normal;
 }
 @media (max-width: 999px) {
-  .div-21azgz5avex {
+  .div-t9spj7joih {
     flex-direction: var(--flex-dir-tablet);
   }
 }
 @media (max-width: 639px) {
-  .div-21azgz5avex {
+  .div-t9spj7joih {
     flex-direction: var(--flex-dir);
   }
 }
-.div-21azgz5avex-2 {
+.div-t9spj7joih-2 {
   flex-grow: 1;
 }
 @media (max-width: 999px) {
-  .div-21azgz5avex-2 {
+  .div-t9spj7joih-2 {
     width: var(--column-width-tablet) !important;
     margin-left: var(--column-margin-left-tablet) !important;
   }
 }
 @media (max-width: 639px) {
-  .div-21azgz5avex-2 {
+  .div-t9spj7joih-2 {
     width: var(--column-width) !important;
     margin-left: var(--column-margin-left) !important;
   }

--- a/packages/sdks/output/vue/nuxt2/src/blocks/form.vue
+++ b/packages/sdks/output/vue/nuxt2/src/blocks/form.vue
@@ -27,7 +27,7 @@
     ></builder-blocks>
 
     <pre
-      class="builder-form-error-text pre-t9spj7joih"
+      class="builder-form-error-text pre-1be3j8m9ewb"
       v-if="submissionState === 'error' && responseData"
     >
         {{ JSON.stringify(responseData, null, 2) }}
@@ -515,7 +515,7 @@ export default registerComponent(
 );
 </script>
 <style scoped>
-.pre-t9spj7joih {
+.pre-1be3j8m9ewb {
   padding: 10px;
   color: red;
   text-align: center;

--- a/packages/sdks/output/vue/nuxt2/src/blocks/image.vue
+++ b/packages/sdks/output/vue/nuxt2/src/blocks/image.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="div-4wbls88y960">
+  <div class="div-1pl23ac79ld">
     <picture>
       <img
         loading="lazy"
-        class="img-4wbls88y960"
+        class="img-1pl23ac79ld"
         :alt="altText"
         :aria-role="altText ? 'presentation' : undefined"
         :style="{
@@ -23,7 +23,7 @@
     </picture>
 
     <div
-      class="builder-image-sizer div-4wbls88y960-2"
+      class="builder-image-sizer div-1pl23ac79ld-2"
       v-if="
         aspectRatio &&
         !(
@@ -42,7 +42,7 @@
 
     <slot></slot>
 
-    <div class="div-4wbls88y960-3" v-if="!fitContent">
+    <div class="div-1pl23ac79ld-3" v-if="!fitContent">
       <slot></slot>
     </div>
   </div>
@@ -167,10 +167,10 @@ export default registerComponent(
 );
 </script>
 <style scoped>
-.div-4wbls88y960 {
+.div-1pl23ac79ld {
   position: relative;
 }
-.img-4wbls88y960 {
+.img-1pl23ac79ld {
   opacity: 1;
   transition: opacity 0.2s ease-in-out;
   position: absolute;
@@ -179,12 +179,12 @@ export default registerComponent(
   top: 0px;
   left: 0px;
 }
-.div-4wbls88y960-2 {
+.div-1pl23ac79ld-2 {
   width: 100%;
   pointer-events: none;
   font-size: 0;
 }
-.div-4wbls88y960-3 {
+.div-1pl23ac79ld-3 {
   display: flex;
   flex-direction: column;
   align-items: stretch;

--- a/packages/sdks/output/vue/nuxt2/src/components/render-blocks.vue
+++ b/packages/sdks/output/vue/nuxt2/src/components/render-blocks.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="div-2flfunvabst"
+    class="div-21azgz5avex"
     :builder-path="path"
     :builder-parent-id="parent"
     :dataSet="{
@@ -76,7 +76,7 @@ export default {
 };
 </script>
 <style scoped>
-.div-2flfunvabst {
+.div-21azgz5avex {
   display: flex;
   flex-direction: column;
   align-items: stretch;

--- a/packages/sdks/output/vue/nuxt2/src/components/render-blocks.vue
+++ b/packages/sdks/output/vue/nuxt2/src/components/render-blocks.vue
@@ -1,16 +1,14 @@
 <template>
   <div
-    class="div-178o76acnws"
+    class="div-2flfunvabst"
     :builder-path="path"
     :builder-parent-id="parent"
-    @click="onClick"
-    @mouseenter="onMouseEnter"
-    :class="
-      _classStringToObject(
-        'builder-blocks' +
-          (!(this.blocks && this.blocks.length) ? ' no-blocks' : '')
-      )
-    "
+    :dataSet="{
+      class: className,
+    }"
+    @click="onClick()"
+    @mouseenter="onMouseEnter()"
+    :class="_classStringToObject(this.className)"
   >
     <render-block
       v-for="(block, index) in blocks"
@@ -27,6 +25,12 @@ export default {
   name: 'render-blocks',
   components: { 'render-block': async () => RenderBlock },
   props: ['blocks', 'parent', 'path'],
+
+  computed: {
+    className() {
+      return 'builder-blocks' + (!this.blocks?.length ? ' no-blocks' : '');
+    },
+  },
 
   methods: {
     onClick() {
@@ -72,7 +76,7 @@ export default {
 };
 </script>
 <style scoped>
-.div-178o76acnws {
+.div-2flfunvabst {
   display: flex;
   flex-direction: column;
   align-items: stretch;

--- a/packages/sdks/output/vue/nuxt2/src/components/render-content.vue
+++ b/packages/sdks/output/vue/nuxt2/src/components/render-content.vue
@@ -25,24 +25,21 @@
             ).length)) &&
         !isReactNative()
       "
-      is="style"
+      :is="style"
     >
       {{ useContent.data.cssCode }}
       {{ getFontCss(useContent.data) }}
     </component>
 
-    <render-block
-      v-for="(block, index) in useContent &&
-      useContent.data &&
-      (useContent && useContent.data).blocks"
-      :block="block"
-      :key="block.id"
-    ></render-block>
+    <render-blocks
+      :blocks="
+        useContent && useContent.data && (useContent && useContent.data).blocks
+      "
+    ></render-blocks>
   </div>
 </template>
 <script>
 import { isBrowser } from '../functions/is-browser';
-import RenderBlock from './render-block';
 import BuilderContext from '../context/builder.context';
 import { track } from '../functions/track';
 import { ifTarget } from '../functions/if-target';
@@ -56,10 +53,11 @@ import {
   convertSearchParamsToQueryObject,
   getBuilderSearchParams,
 } from '../functions/get-builder-search-params';
+import RenderBlocks from './render-blocks';
 
 export default {
   name: 'render-content',
-  components: { 'render-block': async () => RenderBlock },
+  components: { 'render-blocks': async () => RenderBlocks },
   props: ['content', 'model'],
 
   data: () => ({
@@ -121,6 +119,12 @@ export default {
           }
         }
       }
+    }
+  },
+
+  unmounted() {
+    if (isBrowser()) {
+      window.removeEventListener('message', this.processMessage);
     }
   },
 

--- a/packages/sdks/src/components/render-blocks.lite.tsx
+++ b/packages/sdks/src/components/render-blocks.lite.tsx
@@ -55,9 +55,11 @@ export default function RenderBlocks(props: RenderBlockProps) {
       onMouseEnter={state.onMouseEnter}
     >
       <Show when={props.blocks}>
-        {props.blocks?.map((block: any) => (
-          <RenderBlock block={block} />
-        ))}
+        <>
+          {props.blocks?.map((block: any, index) => (
+            <RenderBlock block={block} key={index} />
+          ))}
+        </>
       </Show>
     </div>
   );

--- a/packages/sdks/src/components/render-blocks.lite.tsx
+++ b/packages/sdks/src/components/render-blocks.lite.tsx
@@ -11,6 +11,9 @@ export type RenderBlockProps = {
 
 export default function RenderBlocks(props: RenderBlockProps) {
   const state = useState({
+    get className() {
+      return 'builder-blocks' + (!props.blocks?.length ? ' no-blocks' : '');
+    },
     onClick() {
       if (isEditing() && !props.blocks?.length) {
         window.parent?.postMessage(
@@ -43,21 +46,24 @@ export default function RenderBlocks(props: RenderBlockProps) {
 
   return (
     <div
-      className={'builder-blocks' + (!props.blocks?.length ? ' no-blocks' : '')}
+      className={state.className}
       builder-path={props.path}
       builder-parent-id={props.parent}
+      dataSet={{
+        class: state.className,
+      }}
       css={{
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'stretch',
       }}
-      onClick={state.onClick}
-      onMouseEnter={state.onMouseEnter}
+      onClick={(event) => state.onClick()}
+      onMouseEnter={(event) => state.onMouseEnter()}
     >
       <Show when={props.blocks}>
         <>
-          {props.blocks?.map((block: any, index) => (
-            <RenderBlock block={block} key={index} />
+          {props.blocks?.map((block: any) => (
+            <RenderBlock block={block} />
           ))}
         </>
       </Show>

--- a/packages/sdks/src/components/render-blocks.lite.tsx
+++ b/packages/sdks/src/components/render-blocks.lite.tsx
@@ -61,11 +61,9 @@ export default function RenderBlocks(props: RenderBlockProps) {
       onMouseEnter={(event) => state.onMouseEnter()}
     >
       <Show when={props.blocks}>
-        <>
-          {props.blocks?.map((block: any) => (
-            <RenderBlock block={block} />
-          ))}
-        </>
+        {props.blocks?.map((block: any) => (
+          <RenderBlock block={block} />
+        ))}
       </Show>
     </div>
   );

--- a/packages/sdks/src/components/render-content.lite.tsx
+++ b/packages/sdks/src/components/render-content.lite.tsx
@@ -8,7 +8,6 @@ import {
 } from '@builder.io/mitosis';
 import { isBrowser } from '../functions/is-browser';
 import { BuilderContent } from '../types/builder-content';
-import RenderBlock from './render-block.lite';
 import BuilderContext from '../context/builder.context.lite';
 import { track } from '../functions/track';
 import { ifTarget } from '../functions/if-target';
@@ -22,6 +21,7 @@ import {
   convertSearchParamsToQueryObject,
   getBuilderSearchParams,
 } from '../functions/get-builder-search-params';
+import RenderBlocks from './render-blocks.lite';
 
 export type RenderContentProps = {
   content?: BuilderContent;
@@ -207,9 +207,7 @@ export default function RenderContent(props: RenderContentProps) {
               {state.getFontCss(state.useContent.data)}
             </style>
           )}
-        {state.useContent?.data?.blocks?.map((block: any) => (
-          <RenderBlock key={block.id} block={block} />
-        ))}
+        <RenderBlocks blocks={state.useContent?.data?.blocks} />
       </div>
     </Show>
   );


### PR DESCRIPTION
## Description

A handful of fixes to bring the "+ add block" button to the SDKs on empty pages:
- use `RenderBlocks` instead of `RenderBlock` in `RenderContent` 3287dd77aa1588d8f8c76869a65dcca2794b1243
- fix event handlers in `RenderBlocks` 6307945e20b160c7ba053d80b41ca4f952cd0b98
- re-compile with latest version of Mitosis:
  - fixes `<style>` tag generation in Vue
  - removes extraneous `class` attributes in React-Native
  - fix `onUnMount` generation