### PR TITLE
fix(sdks): add builder-model attribute

### DIFF
--- a/packages/sdks/src/components/render-content/render-content.lite.tsx
+++ b/packages/sdks/src/components/render-content/render-content.lite.tsx
@@ -367,6 +367,7 @@ export default function RenderContent(props: RenderContentProps) {
         ref={elementRef}
         onClick={(event) => state.onClick(event)}
         builder-content-id={state.useContent?.id}
+        builder-model={props.model}
       >
         {state.shouldRenderContentStyles && (
           <RenderContentStyles

--- a/packages/sdks/src/scripts/init-editing.ts
+++ b/packages/sdks/src/scripts/init-editing.ts
@@ -34,6 +34,9 @@ export const setupBrowserForEditing = () => {
           // type: process.env.SDK_TYPE,
           // version: process.env.SDK_VERSION,
           supportsPatchUpdates: false,
+          // Supports builder-model="..." attribute which is needed to
+          // scope our '+ add block' button styling
+          supportsAddBlockScoping: true,
         },
       },
       '*'


### PR DESCRIPTION
this is needed for an upcoming fix to the visual editor to better scope our "add block" button styles to only the model being edited, not to others