### PR TITLE
fixes for starters

### DIFF
--- a/examples/embed-starter-kit/site/pages/[[...page]].tsx
+++ b/examples/embed-starter-kit/site/pages/[[...page]].tsx
@@ -34,7 +34,7 @@ export async function getStaticPaths() {
 
   return {
     paths: pages.map((page) => `${page.data?.url}`),
-    fallback: true,
+    fallback: 'blocking',
   }
 }
 

--- a/examples/next-js-builder-site/src/functions/get-builder-static-paths.ts
+++ b/examples/next-js-builder-site/src/functions/get-builder-static-paths.ts
@@ -19,6 +19,6 @@ export const getBuilderStaticPaths = async (modelName: string) => {
 
   return {
     paths,
-    fallback: true,
+    fallback: 'blocking',
   };
 };

--- a/examples/next-js-builder-site/src/pages/blog/[article].tsx
+++ b/examples/next-js-builder-site/src/pages/blog/[article].tsx
@@ -327,7 +327,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
     paths: results
       .map((item) => ({ params: { article: item.data!.handle || '' } }))
       .concat([{ params: { article: '_' /* For previewing and editing */ } }]),
-    fallback: true,
+    fallback: 'blocking',
   };
 };
 

--- a/examples/next-js-builder-site/src/pages/c/[...content].tsx
+++ b/examples/next-js-builder-site/src/pages/c/[...content].tsx
@@ -159,7 +159,7 @@ export const getStaticPaths = async () => {
 
   return {
     paths,
-    fallback: true,
+    fallback: 'blocking',
   };
 };
 

--- a/examples/next-js-builder-site/src/pages/c/docs/[...doc].tsx
+++ b/examples/next-js-builder-site/src/pages/c/docs/[...doc].tsx
@@ -229,7 +229,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
         doc: (item.data?.url?.replace('/c/docs/', '') || '').split('/'),
       },
     })),
-    fallback: true,
+    fallback: 'blocking',
   };
 };
 

--- a/examples/next-js-simple/pages/[[...page]].tsx
+++ b/examples/next-js-simple/pages/[[...page]].tsx
@@ -39,7 +39,7 @@ export async function getStaticPaths() {
 
   return {
     paths: pages.map((page) => `${page.data?.url}`),
-    fallback: true,
+    fallback: 'blocking',
   }
 }
 

--- a/starters/create-builder/nextjs/pages/[[...page]].tsx
+++ b/starters/create-builder/nextjs/pages/[[...page]].tsx
@@ -1,16 +1,14 @@
-import type { GetStaticPropsContext, InferGetStaticPropsType } from "next";
-import { useRouter } from "next/router";
-import { BuilderComponent, Builder, builder } from "@builder.io/react";
-import DefaultErrorPage from "next/error";
-import Head from "next/head";
+import type { GetStaticPropsContext, InferGetStaticPropsType } from 'next';
+import { useRouter } from 'next/router';
+import { BuilderComponent, Builder, builder } from '@builder.io/react';
+import DefaultErrorPage from 'next/error';
+import Head from 'next/head';
 
-export async function getStaticProps({
-  params,
-}: GetStaticPropsContext<{ page: string[] }>) {
+export async function getStaticProps({ params }: GetStaticPropsContext<{ page: string[] }>) {
   const page = await builder
-    .get("page", {
+    .get('page', {
       userAttributes: {
-        urlPath: "/" + (params?.page?.join("/") || ""),
+        urlPath: '/' + (params?.page?.join('/') || ''),
       },
     })
     .toPromise();
@@ -27,20 +25,18 @@ export async function getStaticProps({
 }
 
 export async function getStaticPaths() {
-  const pages = await builder.getAll("page", {
+  const pages = await builder.getAll('page', {
     options: { noTargeting: true },
-    omit: "data.blocks",
+    omit: 'data.blocks',
   });
 
   return {
-    paths: pages.map((page) => `${page.data?.url}`),
-    fallback: true,
+    paths: pages.map(page => `${page.data?.url}`),
+    fallback: 'blocking',
   };
 }
 
-export default function Page({
-  page,
-}: InferGetStaticPropsType<typeof getStaticProps>) {
+export default function Page({ page }: InferGetStaticPropsType<typeof getStaticProps>) {
   const router = useRouter();
   if (router.isFallback) {
     return <h1>Loading...</h1>;
@@ -63,9 +59,6 @@ export default function Page({
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
-      <div>
-
-      </div>
       <BuilderComponent model="page" content={page} />
     </>
   );


### PR DESCRIPTION
- remove an empty div causing the visual editor to appear broken
- always default to `fallback: 'blocking'` so pages don't look broken while loading