### PR TITLE
Fix editing `BuilderContent` containing a `BuilderCompoennt`

### DIFF
--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/react",
-  "version": "2.0.3-2",
+  "version": "2.0.3-4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/react",
-      "version": "2.0.3-2",
+      "version": "2.0.3-4",
       "license": "MIT",
       "dependencies": {
         "@builder.io/sdk": "^1.1.27",

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/react",
-  "version": "2.0.3-4",
+  "version": "2.0.3-5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/react",
-      "version": "2.0.3-4",
+      "version": "2.0.3-5",
       "license": "MIT",
       "dependencies": {
         "@builder.io/sdk": "^1.1.27",

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/react",
-  "version": "2.0.3-1",
+  "version": "2.0.3-2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/react",
-      "version": "2.0.3-1",
+      "version": "2.0.3-2",
       "license": "MIT",
       "dependencies": {
         "@builder.io/sdk": "^1.1.27",

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/react",
-  "version": "2.0.3-5",
+  "version": "2.0.3-8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/react",
-      "version": "2.0.3-5",
+      "version": "2.0.3-8",
       "license": "MIT",
       "dependencies": {
         "@builder.io/sdk": "^1.1.27",

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/react",
-  "version": "2.0.2",
+  "version": "2.0.3-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/react",
-      "version": "2.0.2",
+      "version": "2.0.3-1",
       "license": "MIT",
       "dependencies": {
         "@builder.io/sdk": "^1.1.27",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/react",
-  "version": "2.0.3-2",
+  "version": "2.0.3-4",
   "description": "",
   "keywords": [],
   "main": "dist/builder-react.cjs.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/react",
-  "version": "2.0.2",
+  "version": "2.0.3-1",
   "description": "",
   "keywords": [],
   "main": "dist/builder-react.cjs.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/react",
-  "version": "2.0.3-1",
+  "version": "2.0.3-2",
   "description": "",
   "keywords": [],
   "main": "dist/builder-react.cjs.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/react",
-  "version": "2.0.3-4",
+  "version": "2.0.3-5",
   "description": "",
   "keywords": [],
   "main": "dist/builder-react.cjs.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/react",
-  "version": "2.0.3-5",
+  "version": "2.0.3-8",
   "description": "",
   "keywords": [],
   "main": "dist/builder-react.cjs.js",

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -88,6 +88,9 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
     let options = {
       ...(this.props.options || ({} as GetContentOptions)),
     };
+    if (!options.key && this.props.content?.id) {
+      options.key = this.props.content.id;
+    }
     if (this.props.content && !options.initialContent?.length) {
       options.initialContent = [this.props.content];
     }

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -88,7 +88,7 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
     let options = {
       ...(this.props.options || ({} as GetContentOptions)),
     };
-    if (!options.key && this.props.content?.id) {
+    if (!options.key && this.props.content?.id && !Builder.isEditing && !Builder.isPreviewing) {
       options.key = this.props.content.id;
     }
     if (this.props.content && !options.initialContent?.length) {

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -88,7 +88,7 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
     let options = {
       ...(this.props.options || ({} as GetContentOptions)),
     };
-    if (!options.key && this.props.content?.id && !Builder.isEditing) {
+    if (!options.key && this.props.content?.id && !Builder.isEditing && !Builder.isPreviewing) {
       options.key = this.props.content.id;
     }
     if (this.props.content && !options.initialContent?.length) {

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -91,7 +91,11 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
     if (!options.key && this.props.content?.id && !Builder.isEditing && !Builder.isPreviewing) {
       options.key = this.props.content.id;
     }
-    if (this.props.content && !options.initialContent?.length) {
+    if (
+      this.props.content &&
+      !options.initialContent?.length &&
+      (this.props.inline || !Builder.isPreviewing)
+    ) {
       options.initialContent = [this.props.content];
     }
 

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -88,9 +88,6 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
     let options = {
       ...(this.props.options || ({} as GetContentOptions)),
     };
-    if (!options.key && this.props.content?.id) {
-      options.key = this.props.content.id;
-    }
     if (this.props.content && !options.initialContent?.length) {
       options.initialContent = [this.props.content];
     }

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -186,6 +186,7 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
 
   subscribeToContent() {
     if (this.name !== '_inline') {
+      console.log(' here fetching content with ', this.options);
       // TODO:... using targeting...? express.request hmmm
       this.subscriptions.add(
         builder.queueGetContent(this.name, this.options).subscribe(

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -88,7 +88,7 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
     let options = {
       ...(this.props.options || ({} as GetContentOptions)),
     };
-    if (!options.key && this.props.content?.id && !Builder.isEditing && !Builder.isPreviewing) {
+    if (!options.key && this.props.content?.id && !Builder.isEditing) {
       options.key = this.props.content.id;
     }
     if (this.props.content && !options.initialContent?.length) {
@@ -165,7 +165,7 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
     // Temporary to test metrics diving in with bigquery and heatmaps
     // this.builder.autoTrack = true;
     // this.builder.env = 'development';
-    if (!this.props.inline || Builder.isEditing) {
+    if (!this.props.inline || Builder.isEditing || Builder.isPreviewing) {
       this.subscribeToContent();
     } else if (this.props.inline && this.options?.initialContent?.length) {
       const contentData = this.options.initialContent[0];

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -190,7 +190,6 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
 
   subscribeToContent() {
     if (this.name !== '_inline') {
-      console.log(' here fetching content with ', this.options);
       // TODO:... using targeting...? express.request hmmm
       this.subscriptions.add(
         builder.queueGetContent(this.name, this.options).subscribe(


### PR DESCRIPTION
This also fixes previewing with standalone `BuilderContent` , it seems to be busted on latest SDK version