### PR TITLE
Use the "Required" attribute

### DIFF
--- a/packages/react/src/blocks/forms/TextArea.tsx
+++ b/packages/react/src/blocks/forms/TextArea.tsx
@@ -7,6 +7,7 @@ export interface FormTextAreaProps {
   value?: string;
   defaultValue?: string;
   placeholder?: string;
+  required?: boolean;
 }
 
 class TextAreaComponent extends React.Component<FormTextAreaProps> {
@@ -17,6 +18,7 @@ class TextAreaComponent extends React.Component<FormTextAreaProps> {
         name={this.props.name}
         value={this.props.value}
         defaultValue={this.props.defaultValue}
+        {if (this.props.required) 'required'}
         {...this.props.attributes}
       />
     );

--- a/packages/react/src/blocks/forms/TextArea.tsx
+++ b/packages/react/src/blocks/forms/TextArea.tsx
@@ -18,7 +18,7 @@ class TextAreaComponent extends React.Component<FormTextAreaProps> {
         name={this.props.name}
         value={this.props.value}
         defaultValue={this.props.defaultValue}
-        {...(this.props.required ? { required: "required" } : {})}
+        {...(this.props.required ? { required: 'required' } : {})}
         {...this.props.attributes}
       />
     );

--- a/packages/react/src/blocks/forms/TextArea.tsx
+++ b/packages/react/src/blocks/forms/TextArea.tsx
@@ -18,7 +18,7 @@ class TextAreaComponent extends React.Component<FormTextAreaProps> {
         name={this.props.name}
         value={this.props.value}
         defaultValue={this.props.defaultValue}
-        {if (this.props.required) 'required'}
+        {...( this.props.required ? { required: 'required' } : {} )}
         {...this.props.attributes}
       />
     );

--- a/packages/react/src/blocks/forms/TextArea.tsx
+++ b/packages/react/src/blocks/forms/TextArea.tsx
@@ -18,7 +18,7 @@ class TextAreaComponent extends React.Component<FormTextAreaProps> {
         name={this.props.name}
         value={this.props.value}
         defaultValue={this.props.defaultValue}
-        {...( this.props.required ? { required: 'required' } : {} )}
+        {...(this.props.required ? { required: "required" } : {})}
         {...this.props.attributes}
       />
     );


### PR DESCRIPTION
User reported error. Textarea was not preventing empty submission when set as Required in inputs. This was because the value was not being used in the render() method for the component.