### PR TITLE
Fix: RN SDK % units

### DIFF
--- a/examples/react-native/yarn.lock
+++ b/examples/react-native/yarn.lock
@@ -1487,14 +1487,14 @@ __metadata:
   linkType: hard
 
 "@builder.io/sdk-react-native@npm:latest":
-  version: 0.0.4
-  resolution: "@builder.io/sdk-react-native@npm:0.0.4"
+  version: 0.0.5
+  resolution: "@builder.io/sdk-react-native@npm:0.0.5"
   dependencies:
     react-native-render-html: ^6.3.4
     react-native-video: ^5.1.1
   peerDependencies:
     react-native: ^0.64.3
-  checksum: a116cc00919d07cae0bbdcf27b30e732641ba31687639b55a63836f8ab8b53a334c93ad36ec1f5327c06b836fa3d8472cb9786ff8cc6838caa76519f09e9d32e
+  checksum: 09acd8ef2ca296c81a95f37033c212c6c6ab37b4e61a59f5ace0af99e58b49bc3dfb8b1034490c6bf2601f5aa0d9e491c49a287106a67c39cacb1021a4ab8f29
   languageName: node
   linkType: hard
 

--- a/packages/sdks/output/react-native/package-lock.json
+++ b/packages/sdks/output/react-native/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/sdk-react-native",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/sdk-react-native",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "dependencies": {
         "react-native-render-html": "^6.3.4",
         "react-native-video": "^5.1.1"

--- a/packages/sdks/output/react-native/package.json
+++ b/packages/sdks/output/react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@builder.io/sdk-react-native",
   "description": "Builder.io SDK for React Native",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "src/index.js",
   "scripts": {
     "release:patch": "npm version patch --no-git-tag-version && npm publish --access public",

--- a/packages/sdks/overrides/react-native/src/functions/sanitize-styles.ts
+++ b/packages/sdks/overrides/react-native/src/functions/sanitize-styles.ts
@@ -3,11 +3,20 @@ const displayValues = new Set(['flex', 'none']);
 
 const SHOW_WARNINGS = false;
 
-export const sanitizeBlockStyles = (
-  styles: Record<string, string | number>
-) => {
-  // Style properties like `"20px"` need to be numbers like `20` for react native
-  for (const key in styles) {
+type Styles = Record<string, string | number>;
+
+const normalizeNumber = (value: number): number | undefined => {
+  if (Number.isNaN(value)) {
+    return undefined;
+  } else if (value < 0) {
+    return 0;
+  } else {
+    return value;
+  }
+};
+
+export const sanitizeBlockStyles = (styles: Styles): Styles => {
+  return Object.keys(styles).reduce<Styles>((acc, key): Styles => {
     const propertyValue = styles[key];
 
     if (key === 'display' && !displayValues.has(propertyValue as string)) {
@@ -16,29 +25,36 @@ export const sanitizeBlockStyles = (
           `Style value for key "display" must be "flex" or "none" but had ${propertyValue}`
         );
       }
-      delete styles[key];
+      return acc;
     }
 
-    if (typeof propertyValue === 'string' && propertyValue.match(/^-?\d/)) {
-      const newValue = parseFloat(propertyValue);
-      if (!isNaN(newValue)) {
-        styles[key] = newValue;
-      }
-
-      if (typeof newValue === 'number' && newValue < 0) {
-        styles[key] = 0;
-      }
-    }
     if (
       propertiesThatMustBeNumber.has(key) &&
-      typeof styles[key] !== 'number'
+      typeof propertyValue !== 'number'
     ) {
       if (SHOW_WARNINGS) {
         console.warn(
           `Style key ${key} must be a number, but had value \`${styles[key]}\``
         );
       }
-      delete styles[key];
+      return acc;
     }
-  }
+
+    // Style properties like `"20px"` need to be numbers like `20` for react native
+    if (typeof propertyValue === 'string' && propertyValue.match(/^-?\d/)) {
+      const newValue = parseFloat(propertyValue);
+      const normalizedValue = normalizeNumber(newValue);
+
+      if (normalizedValue) {
+        const valueWithUnits = propertyValue.endsWith('%')
+          ? `${normalizedValue}%`
+          : '';
+        return { ...acc, [key]: valueWithUnits };
+      } else {
+        return acc;
+      }
+    }
+
+    return { ...acc, [key]: propertyValue };
+  }, {});
 };

--- a/packages/sdks/overrides/react-native/src/functions/sanitize-styles.ts
+++ b/packages/sdks/overrides/react-native/src/functions/sanitize-styles.ts
@@ -9,6 +9,7 @@ const normalizeNumber = (value: number): number | undefined => {
   if (Number.isNaN(value)) {
     return undefined;
   } else if (value < 0) {
+    // TODO: why are negative values not allowed?
     return 0;
   } else {
     return value;
@@ -40,8 +41,12 @@ export const sanitizeBlockStyles = (styles: Styles): Styles => {
       return acc;
     }
 
-    // Style properties like `"20px"` need to be numbers like `20` for react native
-    if (typeof propertyValue === 'string' && propertyValue.match(/^-?\d/)) {
+    // `px` units need to be stripped and replace with numbers
+    // https://regexr.com/6u5u1
+    if (
+      typeof propertyValue === 'string' &&
+      propertyValue.match(/^-?(\d*)(\.?)(\d*)*px/)
+    ) {
       const newValue = parseFloat(propertyValue);
       const normalizedValue = normalizeNumber(newValue);
 

--- a/packages/sdks/src/functions/get-block-styles.ts
+++ b/packages/sdks/src/functions/get-block-styles.ts
@@ -45,7 +45,7 @@ export function getBlockStyles(block: BuilderBlock) {
 
   const styles = getStyleForTarget(block.responsiveStyles);
 
-  sanitizeBlockStyles(styles);
+  const newStyles = sanitizeBlockStyles(styles);
 
-  return styles;
+  return newStyles;
 }

--- a/packages/sdks/src/functions/sanitize-styles.ts
+++ b/packages/sdks/src/functions/sanitize-styles.ts
@@ -2,6 +2,5 @@
  * No-op function, sanitize on a per-framework basis by overriding.
  */
 export const sanitizeBlockStyles = (
-  _styles: Partial<CSSStyleDeclaration>
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-): void => {};
+  styles: Partial<CSSStyleDeclaration>
+): Partial<CSSStyleDeclaration> => styles;


### PR DESCRIPTION
## Description

- make `sanitizeStylesObject` a pure function
- stop stripping `%` units in React Native