### PR TITLE
fix editor options set in prod

### DIFF
--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -738,30 +738,13 @@ export class Builder {
   static settings: Settings = {};
   static settingsChange = new BehaviorSubject<Settings>({});
 
-  static set(settings: Settings) {
-    if (Builder.isBrowser) {
-      // TODO: merge
-      Object.assign(this.settings, settings);
-      const message = {
-        type: 'builder.settingsChange',
-        data: this.settings,
-      };
-      parent.postMessage(message, '*');
-    }
-    this.settingsChange.next({...this.settings});
-  }
-
-  // TODO: Check if editor options in prod is fixed
-  static setSettings(settings: Settings): void {
-    if (Builder.isBrowser) {
-      Object.assign(this.settings, settings);
-      const message = {
-        type: 'builder.settingsChange',
-       data: this.settings,
-      };
-      parent.postMessage(message, '*');
-    }
-    this.settingsChange.next({...this.settings});
+  /**
+   * @deprecated
+   *
+   * Use Builder.register('editor.settings', {}) instead.
+   */
+  static set(settings: Settings): void {
+    Builder.register('editor.settings', settings);
   }
 
   static import(packageName: string) {

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -748,7 +748,20 @@ export class Builder {
       };
       parent.postMessage(message, '*');
     }
-    this.settingsChange.next(this.settings);
+    this.settingsChange.next({...this.settings});
+  }
+
+  // TODO: Check if editor options in prod is fixed
+  static setSettings(settings: Settings): void {
+    if (Builder.isBrowser) {
+      Object.assign(this.settings, settings);
+      const message = {
+        type: 'builder.settingsChange',
+       data: this.settings,
+      };
+      parent.postMessage(message, '*');
+    }
+    this.settingsChange.next({...this.settings});
   }
 
   static import(packageName: string) {


### PR DESCRIPTION
## Description

Builder.set() seems to be setting editor options correctly in development but they are lost in production. I’ve tested this with the customInsertMenu and hideABTab flags using v1.1.47 of the react sdk. appState.designerState.editorOptions returns true for both fields in development but is undefined in production. 
