### PR TITLE
match breakpoints to official breakpoints

### DIFF
--- a/examples/react-design-system/src/pages/HomepageFullHeadless.jsx
+++ b/examples/react-design-system/src/pages/HomepageFullHeadless.jsx
@@ -320,7 +320,7 @@ const Div12 = styled.div`
 
 const Div13 = styled.div`
   display: flex;
-  @media (max-width: 999px) {
+  @media (max-width: 991px) {
     flex-direction: column;
     align-items: stretch;
   }
@@ -332,7 +332,7 @@ const Div14 = styled.div`
   line-height: normal;
   width: calc(33.333333333333336% - 13.333333333333334px);
   margin-left: 0px;
-  @media (max-width: 999px) {
+  @media (max-width: 991px) {
     width: 100%;
   }
 `;
@@ -406,7 +406,7 @@ const Div19 = styled.div`
   line-height: normal;
   width: calc(33.333333333333336% - 13.333333333333334px);
   margin-left: 20px;
-  @media (max-width: 999px) {
+  @media (max-width: 991px) {
     width: 100%;
   }
 `;
@@ -480,7 +480,7 @@ const Div24 = styled.div`
   line-height: normal;
   width: calc(33.333333333333336% - 13.333333333333334px);
   margin-left: 20px;
-  @media (max-width: 999px) {
+  @media (max-width: 991px) {
     width: 100%;
   }
 `;

--- a/packages/email/src/components/Block.tsx
+++ b/packages/email/src/components/Block.tsx
@@ -24,7 +24,7 @@ const sizes = {
   medium: {
     min: 640,
     default: 641,
-    max: 999,
+    max: 991,
   },
   large: {
     min: 1000,

--- a/packages/email/src/components/Columns.tsx
+++ b/packages/email/src/components/Columns.tsx
@@ -142,7 +142,7 @@ export class Columns extends React.Component<ColumnsProps> {
           <style>
             {`
           @media only screen and (max-width:${
-            this.props.stackColumnsAt === 'mobile' ? 639 : 999
+            this.props.stackColumnsAt === 'mobile' ? 639 : 991
           }px) {
             .${this.props.builderBlock.id}-separator-td {
               display: none !important;

--- a/packages/react/src/blocks/Columns.tsx
+++ b/packages/react/src/blocks/Columns.tsx
@@ -94,7 +94,7 @@ class ColumnsComponent extends React.Component<any> {
           css={{
             display: 'flex',
             ...(this.props.stackColumnsAt !== 'never' && {
-              [`@media (max-width: ${this.props.stackColumnsAt !== 'tablet' ? 639 : 999}px)`]: {
+              [`@media (max-width: ${this.props.stackColumnsAt !== 'tablet' ? 639 : 991}px)`]: {
                 flexDirection: this.props.reverseColumnsWhenStacked ? 'column-reverse' : 'column',
                 alignItems: 'stretch',
               },
@@ -125,7 +125,7 @@ class ColumnsComponent extends React.Component<any> {
                     marginLeft: index === 0 ? 0 : gutterSize,
                     ...(this.props.stackColumnsAt !== 'never' && {
                       [`@media (max-width: ${
-                        this.props.stackColumnsAt !== 'tablet' ? 639 : 999
+                        this.props.stackColumnsAt !== 'tablet' ? 639 : 991
                       }px)`]: {
                         width: '100%',
                         marginLeft: 0,

--- a/packages/react/src/blocks/Image.tsx
+++ b/packages/react/src/blocks/Image.tsx
@@ -129,7 +129,7 @@ export const getSizes = (sizes: string, block: BuilderElement) => {
 
     if (block.responsiveStyles?.medium?.width?.match(unitRegex)) {
       hasSmallOrMediumSize = true;
-      const mediaQuery = '(max-width: 999px)';
+      const mediaQuery = '(max-width: 991px)';
       const widthAndQuery = `${mediaQuery} ${block.responsiveStyles.medium.width.replace(
         '%',
         'vw'

--- a/packages/react/test/__snapshots__/image.test.tsx.snap
+++ b/packages/react/test/__snapshots__/image.test.tsx.snap
@@ -161,7 +161,7 @@ exports[`Image with responsive styles 1`] = `
               loading="lazy"
               onLoad={[Function]}
               role="presentation"
-              sizes="(max-width: 999px) 100vw, 345px"
+              sizes="(max-width: 991px) 100vw, 345px"
               src="https://cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash.jpg?v=1592506853"
               srcSet="//cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_100x100.jpg?v=1592506853 100w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_200x200.jpg?v=1592506853 200w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_400x400.jpg?v=1592506853 400w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_800x800.jpg?v=1592506853 800w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_1200x1200.jpg?v=1592506853 1200w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_1600x1600.jpg?v=1592506853 1600w, //cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash_2000x2000.jpg?v=1592506853 2000w, https://cdn.shopify.com/s/files/1/0374/6457/2041/products/valerie-elash-o1Ic6JdypmA-unsplash.jpg?v=1592506853"
             />

--- a/packages/sdks/src/blocks/columns/columns.lite.tsx
+++ b/packages/sdks/src/blocks/columns/columns.lite.tsx
@@ -80,7 +80,7 @@ export default function Columns(props: ColumnProps) {
         display: 'flex',
         alignItems: 'stretch',
         lineHeight: 'normal',
-        '@media (max-width: 999px)': {
+        '@media (max-width: 991px)': {
           flexDirection: 'var(--flex-dir-tablet)',
         },
         '@media (max-width: 639px)': {
@@ -100,7 +100,7 @@ export default function Columns(props: ColumnProps) {
             class="builder-column"
             css={{
               flexGrow: '1',
-              '@media (max-width: 999px)': {
+              '@media (max-width: 991px)': {
                 width: 'var(--column-width-tablet) !important',
                 marginLeft: 'var(--column-margin-left-tablet) !important',
               },


### PR DESCRIPTION
## Description

Fixes #1027

**Describe the bug**
As reported, some default Builder components' responsive breakpoints are not in sync with officials breakpoints. This includes Block, Image, and Column. Their large breakpoints are 999px when they should be 991px according to @steve8708 on the [Builder forms](https://forum.builder.io/t/builder-io-breakpoints/321). 

This causes problems between 991px and 999px. 

**To Reproduce**
Create a Column component and switch to the Tablet View. You can now see the breakpoint is set to 999px and not 991px. 

<img width="191" alt="image" src="https://user-images.githubusercontent.com/33156025/182939574-3eb48c59-5303-4740-b043-88306d4225d1.png">

**Expected behavior**
Builder Component responsive breakpoints should be:

- Mobile: 0-639px
- Tablet: 640px-991px
- Desktop: 992px+
