### PR TITLE
use actual buttons for button blocks

### DIFF
--- a/packages/sdks/src/blocks/button/button.lite.tsx
+++ b/packages/sdks/src/blocks/button/button.lite.tsx
@@ -12,7 +12,7 @@ export default function Button(props: ButtonProps) {
     <>
       <Show
         when={props.link}
-        else={<span {...props.attributes}>{props.text}</span>}
+        else={<button css={{ all: 'unset' }} {...props.attributes}>{props.text}</button>}
       >
         <a
           {...props.attributes}

--- a/packages/sdks/src/blocks/button/button.lite.tsx
+++ b/packages/sdks/src/blocks/button/button.lite.tsx
@@ -12,7 +12,11 @@ export default function Button(props: ButtonProps) {
     <>
       <Show
         when={props.link}
-        else={<button css={{ all: 'unset' }} {...props.attributes}>{props.text}</button>}
+        else={
+          <button css={{ all: 'unset' }} {...props.attributes}>
+            {props.text}
+          </button>
+        }
       >
         <a
           {...props.attributes}


### PR DESCRIPTION
this is best for a11y and semantic html, and with `all: unset` we can avoid styling issues from browser default styling

next thing to figure out is how to preserve the outline behavior on hover, ideally default styling would work for that. we could perhaps in the short term just add like `css={{ ':hover': { outline: '1px solid some-color' } }}`

@samijaber does mitosis support :hover in css={{}} currently? 