### PR TITLE
fix(sdks): mobile and tablet styles

### DIFF
--- a/packages/sdks/src/components/render-block/block-styles.lite.tsx
+++ b/packages/sdks/src/components/render-block/block-styles.lite.tsx
@@ -4,6 +4,8 @@ import { getProcessedBlock } from '../../functions/get-processed-block.js';
 import { BuilderBlock } from '../../types/builder-block.js';
 import RenderInlinedStyles from '../render-inlined-styles.lite';
 import { Show, useContext, useStore } from '@builder.io/mitosis';
+import { convertStyleMaptoCSS } from '../../helpers/css.js';
+import { getMaxWidthQueryForSize } from '../../constants/device-sizes.js';
 
 export type BlockStylesProps = {
   block: BuilderBlock;
@@ -20,31 +22,35 @@ export default function BlockStyles(props: BlockStylesProps) {
         context: builderContext.context,
       });
     },
-    camelToKebabCase(string: string) {
-      return string
-        .replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2')
-        .toLowerCase();
-    },
 
     get css(): string {
-      // TODO: media queries
-      const styleObject = state.useBlock.responsiveStyles?.large;
-      if (!styleObject) {
-        return '';
-      }
+      const styles = state.useBlock.responsiveStyles;
 
-      let str = `.${state.useBlock.id} {`;
+      const largeStyles = styles?.large;
+      const mediumStyles = styles?.medium;
+      const smallStyles = styles?.small;
 
-      for (const key in styleObject) {
-        const value = styleObject[key];
-        if (typeof value === 'string') {
-          str += `${state.camelToKebabCase(key)}: ${value};`;
+      return `
+        ${
+          largeStyles
+            ? `.${state.useBlock.id} {${convertStyleMaptoCSS(largeStyles)}}`
+            : ''
         }
-      }
-
-      str += '}';
-
-      return str;
+        ${
+          mediumStyles
+            ? `${getMaxWidthQueryForSize('medium')} {
+              .${state.useBlock.id} {${convertStyleMaptoCSS(mediumStyles)}}
+            }`
+            : ''
+        }
+        ${
+          smallStyles
+            ? `${getMaxWidthQueryForSize('small')} {
+              .${state.useBlock.id} {${convertStyleMaptoCSS(smallStyles)}}
+            }`
+            : ''
+        }
+      }`;
     },
   });
   return (

--- a/packages/sdks/src/constants/device-sizes.ts
+++ b/packages/sdks/src/constants/device-sizes.ts
@@ -1,12 +1,12 @@
-export type Size = 'large' | 'medium' | 'small' | 'xsmall';
-export const sizeNames: Size[] = ['xsmall', 'small', 'medium', 'large'];
+export type SizeName = 'large' | 'medium' | 'small';
 
-export const sizes = {
-  xsmall: {
-    min: 0,
-    default: 0,
-    max: 0,
-  },
+interface Size {
+  min: number;
+  default: number;
+  max: number;
+}
+
+const SIZES: Record<SizeName, Size> = {
   small: {
     min: 320,
     default: 321,
@@ -22,16 +22,7 @@ export const sizes = {
     default: 991,
     max: 1200,
   },
-  getWidthForSize(size: Size) {
-    return this[size].default;
-  },
-  getSizeForWidth(width: number) {
-    for (const size of sizeNames) {
-      const value = this[size];
-      if (width <= value.max) {
-        return size;
-      }
-    }
-    return 'large';
-  },
 };
+
+export const getMaxWidthQueryForSize = (size: SizeName) =>
+  `@media (max-width: ${SIZES[size].max}px)`;

--- a/packages/sdks/src/functions/camel-to-kebab-case.ts
+++ b/packages/sdks/src/functions/camel-to-kebab-case.ts
@@ -1,0 +1,2 @@
+export const camelToKebabCase = (string: string) =>
+  string.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase();

--- a/packages/sdks/src/functions/get-block-styles.ts
+++ b/packages/sdks/src/functions/get-block-styles.ts
@@ -1,19 +1,17 @@
-import { sizes } from '../constants/device-sizes.js';
+import { getMaxWidthQueryForSize } from '../constants/device-sizes.js';
 import { BuilderBlock } from '../types/builder-block.js';
 
 export function getBlockStyles(block: BuilderBlock) {
-  const styles: any = {
+  const styles = {
     ...block.responsiveStyles?.large,
     ...(block as any).styles,
   };
 
   if (block.responsiveStyles?.medium) {
-    styles[`@media (max-width: ${sizes.medium})`] =
-      block.responsiveStyles?.medium;
+    styles[getMaxWidthQueryForSize('medium')] = block.responsiveStyles?.medium;
   }
   if (block.responsiveStyles?.small) {
-    styles[`@media (max-width: ${sizes.small})`] =
-      block.responsiveStyles?.small;
+    styles[getMaxWidthQueryForSize('small')] = block.responsiveStyles?.small;
   }
 
   return styles;

--- a/packages/sdks/src/helpers/css.ts
+++ b/packages/sdks/src/helpers/css.ts
@@ -1,0 +1,13 @@
+import { camelToKebabCase } from '../functions/camel-to-kebab-case';
+
+export const convertStyleMaptoCSS = (
+  style: Partial<CSSStyleDeclaration>
+): string => {
+  const cssProps = Object.entries(style).map(([key, value]) => {
+    if (typeof value === 'string') {
+      return `${camelToKebabCase(key)}: ${value};`;
+    }
+  });
+
+  return cssProps.join('\n');
+};


### PR DESCRIPTION
## Description

- we were missing mobile/tablet styles in Vue & Svelte SDKs
- we were inaccurately setting the max-width conditions for other SDKs