### PR TITLE
Better data binding execution errors

### DIFF
--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/react",
-  "version": "2.0.7",
+  "version": "2.0.8-4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/react",
-      "version": "2.0.7",
+      "version": "2.0.8-4",
       "license": "MIT",
       "dependencies": {
         "@builder.io/sdk": "^1.1.30",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/react",
-  "version": "2.0.7",
+  "version": "2.0.8-4",
   "description": "",
   "keywords": [],
   "main": "dist/builder-react.cjs.js",

--- a/packages/react/src/components/builder-block.component.tsx
+++ b/packages/react/src/components/builder-block.component.tsx
@@ -516,7 +516,7 @@ export class BuilderBlock extends React.Component<
     // tslint:disable-next-line:comment-format
     ///REACT15ONLY finalOptions.className = finalOptions.class
 
-    if (Builder.isEditing) {
+    if (Builder.isEditing || !Builder.isBrowser) {
       // TODO: removed bc JS can add styles inline too?
       (finalOptions as any)['builder-inline-styles'] = !(options.attr && options.attr.style)
         ? ''
@@ -636,7 +636,13 @@ export class BuilderBlock extends React.Component<
 
     if (block.repeat && block.repeat.collection) {
       const collectionPath = block.repeat.collection;
-      const collectionName = last((collectionPath || '').trim().split('(')[0].trim().split('.'));
+      const collectionName = last(
+        (collectionPath || '')
+          .trim()
+          .split('(')[0]
+          .trim()
+          .split('.')
+      );
       const itemName = block.repeat.itemName || (collectionName ? collectionName + 'Item' : 'item');
       const array = this.stringToFunction(collectionPath)(
         state.state,

--- a/packages/react/src/components/builder-block.component.tsx
+++ b/packages/react/src/components/builder-block.component.tsx
@@ -128,8 +128,8 @@ export class BuilderBlock extends React.Component<
 
   // TODO: handle adding return if none provided
   // TODO: cache/memoize this (globally with LRU?)
-  stringToFunction(str: string, expression = true) {
-    return stringToFunction(str, expression, this._errors, this._logs);
+  stringToFunction(type: string, str: string, expression = true) {
+    return stringToFunction(type, str, expression, this._errors, this._logs);
   }
 
   get block() {
@@ -193,7 +193,7 @@ export class BuilderBlock extends React.Component<
   }
 
   eval(str: string) {
-    const fn = this.stringToFunction(str);
+    const fn = this.stringToFunction('eval', str);
     // TODO: only one root instance of this, don't rewrap every time...
     return fn(
       this.privateState.state,
@@ -288,7 +288,7 @@ export class BuilderBlock extends React.Component<
 
           if (key.startsWith('animations.')) {
             // TODO: this needs to run in getElement bc of local state per element for repeats
-            const value = this.stringToFunction(block.bindings[key]);
+            const value = this.stringToFunction('animation', block.bindings[key]);
             if (value !== undefined) {
               set(
                 options,
@@ -397,7 +397,7 @@ export class BuilderBlock extends React.Component<
           continue;
         }
 
-        const value = this.stringToFunction(block.bindings[key]);
+        const value = this.stringToFunction('data binding', block.bindings[key]);
         // TODO: pass block, etc
         set(
           options,
@@ -437,7 +437,7 @@ export class BuilderBlock extends React.Component<
               },
             });
           }
-          const fn = this.stringToFunction(value, false);
+          const fn = this.stringToFunction('event handling', value, false);
           // TODO: only one root instance of this, don't rewrap every time...
           return fn(
             useState,
@@ -644,7 +644,7 @@ export class BuilderBlock extends React.Component<
           .split('.')
       );
       const itemName = block.repeat.itemName || (collectionName ? collectionName + 'Item' : 'item');
-      const array = this.stringToFunction(collectionPath)(
+      const array = this.stringToFunction('repeat for each', collectionPath)(
         state.state,
         null,
         block,

--- a/packages/react/src/components/builder-block.component.tsx
+++ b/packages/react/src/components/builder-block.component.tsx
@@ -516,7 +516,7 @@ export class BuilderBlock extends React.Component<
     // tslint:disable-next-line:comment-format
     ///REACT15ONLY finalOptions.className = finalOptions.class
 
-    if (Builder.isEditing || !Builder.isBrowser) {
+    if (Builder.isEditing || (!Builder.isBrowser && process.env.NODE_ENV !== 'production')) {
       // TODO: removed bc JS can add styles inline too?
       (finalOptions as any)['builder-inline-styles'] = !(options.attr && options.attr.style)
         ? ''

--- a/packages/react/src/functions/safe-dynamic-require.ts
+++ b/packages/react/src/functions/safe-dynamic-require.ts
@@ -5,12 +5,33 @@ import { Builder } from '@builder.io/sdk';
 const noop = () => null;
 // Allow us to require things dynamically safe from webpack bundling
 
-export let safeDynamicRequire: typeof require;
+export let safeDynamicRequire : typeof require;
 
 /*
- * The if condition below used to be if (typeof globalThis.require === "function"
+ * The if condition below used to be 
+ * 
+ *     if (typeof globalThis.require === "function")
+ * 
  * That broke in case Builder was running on the server (Next, SSR use-cases) where
  * globalThis.require was undefined. Avoiding use of Builder.isServer for Cloudflare worker cases
+ * That said, if change it to 
+ * 
+ * if (typeof require === 'function') {
+ *   localSafeDynamicRequire = eval('require');
+ * }
+ * 
+ * Then the TSC / rollup compiler over-optimizes and replaces the if condition with true always
+ * causing it to blow up on the client side. Hence this convoluted way of doing it.
+ * 
+ * In Summary:
+ * 
+ * 1. Node -> globalThis.require does not work
+ * 2. Client -> typeof require === 'function' does not work because of overoptimization by the compiler
+ * 3. Cloudflare edge -> only globalThis.require works
  */
-if (typeof require === 'function') safeDynamicRequire = eval('require');
+if (typeof globalThis.require === 'function' || Builder.isServer) {
+  safeDynamicRequire = eval('require');
+}
+
 safeDynamicRequire ??= noop as any;
+

--- a/packages/react/src/functions/string-to-function.ts
+++ b/packages/react/src/functions/string-to-function.ts
@@ -105,10 +105,23 @@ export function stringToFunction(
   }
 
   const final = (...args: any[]) => {
-    try {
-      if (Builder.isBrowser) {
+    if (Builder.isBrowser) {
+      try {
         return fn(...args);
-      } else {
+      } catch (error: any) {
+        console.warn(
+          'Builder custom code error:',
+          error.message || error,
+          'in',
+          str,
+          error.stack || error
+        );
+        if (errors) {
+          errors.push(error);
+        }
+      }
+    } else {
+      try {
         // TODO: memoize on server
         // TODO: use something like this instead https://www.npmjs.com/package/rollup-plugin-strip-blocks
         // There must be something more widely used?
@@ -132,17 +145,7 @@ export function stringToFunction(
           },
         }).run(str.replace(/(^|;)return /, '$1'));
         // tslint:enable:comment-format
-      }
-    } catch (error: any) {
-      if (Builder.isBrowser) {
-        console.warn(
-          'Builder custom code error:',
-          error.message || error,
-          'in',
-          str,
-          error.stack || error
-        );
-      } else {
+      } catch (error: any) {
         if (process.env.DEBUG) {
           console.debug(
             'Builder custom code error:',
@@ -152,9 +155,9 @@ export function stringToFunction(
             error.stack || error
           );
         }
-      }
-      if (errors) {
-        errors.push(error);
+        if (errors) {
+          errors.push(error);
+        }
       }
     }
   };

--- a/packages/react/src/functions/string-to-function.ts
+++ b/packages/react/src/functions/string-to-function.ts
@@ -47,7 +47,7 @@ Content item name: ${context.builderContent.name}
     }
   }
 
-  let message = `The Builder React SDK failed to execute the following data binding on the ${
+  let message = `The Builder React SDK failed to execute the following data binding code on the ${
     Builder.isServer ? 'server' : 'browser'
   }:
 
@@ -57,11 +57,11 @@ The error was
 
   ${error}
 
-You can inspect the binding and its code by visiting https://www.builder.io/content/${
+You can inspect the generated code listed above by visiting https://www.builder.io/content/${
     context.builderContent.id
   }/edit?activeDesignerTab=3&selectedBlock=${
     block.id
-  } and entering the JSON view for the selected block. You can enter the JSON view by right clicking on the block in the Layers tab or by pressing Cmd/Ctrl+E with the block selected.
+  } and entering the JSON view for the selected block by right clicking on the block in the Layers tab or by pressing Cmd/Ctrl+E with the block selected. You can also access the data binding itself from the Data tab.
 `;
 
   if (Builder.isServer) message = message.concat(`\n${debugInfo}`);

--- a/packages/react/src/functions/string-to-function.ts
+++ b/packages/react/src/functions/string-to-function.ts
@@ -53,7 +53,7 @@ Content item name: ${context.builderContent.name}
 
   ${code}
 
-The error was
+The error thrown was:
 
   ${error}
 

--- a/packages/react/src/functions/string-to-function.ts
+++ b/packages/react/src/functions/string-to-function.ts
@@ -205,28 +205,7 @@ export function stringToFunction(
       });
 
       try {
-        // TODO: memoize on server
-        // TODO: use something like this instead https://www.npmjs.com/package/rollup-plugin-strip-blocks
-        // There must be something more widely used?
-        // TODO: regex for between comments instead so can still type check the code... e.g. //SERVER-START ... code ... //SERVER-END
-        // Below is a hack to get certain code to *only* load in the server build, to not screw with
-        // browser bundler's like rollup and webpack. Our rollup plugin strips these comments only
-        // for the server build
-        // TODO: cache these for better performancs with new VmScript
-        // tslint:disable:comment-format
-        const { VM } = safeDynamicRequire('vm2');
-        const [state, event, _block, _builder, _Device, _update, _Builder, context] = args;
-
-        return new VM({
-          timeout: 100,
-          sandbox: {
-            ...state,
-            ...{ state },
-            ...{ context },
-            ...{ builder: api },
-            event,
-          },
-        }).run(str.replace(/(^|;)return /, '$1'));
+        return vm.run(str.replace(/(^|;)return /, '$1'));
         // tslint:enable:comment-format
       } catch (error: any) {
         logError({

--- a/packages/react/src/functions/string-to-function.ts
+++ b/packages/react/src/functions/string-to-function.ts
@@ -199,6 +199,7 @@ export function stringToFunction(
       const sandbox = {
         ...state,
         ...{ state },
+        ...{ context },
         ...{ builder: api },
         event,
       };

--- a/packages/react/src/functions/string-to-function.ts
+++ b/packages/react/src/functions/string-to-function.ts
@@ -195,6 +195,7 @@ export function stringToFunction(
       const sandbox = {
         ...state,
         ...{ state },
+        ...{ context },
         ...{ builder: api },
         event,
       };

--- a/packages/react/src/functions/string-to-function.ts
+++ b/packages/react/src/functions/string-to-function.ts
@@ -20,12 +20,14 @@ const logError = ({
   context,
   block,
   sandbox,
+  type,
 }: {
   code: string;
   error: any;
   context: any;
   block: any;
   sandbox?: any;
+  type: string;
 }) => {
   let debugInfo = `For a more detailed error message, restart your server with DEBUG=true set in your environment variables. If you're using npm, yarn, or a similar tool to run your development server, be sure to add DEBUG=true to your script in package.json so that your server can access the environment variable.
 `;
@@ -47,7 +49,7 @@ Content item name: ${context.builderContent.name}
     }
   }
 
-  let message = `The Builder React SDK failed to execute the following data binding code on the ${
+  let message = `The Builder React SDK failed to execute the following ${type} code on the ${
     Builder.isServer ? 'server' : 'browser'
   }:
 
@@ -77,10 +79,11 @@ You can inspect the generated code listed above by visiting https://www.builder.
 export const api = (state: any) => builder;
 
 export function stringToFunction(
+  type: string,
   str: string,
   expression = true,
   errors?: Error[],
-  logs?: string[]
+  logs?: string[],
 ): BuilderEvanFunction {
   /* TODO: objedct */
   if (!str || !str.trim()) {
@@ -174,6 +177,7 @@ export function stringToFunction(
           error: error,
           context: args[7],
           block: args[2],
+          type,
         });
 
         if (errors) {
@@ -195,7 +199,6 @@ export function stringToFunction(
       const sandbox = {
         ...state,
         ...{ state },
-        ...{ context },
         ...{ builder: api },
         event,
       };
@@ -215,6 +218,7 @@ export function stringToFunction(
           context,
           block,
           sandbox,
+          type
         });
 
         if (errors) {


### PR DESCRIPTION
Data bindings silently failing to execute during SSR is major cause of hydration issues. These failures are almost impossible to debug without some deep knowledge of the React SDK.

Fortunately, the React SDK logs these failures. Unfortunately, the errors are not very helpful and are hidden behind an undocumented `DEBUG=true` environment variable:

https://github.com/BuilderIO/builder/blob/c2663237c83435c04d92e6b81d658e5759e9396b/packages/react/src/functions/string-to-function.ts#L143-L153

The errors aren't helpful because:

1. They misleadingly state that there is a `Builder custom code error`. I think that most users would understand "custom code" to refer to the Visual Editor's custom/content JS feature, but the code that's executed here actually comes from data bindings.
2. The errors log the code that failed to execute but without any context as to where it's from.

My PR does the following:

1. Gives a better description of the error. An example on the server:

```
The Builder React SDK failed to execute the following data binding on the server:

  var _virtual_index=context.builderContent;return _virtual_index

The error was

  ReferenceError: context is not defined

You can inspect the binding and its code by visiting https://www.builder.io/content/87aaf4bc20b140f98ba3db2aba959453/edit?activeDesignerTab=3&selectedBlock=builder-a79fc1ddb9c443a6a9b1b69d77048aa8 and entering the JSON view for the selected block. You can enter the JSON view by right clicking on the block in the Layers tab or by pressing Cmd/Ctrl+E with the block selected.

For a more detailed error message, restart your server with DEBUG=true set in your environment variables. If you're using npm, yarn, or a similar tool to run your development server, be sure to add DEBUG=true to your script in package.json so that your server can access the environment variable.
```

And if `DEBUG=true` is set, the above example looks like:

```
The Builder React SDK failed to execute the following data binding on the server:

  var _virtual_index=context.builderContent;return _virtual_index

The error was

  ReferenceError: context is not defined

You can inspect the code by visiting https://www.builder.io/content/87aaf4bc20b140f98ba3db2aba959453/edit?activeDesignerTab=3&selectedBlock=builder-a79fc1ddb9c443a6a9b1b69d77048aa8 and entering the JSON view for the selected block. You can enter the JSON view by right clicking on the block in the Layers tab or by pressing Cmd/Ctrl+E with the block selected.

***BEGIN DEBUG INFO***

Block type: Text
Block ID: builder-a79fc1ddb9c443a6a9b1b69d77048aa8
Content item ID: 87aaf4bc20b140f98ba3db2aba959453
Content item name: Blank page

Server VM sandbox:

{
  "deviceSize": "large",
  "location": {
    "path": "",
    "query": {}
  },
  "isBrowser": false,
  "isServer": true,
  "device": "desktop",
  "state": {
    "deviceSize": "large",
    "location": {
      "path": "",
      "query": {}
    },
    "isBrowser": false,
    "isServer": true,
    "device": "desktop"
  },
  "event": null
}

Error stack trace:

ReferenceError: context is not defined
    at vm.js:1:20
    at Script.runInContext (node:vm:139:12)
    at VM.runScript (/Users/ersin/projects/hydration-test/node_modules/vm2/lib/vm.js:285:18)
    at /Users/ersin/projects/hydration-test/node_modules/vm2/lib/vm.js:507:16
    at timeout_bridge.js:1:1
    at Script.runInContext (node:vm:139:12)
    at doWithTimeout (/Users/ersin/projects/hydration-test/node_modules/vm2/lib/vm.js:132:29)
    at VM.run (/Users/ersin/projects/hydration-test/node_modules/vm2/lib/vm.js:506:10)
    at final (webpack-internal:///../builder/packages/react/dist/builder-react.cjs.js:349:33)
    at BuilderBlock.getElement (webpack-internal:///../builder/packages/react/dist/builder-react.cjs.js:775:35)

***END DEBUG INFO***
```

Whether `DEBUG=true` is set or not, the original error is logged separately for good measure, although it's not terribly helpful since it's being eval'd from a string inside of a block. This behavior is similar to how React logs the raw stack trace and then provides a more helpful error immediately afterward.

A similar error is logged in the browser:

![CleanShot 2022-09-28 at 17 30 30](https://user-images.githubusercontent.com/5427394/192912008-58a3cd0b-7f21-40c9-9232-cbd7b7304e71.png)

2. My PR makes these errors visible by default, not just behind `DEBUG=true`, and logs them as `console.error`, not `console.warn` or `console.debug`. If a data binding doesn't execute, that's really important info and we should consider it as breaking the page!

3. The `DEBUG` environment variable is now used to toggle some verbose info on the server (see above). It has no effect on browser errors.

Note that while the original intention was to improve errors on the server where there was almost no visibility into what was going wrong, my PR also improves the browser errors.