### PR TITLE
Use breakpoints passed from editor on priority inside React SDK

### DIFF
--- a/packages/react/src/blocks/Columns.tsx
+++ b/packages/react/src/blocks/Columns.tsx
@@ -6,6 +6,7 @@ import { BuilderElement } from '@builder.io/sdk';
 import { BuilderBlocks } from '../components/builder-blocks.component';
 import { withBuilder } from '../functions/with-builder';
 import { Link } from '../components/Link';
+import { Breakpoints, getSizesForBreakpoints } from 'src/constants/device-sizes.constant';
 
 const DEFAULT_ASPECT_RATIO = 0.7004048582995948;
 
@@ -85,6 +86,9 @@ class ColumnsComponent extends React.Component<any> {
 
   render() {
     const { columns, gutterSize } = this;
+    const contentBreakpoints: Breakpoints =
+      this.props.builderState?.context.builderContent?.meta?.breakpoints || {};
+    const breakpointSizes = getSizesForBreakpoints(contentBreakpoints);
 
     return (
       // FIXME: make more elegant
@@ -94,7 +98,11 @@ class ColumnsComponent extends React.Component<any> {
           css={{
             display: 'flex',
             ...(this.props.stackColumnsAt !== 'never' && {
-              [`@media (max-width: ${this.props.stackColumnsAt !== 'tablet' ? 639 : 991}px)`]: {
+              [`@media (max-width: ${
+                this.props.stackColumnsAt !== 'tablet'
+                  ? breakpointSizes.small.max
+                  : breakpointSizes.medium.max
+              }px)`]: {
                 flexDirection: this.props.reverseColumnsWhenStacked ? 'column-reverse' : 'column',
                 alignItems: 'stretch',
               },
@@ -125,7 +133,9 @@ class ColumnsComponent extends React.Component<any> {
                     marginLeft: index === 0 ? 0 : gutterSize,
                     ...(this.props.stackColumnsAt !== 'never' && {
                       [`@media (max-width: ${
-                        this.props.stackColumnsAt !== 'tablet' ? 639 : 991
+                        this.props.stackColumnsAt !== 'tablet'
+                          ? breakpointSizes.small.max
+                          : breakpointSizes.medium.max
                       }px)`]: {
                         width: '100%',
                         marginLeft: 0,

--- a/packages/react/src/blocks/Columns.tsx
+++ b/packages/react/src/blocks/Columns.tsx
@@ -6,7 +6,7 @@ import { BuilderElement } from '@builder.io/sdk';
 import { BuilderBlocks } from '../components/builder-blocks.component';
 import { withBuilder } from '../functions/with-builder';
 import { Link } from '../components/Link';
-import { Breakpoints, getSizesForBreakpoints } from 'src/constants/device-sizes.constant';
+import { Breakpoints, getSizesForBreakpoints } from '../constants/device-sizes.constant';
 
 const DEFAULT_ASPECT_RATIO = 0.7004048582995948;
 

--- a/packages/react/src/blocks/Image.tsx
+++ b/packages/react/src/blocks/Image.tsx
@@ -7,6 +7,7 @@ import { BuilderElement, Builder } from '@builder.io/sdk';
 import { BuilderMetaContext } from '../store/builder-meta';
 import { withBuilder } from '../functions/with-builder';
 import { throttle } from '../functions/throttle';
+import { Breakpoints, getSizesForBreakpoints } from 'src/constants/device-sizes.constant';
 
 // Taken from (and modified) the shopify theme script repo
 // https://github.com/Shopify/theme-scripts/blob/bcfb471f2a57d439e2f964a1bb65b67708cc90c3/packages/theme-images/images.js#L59
@@ -92,7 +93,11 @@ export function getSrcSet(url: string): string {
   return url;
 }
 
-export const getSizes = (sizes: string, block: BuilderElement) => {
+export const getSizes = (
+  sizes: string,
+  block: BuilderElement,
+  contentBreakpoints: Breakpoints = {}
+) => {
   let useSizes = '';
 
   if (sizes) {
@@ -117,9 +122,10 @@ export const getSizes = (sizes: string, block: BuilderElement) => {
     let hasSmallOrMediumSize = false;
     const unitRegex = /^\d+/;
 
+    const breakpointSizes = getSizesForBreakpoints(contentBreakpoints);
     if (block.responsiveStyles?.small?.width?.match(unitRegex)) {
       hasSmallOrMediumSize = true;
-      const mediaQuery = '(max-width: 639px)';
+      const mediaQuery = `(max-width: ${breakpointSizes.small.max}px)`;
       const widthAndQuery = `${mediaQuery} ${block.responsiveStyles.small.width.replace(
         '%',
         'vw'
@@ -129,7 +135,7 @@ export const getSizes = (sizes: string, block: BuilderElement) => {
 
     if (block.responsiveStyles?.medium?.width?.match(unitRegex)) {
       hasSmallOrMediumSize = true;
-      const mediaQuery = '(max-width: 991px)';
+      const mediaQuery = `(max-width: ${breakpointSizes.medium.max}px)`;
       const widthAndQuery = `${mediaQuery} ${block.responsiveStyles.medium.width.replace(
         '%',
         'vw'
@@ -267,11 +273,15 @@ class ImageComponent extends React.Component<any, { imageLoaded: boolean; load: 
   }
 
   render() {
-    const { aspectRatio, lazy } = this.props;
+    const { aspectRatio, lazy, builderBlock, builderState } = this.props;
     const children = this.props.builderBlock && this.props.builderBlock.children;
 
     let srcset = this.props.srcset;
-    const sizes = getSizes(this.props.sizes, this.props.builderBlock);
+    const sizes = getSizes(
+      this.props.sizes,
+      builderBlock,
+      builderState?.context.builderContent?.meta?.breakpoints || {}
+    );
     const image = this.image;
 
     if (srcset && image && image.includes('builder.io/api/v1/image')) {
@@ -283,7 +293,7 @@ class ImageComponent extends React.Component<any, { imageLoaded: boolean; load: 
       srcset = this.getSrcSet();
     }
 
-    const isPixel = this.props.builderBlock?.id.startsWith('builder-pixel-');
+    const isPixel = builderBlock?.id.startsWith('builder-pixel-');
     const { fitContent } = this.props;
 
     return (

--- a/packages/react/src/blocks/Image.tsx
+++ b/packages/react/src/blocks/Image.tsx
@@ -7,7 +7,7 @@ import { BuilderElement, Builder } from '@builder.io/sdk';
 import { BuilderMetaContext } from '../store/builder-meta';
 import { withBuilder } from '../functions/with-builder';
 import { throttle } from '../functions/throttle';
-import { Breakpoints, getSizesForBreakpoints } from 'src/constants/device-sizes.constant';
+import { Breakpoints, getSizesForBreakpoints } from '../constants/device-sizes.constant';
 
 // Taken from (and modified) the shopify theme script repo
 // https://github.com/Shopify/theme-scripts/blob/bcfb471f2a57d439e2f964a1bb65b67708cc90c3/packages/theme-images/images.js#L59

--- a/packages/react/src/components/builder-block.component.tsx
+++ b/packages/react/src/components/builder-block.component.tsx
@@ -1,5 +1,6 @@
 /** @jsx jsx */
-
+/* ts-ignore */
+// @ts-ignore
 import { Builder, builder, BuilderElement, Component } from '@builder.io/sdk';
 import { ClassNames, jsx } from '@emotion/core';
 import React from 'react';

--- a/packages/react/src/components/builder-block.component.tsx
+++ b/packages/react/src/components/builder-block.component.tsx
@@ -1,6 +1,4 @@
 /** @jsx jsx */
-/* ts-ignore */
-// @ts-ignore
 import { Builder, builder, BuilderElement, Component } from '@builder.io/sdk';
 import { ClassNames, jsx } from '@emotion/core';
 import React from 'react';

--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -290,7 +290,7 @@ export interface BuilderComponentState {
   updates: number;
   context: any;
   key: number;
-  breakpoints?: Breakpoints
+  breakpoints?: Breakpoints;
 }
 
 function searchToObject(location: Location | Url) {
@@ -1038,9 +1038,9 @@ export class BuilderComponent extends React.Component<
                             ...fullData,
                             meta: {
                               ...(fullData.meta || {}),
-                              breakpoints: this.state.breakpoints || fullData.meta?.breakpoints
-                            }
-                          }
+                              breakpoints: this.state.breakpoints || fullData.meta?.breakpoints,
+                            },
+                          };
                           this.state.context.builderContent = fullData;
                         }
                         if (Builder.isBrowser) {

--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -1034,13 +1034,10 @@ export class BuilderComponent extends React.Component<
                         }
 
                         if (fullData && fullData.id) {
-                          fullData = {
-                            ...fullData,
-                            meta: {
-                              ...(fullData.meta || {}),
-                              breakpoints: this.state.breakpoints || fullData.meta?.breakpoints,
-                            },
-                          };
+                          if (this.state.breakpoints) {
+                            fullData.meta = fullData.meta || {};
+                            fullData.meta.breakpoints = this.state.breakpoints;
+                          }
                           this.state.context.builderContent = fullData;
                         }
                         if (Builder.isBrowser) {

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -151,7 +151,7 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
           newData.meta = newData.meta || {};
           newData.meta.breakpoints = data.meta?.breakpoints;
         }
-        
+
         this.setState({
           updates: this.state.updates + 1,
           data: newData,

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -141,17 +141,9 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
           eval('debugger');
         }
         let newData = this.state.data as any;
-        if (data.data) {
-          for (const patch of patches) {
-            newData = applyPatchWithMinimalMutationChain(newData, patch, false);
-          }
+        for (const patch of patches) {
+          newData = applyPatchWithMinimalMutationChain(newData, patch, false);
         }
-
-        if (data.meta?.breakpoints) {
-          newData.meta = newData.meta || {};
-          newData.meta.breakpoints = data.meta?.breakpoints;
-        }
-
         this.setState({
           updates: this.state.updates + 1,
           data: newData,

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -141,9 +141,17 @@ export class BuilderContent<ContentType extends object = any> extends React.Comp
           eval('debugger');
         }
         let newData = this.state.data as any;
-        for (const patch of patches) {
-          newData = applyPatchWithMinimalMutationChain(newData, patch, false);
+        if (data.data) {
+          for (const patch of patches) {
+            newData = applyPatchWithMinimalMutationChain(newData, patch, false);
+          }
         }
+
+        if (data.meta?.breakpoints) {
+          newData.meta = newData.meta || {};
+          newData.meta.breakpoints = data.meta?.breakpoints;
+        }
+        
         this.setState({
           updates: this.state.updates + 1,
           data: newData,

--- a/packages/react/src/constants/device-sizes.constant.ts
+++ b/packages/react/src/constants/device-sizes.constant.ts
@@ -40,7 +40,7 @@ const sizes = {
 };
 export type Sizes = typeof sizes;
 
-interface Breakpoints {
+export interface Breakpoints {
   small?: number;
   medium?: number;
 }


### PR DESCRIPTION
When react sdk is used inside the editor, we need to use the breakpoints values coming from editor on priority vs the breakpoints values available in passed content entry.
This is for cases when fresh breakpoints are set in org settings but they haven't yet persisted in content and to ensure editor to render content iframe based on this fresh breakpoints values (over the one persisted aka stale in content.meta.breakpoints)

Editor PR: [https://github.com/bridgeproject/builder-internal/pull/3709](https://github.com/bridgeproject/builder-internal/pull/3709)