### PR TITLE
Fix issue with require getting triggered on client side

### DIFF
--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -38,7 +38,7 @@
         "jest": "^28.1.3",
         "jest-environment-jsdom": "^28.1.3",
         "lint-staged": "^7.0.0",
-        "prettier": "^1.4.4",
+        "prettier": "^2.6.2",
         "prompt": "^1.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0",
@@ -14281,15 +14281,18 @@
       }
     },
     "node_modules/prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -28698,9 +28701,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },
     "pretty-format": {

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/react",
-  "version": "2.0.7",
+  "version": "2.0.8-4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/react",
-      "version": "2.0.7",
+      "version": "2.0.8-4",
       "license": "MIT",
       "dependencies": {
         "@builder.io/sdk": "^1.1.30",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -84,7 +84,7 @@
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.3",
     "lint-staged": "^7.0.0",
-    "prettier": "^1.4.4",
+    "prettier": "^2.6.2",
     "prompt": "^1.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/react",
-  "version": "2.0.7",
+  "version": "2.0.8-4",
   "description": "",
   "keywords": [],
   "main": "dist/builder-react.cjs.js",

--- a/packages/react/src/functions/safe-dynamic-require.ts
+++ b/packages/react/src/functions/safe-dynamic-require.ts
@@ -5,26 +5,26 @@ import { Builder } from '@builder.io/sdk';
 const noop = () => null;
 // Allow us to require things dynamically safe from webpack bundling
 
-export let safeDynamicRequire : typeof require;
+export let safeDynamicRequire: typeof require;
 
 /*
- * The if condition below used to be 
- * 
+ * The if condition below used to be
+ *
  *     if (typeof globalThis.require === "function")
- * 
+ *
  * That broke in case Builder was running on the server (Next, SSR use-cases) where
  * globalThis.require was undefined. Avoiding use of Builder.isServer for Cloudflare worker cases
- * That said, if change it to 
- * 
+ * That said, if change it to
+ *
  * if (typeof require === 'function') {
  *   localSafeDynamicRequire = eval('require');
  * }
- * 
+ *
  * Then the TSC / rollup compiler over-optimizes and replaces the if condition with true always
  * causing it to blow up on the client side. Hence this convoluted way of doing it.
- * 
+ *
  * In Summary:
- * 
+ *
  * 1. Node -> globalThis.require does not work
  * 2. Client -> typeof require === 'function' does not work because of overoptimization by the compiler
  * 3. Cloudflare edge -> only globalThis.require works
@@ -34,4 +34,3 @@ if (typeof globalThis.require === 'function' || Builder.isServer) {
 }
 
 safeDynamicRequire ??= noop as any;
-

--- a/packages/react/src/functions/safe-dynamic-require.ts
+++ b/packages/react/src/functions/safe-dynamic-require.ts
@@ -5,12 +5,33 @@ import { Builder } from '@builder.io/sdk';
 const noop = () => null;
 // Allow us to require things dynamically safe from webpack bundling
 
-export let safeDynamicRequire: typeof require;
+export let safeDynamicRequire : typeof require;
 
 /*
- * The if condition below used to be if (typeof globalThis.require === "function"
+ * The if condition below used to be 
+ * 
+ *     if (typeof globalThis.require === "function")
+ * 
  * That broke in case Builder was running on the server (Next, SSR use-cases) where
  * globalThis.require was undefined. Avoiding use of Builder.isServer for Cloudflare worker cases
+ * That said, if change it to 
+ * 
+ * if (typeof require === 'function') {
+ *   localSafeDynamicRequire = eval('require');
+ * }
+ * 
+ * Then the TSC / rollup compiler over-optimizes and replaces the if condition with true always
+ * causing it to blow up on the client side. Hence this convoluted way of doing it.
+ * 
+ * In Summary:
+ * 
+ * 1. Node -> globalThis.require does not work
+ * 2. Client -> typeof require === 'function' does not work because of overoptimization by the compiler
+ * 3. Cloudflare edge -> only globalThis.require works
  */
-if (typeof require === 'function') safeDynamicRequire = eval('require');
+if (typeof globalThis.require === 'function' || Builder.isServer) {
+  safeDynamicRequire = eval('require');
+}
+
 safeDynamicRequire ??= noop as any;
+


### PR DESCRIPTION
## Description

The fix for getting SSR to work broke client side. This fix tries to work around that.

More details in the comments of the file, but basically,

1. Client side - `if (typeof require === 'function')` is over-optimized to `if ('function' === 'function')`
2. Node - `if (typeof globalThis.require === 'function')` does not work since `globalThis.require` is undefined
3. Cloudflare edge workers - Either `if (typeof globalThis.require === 'function')` or `if (typeof require === 'function')` will work, but `Builder.isServer` will not work

Hence the final condition that I think should work across all cases