### PR TITLE
[sdks/svelte] Add homepage and repository information

### DIFF
--- a/packages/sdks/output/svelte/package.json
+++ b/packages/sdks/output/svelte/package.json
@@ -6,6 +6,12 @@
   "files": [
     "src"
   ],
+  "homepage": "https://github.com/BuilderIO/builder/tree/main/packages/sdks/output/svelte#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BuilderIO/builder.git",
+    "directory": "packages/sdks/output/svelte"
+  },
   "main": "./src/index.js",
   "module": "./src/index.js",
   "svelte": "./src/index.js",


### PR DESCRIPTION
This is helpful when viewing through package managers like this page https://www.npmjs.com/package/@builder.io/sdk-svelte
