### PR TITLE
improve withBuilder HOC types

### DIFF
--- a/packages/react/src/decorators/builder-block.decorator.ts
+++ b/packages/react/src/decorators/builder-block.decorator.ts
@@ -1,9 +1,10 @@
-import { Builder, Component } from '@builder.io/sdk';
+import { Builder, Class, Component } from '@builder.io/sdk';
+import React from 'react';
 
 interface ReactComponent extends Component {}
 
-export function BuilderBlock(options: ReactComponent) {
+export function BuilderBlock<P extends object>(options: ReactComponent) {
   options.type = 'react';
 
-  return Builder.Component(options);
+  return Builder.Component(options) as (component: React.ComponentType<P>) => Class;
 }

--- a/packages/react/src/functions/with-builder.ts
+++ b/packages/react/src/functions/with-builder.ts
@@ -1,7 +1,8 @@
+import React from 'react';
 import { Component } from '@builder.io/sdk';
 import { BuilderBlock } from '../decorators/builder-block.decorator';
 
-export function withBuilder(component: Function, options: Component) {
-  BuilderBlock(options)(component as any);
+export function withBuilder<P extends object>(component: React.ComponentType<P>, options: Component) {
+  BuilderBlock<P>(options)(component);
   return component;
 }


### PR DESCRIPTION
## Description
Hey Builder Team,

This PR adds improved TS definitions to the `withBuilder` HOC. Before the change, the function returned from `withBuilder` had the type `Function`. Now, the function returned matched the type of the passed component. If the component is `FC<Props>`, the returned function is `React.ComponentType<Props>`

Thanks!
