### PR TITLE
Add context in SSR flow

### DIFF
--- a/packages/react/src/functions/string-to-function.ts
+++ b/packages/react/src/functions/string-to-function.ts
@@ -119,12 +119,14 @@ export function stringToFunction(
         // TODO: cache these for better performancs with new VmScript
         // tslint:disable:comment-format
         const { VM } = safeDynamicRequire('vm2');
-        const [state, event] = args;
+        const [state, event, _block, _builder, _Device, _update, _Builder, context] = args;
+
         return new VM({
           timeout: 100,
           sandbox: {
             ...state,
             ...{ state },
+            ...{ context },
             ...{ builder: api },
             event,
           },


### PR DESCRIPTION
## Description

The function that runs in the browser when evaluating dynamic bindings has access to many more variables than the VM sandbox that runs on the server. Probably the most important among these is context, since context.builderContent.data.* is a common data binding to populate blocks from model fields. 

This PR populates the sandbox in such a way that there's parity between what's available in the browser vs. what's available on the server
