### PR TITLE
feat(cli): refinements for the Next.js Integration CLI

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/cli",
-  "version": "1.2.1-3",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/cli",
-  "version": "1.2.0",
+  "version": "1.2.1-3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/cli",
-  "version": "1.2.1-3",
+  "version": "1.2.1",
   "description": "Official Builder.io CLI",
   "author": "Steve Sewell <steve@builder.io>",
   "keywords": [
@@ -25,6 +25,7 @@
     "bundle": "npm run build && pkg . --out-dir ./exec/",
     "copy:templates": "cpy --flat ./src/templates/nextjs/ ./dist/templates/nextjs",
     "release:dev": "npm run build && npm version prerelease --no-git-tag-version && npm publish --tag dev",
+    "release:patch": "npm run build && npm version patch --no-git-tag-version && npm publish",
     "release:minor": "npm run build && npm version minor --no-git-tag-version && npm publish"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/cli",
-  "version": "1.2.0",
+  "version": "1.2.1-3",
   "description": "Official Builder.io CLI",
   "author": "Steve Sewell <steve@builder.io>",
   "keywords": [

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -34,6 +34,7 @@ program
   .command('integrate')
   .description('integrate Builder.io with an existing codebase, currently supports Next.js')
   .option('-d,--debug', 'print debugging information')
+  .option('--skip-install', 'skip installing the @builder.io/react sdk')
   .option('-s,--stack <stack>', 'currently supports nextjs', 'nextjs')
   .option('-m,--model <model>', 'name of the model you want to integrate')
   .option('-a,--apiKey <apiKey>', 'you can find your apiKey on builder.io/account/settings')

--- a/packages/cli/src/templates/nextjs/[...page].jsx
+++ b/packages/cli/src/templates/nextjs/[...page].jsx
@@ -1,7 +1,8 @@
 import { useRouter } from 'next/router';
-import { BuilderComponent, builder, useIsPreviewing, Builder } from '@builder.io/react';
 import DefaultErrorPage from 'next/error';
 import Head from 'next/head';
+import React from 'react';
+import { BuilderComponent, builder, useIsPreviewing, Builder } from '@builder.io/react';
 
 /*
   Initialize the Builder SDK with your organization's API Key

--- a/packages/cli/src/templates/nextjs/[...page].tsx
+++ b/packages/cli/src/templates/nextjs/[...page].tsx
@@ -1,7 +1,8 @@
 import { useRouter } from 'next/router';
-import { BuilderComponent, builder, useIsPreviewing, Builder } from '@builder.io/react';
 import DefaultErrorPage from 'next/error';
 import Head from 'next/head';
+import React from 'react';
+import { BuilderComponent, builder, useIsPreviewing, Builder } from '@builder.io/react';
 
 /*
   Initialize the Builder SDK with your organization's API Key


### PR DESCRIPTION
• updates the success message to call out running the dev server
• cleans up the feedback messages if you hit an error
• adds a --noInstall message to make testing faster
• import React to support fragments
• don't open content url, just log it to the console
• add support for src/pages directory structure
