### PR TITLE
fix(core): TypeError - Fixes type error when using `Builder.registerComponent` with type of `reference` and restricting to specific `model`.

### DIFF
--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -587,6 +587,10 @@ export interface Input {
   showIf?: ((options: Map<string, any>) => boolean) | string;
   /** @hidden */
   copyOnAdd?: boolean;
+  /**
+   * Use optionally with inputs of type `reference`. Restricts the content entry picker to a specific model by name.
+   */
+  model?: string;
 }
 
 /**


### PR DESCRIPTION
## Description

When using a custom component with a `reference` input restricted to a model, as per the docs https://www.builder.io/c/docs/custom-components-input-types, a type error is thrown due to missing Input property.

`
Type '{ name: string; friendlyName: string; helperText: string; type: string; model: string; }' is not assignable to type 'Input'.
 Object literal may only specify known properties, and 'model' does not exist in type 'Input'.ts(2322)
`

## Changes
- Adds `model` property to `Input` interface in Builder Core


