### PR TITLE
Add support for Shopify's Hydrogen/Oxygen

### DIFF
--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -15,7 +15,7 @@ import serverOnlyRequire from './functions/server-only-require.function';
 import { getTopLevelDomain } from './functions/get-top-level-domain';
 import { BuilderContent } from './types/content';
 import { uuid } from './functions/uuid';
-import { parse as urlParse } from 'url';
+import { parse as urlParse } from './url';
 
 // Do not change this to a require! It throws runtime errors - rollup
 // will preserve the `require` and throw runtime errors
@@ -97,7 +97,7 @@ const urlParser = {
 };
 
 const parse: (url: string) => UrlLike = isReactNative
-  ? () => (emptyUrl())
+  ? () => emptyUrl()
   : typeof window === 'object'
   ? urlParser.parse
   : urlParse;

--- a/packages/core/src/functions/fetch.function.ts
+++ b/packages/core/src/functions/fetch.function.ts
@@ -99,7 +99,7 @@ if (globalThis.fetch) {
 
 // If fetch is not defined, in a Node.js environment, use node-fetch.
 if (typeof window === 'undefined') {
-  fetch ??=serverOnlyRequire('node-fetch')
+  fetch ??= serverOnlyRequire('node-fetch');
 }
 
 // Otherwise, use tiny-fetch.

--- a/packages/core/src/functions/fetch.function.ts
+++ b/packages/core/src/functions/fetch.function.ts
@@ -6,7 +6,7 @@ export interface SimplifiedFetchOptions {
   headers?: { [key: string]: string };
   method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
   credentials?: 'include';
-  mode?: string;
+  mode?: RequestMode;
 }
 
 export interface SimpleFetchResponse {
@@ -90,11 +90,17 @@ export function tinyFetch(url: string, options: SimplifiedFetchOptions = {}) {
   });
 }
 
-export const fetch: typeof tinyFetch /* | typeof window.fetch */ =
-  typeof global === 'object' && typeof (global as any).fetch === 'function'
-    ? (global as any).fetch
-    : typeof window === 'undefined'
-    ? serverOnlyRequire('node-fetch')
-    : typeof window.fetch !== 'undefined'
-    ? window.fetch
-    : tinyFetch;
+export let fetch: typeof tinyFetch;
+
+// If fetch is defined, in the browser, via polyfill, or in a Cloudflare worker, use it.
+if (globalThis.fetch) {
+  fetch = globalThis.fetch as any;
+}
+
+// If fetch is not defined, in a Node.js environment, use node-fetch.
+if (typeof window === 'undefined') {
+  fetch ??=serverOnlyRequire('node-fetch')
+}
+
+// Otherwise, use tiny-fetch.
+fetch ??= tinyFetch;

--- a/packages/core/src/functions/to-error.ts
+++ b/packages/core/src/functions/to-error.ts
@@ -1,0 +1,16 @@
+/**
+ * Safe conversion to error type. Intended to be used in catch blocks where the
+ *  value is not guaranteed to be an error.
+ *
+ *  @example
+ *  try {
+ *    throw new Error('Something went wrong')
+ *  }
+ *  catch (err: unknown) {
+ *    const error: Error = toError(err)
+ *  }
+ */
+export function toError(err: unknown): Error {
+  if (err instanceof Error) return err;
+  return new Error(String(err));
+}

--- a/packages/core/src/url.test.ts
+++ b/packages/core/src/url.test.ts
@@ -1,0 +1,82 @@
+import { parse } from './url';
+import { parse as oldParse } from 'url';
+
+describe('.parse', () => {
+  test('can parse a full url', async () => {
+    expect(parse('http://example.com/foo/bar?q=1')).toEqual({
+      auth: null,
+      hash: null,
+      host: 'example.com',
+      hostname: 'example.com',
+      href: 'http://example.com/foo/bar?q=1',
+      path: '/foo/bar?q=1',
+      pathname: '/foo/bar',
+      port: null,
+      protocol: 'http:',
+      query: 'q=1',
+      search: '?q=1',
+      slashes: true,
+    });
+  });
+
+  test('can parse a path', async () => {
+    expect(parse('/foo/bar?q=1')).toEqual({
+      auth: null,
+      hash: null,
+      host: null,
+      hostname: null,
+      href: '/foo/bar?q=1',
+      path: '/foo/bar?q=1',
+      pathname: '/foo/bar',
+      port: null,
+      protocol: null,
+      query: 'q=1',
+      search: '?q=1',
+      slashes: null,
+    });
+  });
+
+  test('can parse a url that is missing slashes', async () => {
+    expect(parse('http:example.com/foo/bar?q=1')).toEqual({
+      auth: null,
+      hash: null,
+      host: 'example.com',
+      hostname: 'example.com',
+      href: 'http://example.com/foo/bar?q=1',
+      path: '/foo/bar?q=1',
+      pathname: '/foo/bar',
+      port: null,
+      protocol: 'http:',
+      query: 'q=1',
+      search: '?q=1',
+      slashes: false,
+    });
+  });
+
+  describe('behaves the same as the old query function', () => {
+    describe.each([
+      { url: '/foo/bar?a=1&b=2' },
+      { url: 'http://example.com/foo/bar?a=1&b=2' },
+    ])('with url `$url`', ({ url }) => {
+      const expected = Object.assign({}, oldParse(url));
+      const actual = parse(url);
+
+      test.each([
+        { prop: 'query' },
+        { prop: 'port' },
+        { prop: 'auth' },
+        { prop: 'hash' },
+        { prop: 'host' },
+        { prop: 'hostname' },
+        { prop: 'href' },
+        { prop: 'path' },
+        { prop: 'pathname' },
+        { prop: 'protocol' },
+        { prop: 'search' },
+        { prop: 'slashes' },
+      ] as const)('`$prop` is the same', async ({ prop }) => {
+        expect(actual[prop]).toEqual(expected[prop]);
+      });
+    });
+  });
+});

--- a/packages/core/src/url.test.ts
+++ b/packages/core/src/url.test.ts
@@ -54,29 +54,29 @@ describe('.parse', () => {
   });
 
   describe('behaves the same as the old query function', () => {
-    describe.each([
-      { url: '/foo/bar?a=1&b=2' },
-      { url: 'http://example.com/foo/bar?a=1&b=2' },
-    ])('with url `$url`', ({ url }) => {
-      const expected = Object.assign({}, oldParse(url));
-      const actual = parse(url);
+    describe.each([{ url: '/foo/bar?a=1&b=2' }, { url: 'http://example.com/foo/bar?a=1&b=2' }])(
+      'with url `$url`',
+      ({ url }) => {
+        const expected = Object.assign({}, oldParse(url));
+        const actual = parse(url);
 
-      test.each([
-        { prop: 'query' },
-        { prop: 'port' },
-        { prop: 'auth' },
-        { prop: 'hash' },
-        { prop: 'host' },
-        { prop: 'hostname' },
-        { prop: 'href' },
-        { prop: 'path' },
-        { prop: 'pathname' },
-        { prop: 'protocol' },
-        { prop: 'search' },
-        { prop: 'slashes' },
-      ] as const)('`$prop` is the same', async ({ prop }) => {
-        expect(actual[prop]).toEqual(expected[prop]);
-      });
-    });
+        test.each([
+          { prop: 'query' },
+          { prop: 'port' },
+          { prop: 'auth' },
+          { prop: 'hash' },
+          { prop: 'host' },
+          { prop: 'hostname' },
+          { prop: 'href' },
+          { prop: 'path' },
+          { prop: 'pathname' },
+          { prop: 'protocol' },
+          { prop: 'search' },
+          { prop: 'slashes' },
+        ] as const)('`$prop` is the same', async ({ prop }) => {
+          expect(actual[prop]).toEqual(expected[prop]);
+        });
+      }
+    );
   });
 });

--- a/packages/core/src/url.ts
+++ b/packages/core/src/url.ts
@@ -1,0 +1,56 @@
+import { UrlWithStringQuery } from 'url';
+
+type Fix<T> = { [P in keyof T]: T[P] | null };
+
+// It seems that the types for UrlWithStringQuery are not correct.
+export type UrlLike = Fix<UrlWithStringQuery>;
+
+export function emptyUrl(): UrlLike {
+  return {
+    query: null,
+    port: null,
+    auth: null,
+    hash: null,
+    host: null,
+    hostname: null,
+    href: null,
+    path: null,
+    pathname: null,
+    protocol: null,
+    search: null,
+    slashes: null,
+  };
+}
+
+// Replacement for `url.parse` using `URL` global object that works with relative paths.
+// Assumptions: this function operates in a NodeJS environment.
+export function parse(url: string): UrlLike {
+  const out: UrlLike = emptyUrl();
+
+  let u;
+  const pathOnly = url === '' || url[0] === '/';
+
+  if (pathOnly) {
+    u = new URL(url, 'http://0.0.0.0/');
+    out.href = u.href;
+    out.href = out.href.slice(14); // remove 'http://0.0.0.0/'
+  } else {
+    u = new URL(url);
+    out.href = u.href;
+    out.port = u.port === '' ? null : u.port;
+    out.hash = u.hash === '' ? null : u.hash;
+    out.host = u.host;
+    out.hostname = u.hostname;
+    out.href = u.href;
+    out.pathname = u.pathname;
+    out.protocol = u.protocol;
+    out.slashes = url[u.protocol.length] === '/'; // check if the mimetype is proceeded by a slash
+  }
+
+  out.search = u.search;
+  out.query = u.search.slice(1); // remove '?'
+  out.path = `${u.pathname}${u.search}`;
+  out.pathname = u.pathname;
+
+  return out;
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es5",
     "outDir": "dist",
     "module": "esnext",
+    "composite": true,
     "strict": true,
     "sourceMap": true,
     "skipLibCheck": true,
@@ -10,10 +11,21 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "declarationDir": "dist",
-    "lib": ["dom", "es5", "es2015.promise"],
+    "lib": [
+      "dom",
+      "es5",
+      "es2015.promise"
+    ],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "typeRoots": ["./node_modules/@types"]
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
   },
-  "include": ["./index.ts", "./src/**/*.ts", "./types.d.ts"]
+  "include": [
+    "./package.json",
+    "./index.ts",
+    "./src/**/*.ts",
+    "./types.d.ts"
+  ]
 }

--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -74,11 +74,11 @@ const size = (thing: object) => Object.keys(thing).length;
 
 function debounce(func: Function, wait: number, immediate = false) {
   let timeout: any;
-  return function(this: any) {
+  return function (this: any) {
     const context = this;
     const args = arguments;
     clearTimeout(timeout);
-    timeout = setTimeout(function() {
+    timeout = setTimeout(function () {
       timeout = null;
       if (!immediate) func.apply(context, args);
     }, wait);
@@ -88,9 +88,9 @@ function debounce(func: Function, wait: number, immediate = false) {
 
 const fontsLoaded = new Set();
 
-let fetch: typeof globalThis['fetch']
+let fetch: typeof globalThis['fetch'];
 if (globalThis.fetch) fetch = globalThis.fetch;
-fetch ??= require('node-fetch')
+fetch ??= require('node-fetch');
 
 const sizeMap = {
   desktop: 'large',
@@ -1034,7 +1034,7 @@ export class BuilderComponent extends React.Component<
                           const useBuilderState = (initialState: any) => {
                             const [, setTick] = React.useState(0);
                             const [state] = React.useState(() =>
-                              onChange(initialState, function() {
+                              onChange(initialState, function () {
                                 setTick(tick => tick + 1);
                               })
                             );
@@ -1345,7 +1345,7 @@ export class BuilderComponent extends React.Component<
           // TODO: allow exports = { } syntax?
           // TODO: do something with reuslt like view - methods, computed, actions, properties, template, etc etc
         } catch (err) {
-          const error = toError(err)
+          const error = toError(err);
           if (Builder.isBrowser) {
             console.warn(
               'Builder custom code error:',
@@ -1409,15 +1409,14 @@ export class BuilderComponent extends React.Component<
                 }
 
                 // TODO: fix this
-                const newSubscription = (this.httpSubscriptionPerKey[
-                  key
-                ] = this.onStateChange.subscribe(() => {
-                  const newUrl = this.evalExpression(url);
-                  if (newUrl !== finalUrl) {
-                    this.handleRequest(key, newUrl);
-                    this.lastHttpRequests[key] = newUrl;
-                  }
-                }));
+                const newSubscription = (this.httpSubscriptionPerKey[key] =
+                  this.onStateChange.subscribe(() => {
+                    const newUrl = this.evalExpression(url);
+                    if (newUrl !== finalUrl) {
+                      this.handleRequest(key, newUrl);
+                      this.lastHttpRequests[key] = newUrl;
+                    }
+                  }));
                 this.subscriptions.add(newSubscription);
               }
             } else {

--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -87,8 +87,9 @@ function debounce(func: Function, wait: number, immediate = false) {
 
 const fontsLoaded = new Set();
 
-// TODO: get fetch from core JS....
-const fetch = Builder.isBrowser ? window.fetch : require('node-fetch');
+let fetch: typeof globalThis['fetch']
+if (globalThis.fetch) fetch = globalThis.fetch;
+fetch ??= require('node-fetch')
 
 const sizeMap = {
   desktop: 'large',

--- a/packages/react/src/functions/safe-dynamic-require.ts
+++ b/packages/react/src/functions/safe-dynamic-require.ts
@@ -2,9 +2,9 @@
 
 import { Builder } from '@builder.io/sdk';
 
-const noop = () => null
+const noop = () => null;
 // Allow us to require things dynamically safe from webpack bundling
 
 export let safeDynamicRequire: typeof require;
-if (typeof globalThis.require === 'function') safeDynamicRequire = eval('require')
+if (typeof globalThis.require === 'function') safeDynamicRequire = eval('require');
 safeDynamicRequire ??= noop as any;

--- a/packages/react/src/functions/safe-dynamic-require.ts
+++ b/packages/react/src/functions/safe-dynamic-require.ts
@@ -2,7 +2,9 @@
 
 import { Builder } from '@builder.io/sdk';
 
+const noop = () => null
 // Allow us to require things dynamically safe from webpack bundling
-export const safeDynamicRequire: typeof require = Builder.isServer
-  ? eval('require')
-  : ((() => null) as any);
+
+export let safeDynamicRequire: typeof require;
+if (typeof globalThis.require === 'function') safeDynamicRequire = eval('require')
+safeDynamicRequire ??= noop as any;

--- a/packages/react/src/to-error.ts
+++ b/packages/react/src/to-error.ts
@@ -1,0 +1,16 @@
+/**
+ * Safe conversion to error type. Intended to be used in catch blocks where the
+ *  value is not guaranteed to be an error.
+ *
+ *  @example
+ *  try {
+ *    throw new Error('Something went wrong')
+ *  }
+ *  catch (err: unknown) {
+ *    const error: Error = toError(err)
+ *  }
+ */
+export function toError(err: unknown): Error {
+  if (err instanceof Error) return err;
+  return new Error(String(err));
+}


### PR DESCRIPTION
## Description

Adds support for Shopify's Hydrogen and Oxygen project.

### Changes:

#### Core
- replace deprecated usage of `require('url').parse` with a solution based on `new URL(...)`, verified that it behaves the same (for the most part) as the old function).
  Does have slightly different behavior for urls that don't have "slashes", for example: "http:example.com" will be parsed as "http://example.com", rather than being left as is.
- fold the definition of `requestUrl` to just use `fetch`. Remove custom fetch polyfill that used `http` and `https`.
- Type fixes for catch blocks where the value of `error` was assumed to be `any`. Values are now coerced to an `Error`.
- Type error fix for `fetch({mode: ...})`
- Fix issue with `fetch` polyfill. Changed to check if `fetch` is defined on `globalThis` to better suppport all environments rather than using global, which is only available in NodeJS.
- Changed to be a composite TS project.

#### React
- Fix issue with `fetch` polyfill. Changed to check if `fetch` is defined on `globalThis` to better suppport all environments rather than using global, which is only available in NodeJS.
- Type fixes for catch blocks where the value of `error` was assumed to be `any`. Values are now coerced to an `Error`.
- Fix issue with `safeDynamicRequire` which caused it to not function in the CloudFlare Worker environment. No longer assumes that `eval` is available but rather checks if `require` is a function, which should only be in NodeJS, and if that's the case it calls `eval('require')`. I don't know if the eval trick is still required to work around webpack, or under what circumstances.

As an aside, in the future we should probably replace all usages of `safeDynamicRequire` with just just dynamic `import(...)`, which should be supported everywhere now - it's at least supported in all LTS versions of NodeJS.