### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -1414,7 +1414,7 @@ export class Builder {
 
   setTestsFromUrl() {
     const search = this.getLocation().search;
-    const params = QueryString.parseDeep(this.modifySearch(search || '').substr(1));
+    const params = QueryString.parseDeep(this.modifySearch(search || '').slice(1));
     const tests = params.builder && params.builder.tests;
     if (tests && typeof tests === 'object') {
       for (const key in tests) {
@@ -1442,7 +1442,7 @@ export class Builder {
 
   getOverridesFromQueryString() {
     const location = this.getLocation();
-    const params = QueryString.parseDeep(this.modifySearch(location.search || '').substr(1));
+    const params = QueryString.parseDeep(this.modifySearch(location.search || '').slice(1));
     const { builder } = params;
     if (builder) {
       const {
@@ -1748,7 +1748,7 @@ export class Builder {
 
   get previewingModel() {
     const search = this.getLocation().search;
-    const params = QueryString.parse((search || '').substr(1));
+    const params = QueryString.parse((search || '').slice(1));
     return params['builder.preview'];
   }
 
@@ -2084,7 +2084,7 @@ Response Data: ${data}
 
     const pageQueryParams: ParamsMap =
       typeof location !== 'undefined'
-        ? QueryString.parseDeep(location.search.substr(1))
+        ? QueryString.parseDeep(location.search.slice(1))
         : undefined || {};
 
     const userAttributes =

--- a/packages/core/src/classes/query-string.class.ts
+++ b/packages/core/src/classes/query-string.class.ts
@@ -16,7 +16,7 @@ export class QueryString {
 
   static parse(queryString: string): StringMap {
     const query: StringMap = {};
-    const pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split('&');
+    const pairs = (queryString[0] === '?' ? queryString.slice(1) : queryString).split('&');
     for (let i = 0; i < pairs.length; i++) {
       const pair = pairs[i].split('=');
       // TODO: node support?


### PR DESCRIPTION
## Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.
