### PR TITLE
Fix/svelte sdk sveltekit

### DIFF
--- a/examples/svelte-design-system/package-lock.json
+++ b/examples/svelte-design-system/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "svelte-starter-kit",
 			"version": "0.0.1",
 			"dependencies": {
-				"@builder.io/sdk-svelte": "^0.0.7",
+				"@builder.io/sdk-svelte": "^0.0.8",
 				"@fontsource/fira-mono": "^4.5.0",
 				"cookie": "^0.4.1",
 				"svelte-parallax": "^0.5.2"
@@ -36,9 +36,9 @@
 			}
 		},
 		"node_modules/@builder.io/sdk-svelte": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/@builder.io/sdk-svelte/-/sdk-svelte-0.0.7.tgz",
-			"integrity": "sha512-/3uvlp1gjscBB78Iu72nY13071+hX6il9lm8abmUWekdbeHvyiYq1XqoatrTGVmL6HpgTiNkLtyjMtbi98NzLw==",
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/@builder.io/sdk-svelte/-/sdk-svelte-0.0.8.tgz",
+			"integrity": "sha512-FfWKbvx/1lFqtHTQxocZqngvL39ju48xZ9/BcnMbtTsL6yO/EUwZBUIhk1I8J+3Hu/F+yXWh/xYP8x8FflH+dQ==",
 			"dependencies": {
 				"node-fetch": "^2.6.1"
 			}
@@ -4079,9 +4079,9 @@
 	},
 	"dependencies": {
 		"@builder.io/sdk-svelte": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/@builder.io/sdk-svelte/-/sdk-svelte-0.0.7.tgz",
-			"integrity": "sha512-/3uvlp1gjscBB78Iu72nY13071+hX6il9lm8abmUWekdbeHvyiYq1XqoatrTGVmL6HpgTiNkLtyjMtbi98NzLw==",
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/@builder.io/sdk-svelte/-/sdk-svelte-0.0.8.tgz",
+			"integrity": "sha512-FfWKbvx/1lFqtHTQxocZqngvL39ju48xZ9/BcnMbtTsL6yO/EUwZBUIhk1I8J+3Hu/F+yXWh/xYP8x8FflH+dQ==",
 			"requires": {
 				"node-fetch": "^2.6.1"
 			}

--- a/examples/svelte-design-system/package.json
+++ b/examples/svelte-design-system/package.json
@@ -36,7 +36,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@builder.io/sdk-svelte": "^0.0.7",
+		"@builder.io/sdk-svelte": "^0.0.8",
 		"@fontsource/fira-mono": "^4.5.0",
 		"cookie": "^0.4.1",
 		"svelte-parallax": "^0.5.2"

--- a/examples/svelte/svelte-vite/package-lock.json
+++ b/examples/svelte/svelte-vite/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sveltekit",
       "version": "0.0.1",
       "dependencies": {
-        "@builder.io/sdk-svelte": "^0.0.7",
+        "@builder.io/sdk-svelte": "^0.0.8",
         "svelte-preprocess": "^4.10.7"
       },
       "devDependencies": {
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@builder.io/sdk-svelte": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@builder.io/sdk-svelte/-/sdk-svelte-0.0.7.tgz",
-      "integrity": "sha512-/3uvlp1gjscBB78Iu72nY13071+hX6il9lm8abmUWekdbeHvyiYq1XqoatrTGVmL6HpgTiNkLtyjMtbi98NzLw==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@builder.io/sdk-svelte/-/sdk-svelte-0.0.8.tgz",
+      "integrity": "sha512-FfWKbvx/1lFqtHTQxocZqngvL39ju48xZ9/BcnMbtTsL6yO/EUwZBUIhk1I8J+3Hu/F+yXWh/xYP8x8FflH+dQ==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       }
@@ -2056,7 +2056,7 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -2186,7 +2186,7 @@
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -2202,7 +2202,7 @@
     },
     "node_modules/postcss": {
       "version": "8.4.14",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2580,7 +2580,7 @@
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -2675,6 +2675,7 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.52.0.tgz",
       "integrity": "sha512-FxcnEUOAVfr10vDU5dVgJN19IvqeHQCS1zfe8vayTfis9A2t5Fhx+JDe5uv/C3j//bB1umpLJ6quhgs9xyUbCQ==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -2887,7 +2888,7 @@
     },
     "node_modules/typescript": {
       "version": "4.6.3",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -3042,9 +3043,9 @@
       }
     },
     "@builder.io/sdk-svelte": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@builder.io/sdk-svelte/-/sdk-svelte-0.0.7.tgz",
-      "integrity": "sha512-/3uvlp1gjscBB78Iu72nY13071+hX6il9lm8abmUWekdbeHvyiYq1XqoatrTGVmL6HpgTiNkLtyjMtbi98NzLw==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@builder.io/sdk-svelte/-/sdk-svelte-0.0.8.tgz",
+      "integrity": "sha512-FfWKbvx/1lFqtHTQxocZqngvL39ju48xZ9/BcnMbtTsL6yO/EUwZBUIhk1I8J+3Hu/F+yXWh/xYP8x8FflH+dQ==",
       "requires": {
         "node-fetch": "^2.6.1"
       }
@@ -3410,8 +3411,7 @@
     },
     "acorn-jsx": {
       "version": "5.3.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "agent-base": {
       "version": "6.0.2",
@@ -3874,13 +3874,11 @@
     },
     "eslint-config-prettier": {
       "version": "8.5.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-svelte3": {
       "version": "3.4.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -4291,7 +4289,7 @@
     },
     "nanoid": {
       "version": "3.3.4",
-      "devOptional": true
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -4364,7 +4362,7 @@
     },
     "picocolors": {
       "version": "1.0.0",
-      "devOptional": true
+      "dev": true
     },
     "picomatch": {
       "version": "2.3.1",
@@ -4372,7 +4370,7 @@
     },
     "postcss": {
       "version": "8.4.14",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -4389,8 +4387,7 @@
     },
     "prettier-plugin-svelte": {
       "version": "2.7.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -4582,7 +4579,7 @@
     },
     "source-map-js": {
       "version": "1.0.2",
-      "devOptional": true
+      "dev": true
     },
     "sourcemap-codec": {
       "version": "1.4.8"
@@ -4640,12 +4637,12 @@
     "svelte": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.52.0.tgz",
-      "integrity": "sha512-FxcnEUOAVfr10vDU5dVgJN19IvqeHQCS1zfe8vayTfis9A2t5Fhx+JDe5uv/C3j//bB1umpLJ6quhgs9xyUbCQ=="
+      "integrity": "sha512-FxcnEUOAVfr10vDU5dVgJN19IvqeHQCS1zfe8vayTfis9A2t5Fhx+JDe5uv/C3j//bB1umpLJ6quhgs9xyUbCQ==",
+      "dev": true
     },
     "svelte-hmr": {
       "version": "0.14.12",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "svelte-preprocess": {
       "version": "4.10.7",
@@ -4757,7 +4754,7 @@
     },
     "typescript": {
       "version": "4.6.3",
-      "devOptional": true
+      "dev": true
     },
     "uri-js": {
       "version": "4.4.1",

--- a/examples/svelte/svelte-vite/package.json
+++ b/examples/svelte/svelte-vite/package.json
@@ -23,7 +23,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@builder.io/sdk-svelte": "^0.0.7",
+    "@builder.io/sdk-svelte": "^0.0.8",
     "svelte-preprocess": "^4.10.7"
   }
 }

--- a/examples/svelte/sveltekit/package-lock.json
+++ b/examples/svelte/sveltekit/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "sveltekit",
 			"version": "0.0.1",
 			"dependencies": {
-				"@builder.io/sdk-svelte": "^0.0.6"
+				"@builder.io/sdk-svelte": "^0.0.8"
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "next",
@@ -23,9 +23,9 @@
 			}
 		},
 		"node_modules/@builder.io/sdk-svelte": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/@builder.io/sdk-svelte/-/sdk-svelte-0.0.6.tgz",
-			"integrity": "sha512-gxATeVo2bUb855S5NAehIiV+1P3N/V6PiYA5zR152Av79nPd9On0F94SKksoxxEz7chjc+ql83V4QHH+NTH31w==",
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/@builder.io/sdk-svelte/-/sdk-svelte-0.0.8.tgz",
+			"integrity": "sha512-FfWKbvx/1lFqtHTQxocZqngvL39ju48xZ9/BcnMbtTsL6yO/EUwZBUIhk1I8J+3Hu/F+yXWh/xYP8x8FflH+dQ==",
 			"dependencies": {
 				"node-fetch": "^2.6.1"
 			}
@@ -2868,9 +2868,9 @@
 	},
 	"dependencies": {
 		"@builder.io/sdk-svelte": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/@builder.io/sdk-svelte/-/sdk-svelte-0.0.6.tgz",
-			"integrity": "sha512-gxATeVo2bUb855S5NAehIiV+1P3N/V6PiYA5zR152Av79nPd9On0F94SKksoxxEz7chjc+ql83V4QHH+NTH31w==",
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/@builder.io/sdk-svelte/-/sdk-svelte-0.0.8.tgz",
+			"integrity": "sha512-FfWKbvx/1lFqtHTQxocZqngvL39ju48xZ9/BcnMbtTsL6yO/EUwZBUIhk1I8J+3Hu/F+yXWh/xYP8x8FflH+dQ==",
 			"requires": {
 				"node-fetch": "^2.6.1"
 			},

--- a/examples/svelte/sveltekit/package.json
+++ b/examples/svelte/sveltekit/package.json
@@ -22,6 +22,6 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@builder.io/sdk-svelte": "^0.0.6"
+		"@builder.io/sdk-svelte": "^0.0.8"
 	}
 }

--- a/packages/sdks/output/svelte/package.json
+++ b/packages/sdks/output/svelte/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@builder.io/sdk-svelte",
   "description": "Builder.io SDK for Svelte",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "module",
   "files": [
     "package",

--- a/packages/sdks/output/svelte/package.json
+++ b/packages/sdks/output/svelte/package.json
@@ -15,7 +15,7 @@
   },
   "main": "./package/index.js",
   "module": "./package/index.js",
-  "svelte": "./src/index.ts",
+  "svelte": "./package/index.js",
   "exports": {
     "./src": {
       "import": "./src/index.js",


### PR DESCRIPTION
## Description

- fix issue with `svelte` field in `package.json`, which seem to break for sveltekit. It can't point to a typescript file, it has to point to a compiled `js` file instead, or else the sveltekit user needs to have typescript installed. Even then, Sveltekit bumps into issues importing the SDK