### PR TITLE
corrected typo

### DIFF
--- a/packages/core/docs/interfaces/Input.md
+++ b/packages/core/docs/interfaces/Input.md
@@ -120,7 +120,7 @@ Additional text to render in the UI to give guidance on how to use this
 **`example`**
 ```js
 helperText: 'Be sure to use a proper URL, starting with "https://"'
-111
+```
 
 #### Defined in
 


### PR DESCRIPTION
Closing backticks of fenced code block were missing (instead "111"), so rest of markdown file has unintentionally been placed inside code block. which caused markdown layout to break.

## Description

Add a short description of what changes you made, why you made them, and any other context that you think might be helpful for someone to better understand what is contained in this pull request. This sort of information is useful for people reviewing the code, as well as anyone from the future trying to understand why changes were made or why a bug started happening.

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
