### PR TITLE
Fixes for patch updates

### DIFF
--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/react",
-  "version": "2.0.3",
+  "version": "2.0.4-2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/react",
-      "version": "2.0.3",
+      "version": "2.0.4-2",
       "license": "MIT",
       "dependencies": {
         "@builder.io/sdk": "^1.1.27",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/react",
-  "version": "2.0.3",
+  "version": "2.0.4-2",
   "description": "",
   "keywords": [],
   "main": "dist/builder-react.cjs.js",

--- a/packages/react/src/components/builder-block.component.tsx
+++ b/packages/react/src/components/builder-block.component.tsx
@@ -251,10 +251,6 @@ export class BuilderBlock extends React.Component<
           eval('debugger');
         }
         for (const patch of patches) {
-          // TODO: soehow mark this.block as a new object,
-          // e.g. access it's parent hm. maybe do the listning mutations
-          // on hte parent element not the child (or rather
-          // send the message to the parent)
           applyPatchWithMinimalMutationChain(this.props.block, patch, true);
         }
         this.setState({ updates: this.state.updates + 1 });

--- a/packages/react/src/components/builder-block.component.tsx
+++ b/packages/react/src/components/builder-block.component.tsx
@@ -19,7 +19,6 @@ const kebabCaseToCamelCase = (str = '') =>
   str.replace(/-([a-z])/g, match => match[1].toUpperCase());
 
 const Device = { desktop: 0, tablet: 1, mobile: 2 };
-const blocksMap: Record<string, BuilderElement> = {};
 
 const voidElements = new Set([
   'area',
@@ -136,7 +135,7 @@ export class BuilderBlock extends React.Component<
   }
 
   get block() {
-    return blocksMap[this.props.block.id!] || this.props.block;
+    return this.props.block;
   }
 
   get emotionCss() {
@@ -249,17 +248,15 @@ export class BuilderBlock extends React.Component<
         }
 
         if (location.href.includes('builder.debug=true')) {
-          this.eval('debugger');
+          eval('debugger');
         }
-        let newBlock = { ...this.block };
         for (const patch of patches) {
           // TODO: soehow mark this.block as a new object,
           // e.g. access it's parent hm. maybe do the listning mutations
           // on hte parent element not the child (or rather
           // send the message to the parent)
-          applyPatchWithMinimalMutationChain(newBlock, patch);
+          applyPatchWithMinimalMutationChain(this.props.block, patch, true);
         }
-        blocksMap[this.props.block.id!] = newBlock;
         this.setState({ updates: this.state.updates + 1 });
 
         break;

--- a/packages/react/src/components/builder-blocks.component.tsx
+++ b/packages/react/src/components/builder-blocks.component.tsx
@@ -108,14 +108,16 @@ export class BuilderBlocks extends React.Component<BuilderBlocksProps, BuilderBl
         // TODO: only fi in iframe?
         builder-path={Builder.isIframe ? this.path : undefined}
         builder-parent-id={this.parentId}
-        css={{
-          ...(!this.props.emailMode && {
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'stretch',
-          }),
-          ...this.props.style,
-        } as any}
+        css={
+          {
+            ...(!this.props.emailMode && {
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'stretch',
+            }),
+            ...this.props.style,
+          } as any
+        }
         onClick={() => {
           if (this.noBlocks) {
             this.onClickEmptyBlocks();

--- a/packages/react/src/components/builder-blocks.component.tsx
+++ b/packages/react/src/components/builder-blocks.component.tsx
@@ -115,7 +115,7 @@ export class BuilderBlocks extends React.Component<BuilderBlocksProps, BuilderBl
             alignItems: 'stretch',
           }),
           ...this.props.style,
-        }}
+        } as any}
         onClick={() => {
           if (this.noBlocks) {
             this.onClickEmptyBlocks();

--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -98,7 +98,6 @@ const sizeMap = {
   mobile: 'small',
 };
 
-
 const fetchCache: { [key: string]: any } = {};
 
 export interface BuilderComponentProps {
@@ -1358,22 +1357,22 @@ export class BuilderComponent extends React.Component<
               const builderModelRe = /builder\.io\/api\/v2\/([^\/\?]+)/i;
               const builderModelMatch = url.match(builderModelRe);
               const model = builderModelMatch && builderModelMatch[1];
-                this.handleRequest(key, finalUrl);
-                const currentSubscription = this.httpSubscriptionPerKey[key];
-                if (currentSubscription) {
-                  currentSubscription.unsubscribe();
-                }
+              this.handleRequest(key, finalUrl);
+              const currentSubscription = this.httpSubscriptionPerKey[key];
+              if (currentSubscription) {
+                currentSubscription.unsubscribe();
+              }
 
-                // TODO: fix this
-                const newSubscription = (this.httpSubscriptionPerKey[key] =
-                  this.onStateChange.subscribe(() => {
-                    const newUrl = this.evalExpression(url);
-                    if (newUrl !== finalUrl) {
-                      this.handleRequest(key, newUrl);
-                      this.lastHttpRequests[key] = newUrl;
-                    }
-                  }));
-                this.subscriptions.add(newSubscription);
+              // TODO: fix this
+              const newSubscription = (this.httpSubscriptionPerKey[key] =
+                this.onStateChange.subscribe(() => {
+                  const newUrl = this.evalExpression(url);
+                  if (newUrl !== finalUrl) {
+                    this.handleRequest(key, newUrl);
+                    this.lastHttpRequests[key] = newUrl;
+                  }
+                }));
+              this.subscriptions.add(newSubscription);
             } else {
               this.handleRequest(key, this.evalExpression(url));
             }

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -149,7 +149,7 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
           data: newData,
         });
         if (this.props.contentLoaded) {
-          this.props.contentLoaded(newData.data, this.state.data);
+          this.props.contentLoaded(newData.data, newData);
         }
         break;
       }

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -140,17 +140,17 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
         if (location.href.includes('builder.debug=true')) {
           eval('debugger');
         }
+        let newData = this.state.data as any;
         for (const patch of patches) {
-          applyPatchWithMinimalMutationChain(this.state.data, patch);
+          newData = applyPatchWithMinimalMutationChain(newData, patch, false);
         }
         this.setState({
           updates: this.state.updates + 1,
-          data: this.state.data ? { ...this.state.data } : this.state.data,
+          data: newData,
         });
         if (this.props.contentLoaded) {
-          this.props.contentLoaded(this.state.data?.data, this.state.data);
+          this.props.contentLoaded(newData.data, this.state.data);
         }
-
         break;
       }
     }

--- a/packages/react/src/functions/apply-patch-with-mutation.test.ts
+++ b/packages/react/src/functions/apply-patch-with-mutation.test.ts
@@ -1,0 +1,55 @@
+import { applyPatchWithMinimalMutationChain } from './apply-patch-with-mutation';
+
+describe('applyPatchWithMinimalMutationChain', () => {
+  test('Basic shallow update', () => {
+    const obj = {
+      foo: 'bar',
+    };
+    const patch = {
+      op: 'replace',
+      path: '/foo',
+      value: '60px',
+    } as const;
+    const applied = applyPatchWithMinimalMutationChain(obj, patch);
+    expect(applied.foo).toBe('60px');
+    expect(applied).not.toBe(obj);
+  });
+
+  test('Deep object updates', () => {
+    const obj = {
+      foo: {
+        bar: true,
+      },
+      baz: {},
+    };
+    const patch = {
+      op: 'replace',
+      path: '/foo/bar',
+      value: '60px',
+    } as const;
+    const applied = applyPatchWithMinimalMutationChain(obj, patch);
+    expect(applied.foo.bar).toBe('60px');
+    expect(applied).not.toBe(obj);
+    expect(applied.foo).not.toBe(obj.foo);
+    expect(applied.baz).toBe(obj.baz);
+  });
+
+  test('Deep array updates', () => {
+    const obj = {
+      foo: [{ bar: true }],
+      baz: {},
+    };
+    const patch = {
+      op: 'replace',
+      path: '/foo/0/bar',
+      value: '60px',
+    } as const;
+
+    const applied = applyPatchWithMinimalMutationChain(obj, patch);
+    expect(applied.foo[0].bar).toBe('60px');
+    expect(applied).not.toBe(obj);
+    expect(applied.foo).not.toBe(obj.foo);
+    expect(applied.foo[0]).not.toBe(obj.foo[0]);
+    expect(applied.baz).toBe(obj.baz);
+  });
+});

--- a/packages/react/src/functions/apply-patch-with-mutation.ts
+++ b/packages/react/src/functions/apply-patch-with-mutation.ts
@@ -1,8 +1,8 @@
-export const applyPatchWithMinimalMutationChain = (
-  obj: any,
+export const applyPatchWithMinimalMutationChain = <T extends object>(
+  obj: T,
   patch: { path: string; op: 'add' | 'remove' | 'replace'; value: any },
-  preserveRoot = true
-) => {
+  preserveRoot = false
+): T => {
   if (Object(obj) !== obj) {
     return obj;
   }
@@ -13,7 +13,7 @@ export const applyPatchWithMinimalMutationChain = (
   }
 
   const newObj = preserveRoot ? obj : { ...obj };
-  let objPart = newObj;
+  let objPart = newObj as any;
   for (let i = 0; i < pathArr.length; i++) {
     const isLast = i === pathArr.length - 1;
     const property = pathArr[i];

--- a/packages/react/src/scripts/init-editing.ts
+++ b/packages/react/src/scripts/init-editing.ts
@@ -6,7 +6,7 @@ if (typeof window !== 'undefined') {
       type: 'builder.isReactSdk',
       data: {
         value: true,
-        supportsPatchUpdates: 'v3',
+        supportsPatchUpdates: 'v4',
         priorVersion: version,
       },
     },


### PR DESCRIPTION
The copying of objects had too many issues, so in this latest (and most effective to date) approach, we only patch update primitives, and apply them directly to props - effectively updating the core content tree as needed

This doesn't work when there are child blocks modified in the tree, but works well for primitives

The Builder.io editor has been updated accordingly to only patch primitives, which is the bulk of what needs to be fast too (like updating a style, text, etc)