### PR TITLE
SDKs: Video: do not pass false attributes

### DIFF
--- a/packages/sdks/src/blocks/video/video.lite.tsx
+++ b/packages/sdks/src/blocks/video/video.lite.tsx
@@ -1,3 +1,5 @@
+import { useStore } from '@builder.io/mitosis';
+
 export interface VideoProps {
   attributes?: any;
   video?: string;
@@ -25,9 +27,21 @@ export interface VideoProps {
 }
 
 export default function Video(props: VideoProps) {
+  const state = useStore({
+    get videoProps() {
+      return {
+        ...(props.autoPlay === true ? { autoPlay: true } : {}),
+        ...(props.muted === true ? { muted: true } : {}),
+        ...(props.controls === true ? { controls: true } : {}),
+        ...(props.loop === true ? { loop: true } : {}),
+        ...(props.playsInline === true ? { playsInline: true } : {}),
+      };
+    },
+  });
   return (
     <video
       {...props.attributes}
+      {...state.videoProps}
       style={{
         width: '100%',
         height: '100%',
@@ -38,13 +52,8 @@ export default function Video(props: VideoProps) {
         // not have the video overflow
         borderRadius: 1,
       }}
-      preload="none"
       src={props.video || 'no-src'}
       poster={props.posterImage}
-      autoPlay={props.autoPlay}
-      muted={props.muted}
-      controls={props.controls}
-      loop={props.loop}
     />
   );
 }


### PR DESCRIPTION
## Description

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-controls

> To disable video autoplay, autoplay="false" will not work; the video will autoplay if the attribute is there in the <video> tag at all. To remove autoplay, the attribute needs to be removed altogether.

