### PR TITLE
fix(sdks): ENG-2365 pass content id as an unique key

### DIFF
--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -88,6 +88,9 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
     let options = {
       ...(this.props.options || ({} as GetContentOptions)),
     };
+    if (!options.key && this.props.content?.id) {
+      options.key = this.props.content.id;
+    }
     if (this.props.content && !options.initialContent?.length) {
       options.initialContent = [this.props.content];
     }
@@ -188,6 +191,7 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
         builder.queueGetContent(this.name, this.options).subscribe(
           matches => {
             const match = matches && matches[0];
+            console.log('matches', matches);
             this.setState({
               data: match,
               loading: false,

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -191,7 +191,6 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
         builder.queueGetContent(this.name, this.options).subscribe(
           matches => {
             const match = matches && matches[0];
-            console.log('matches', matches);
             this.setState({
               data: match,
               loading: false,


### PR DESCRIPTION
## Description

This PR passes a content id to options so that HMR takes the correct content id to re-render the BuilderContent component

_Loom Link_
https://www.loom.com/share/2cfb7ab0a4e04674844b5291483a40c0
