### PR TITLE
fix: Adding missing pixel only when some blocks are available

### DIFF
--- a/packages/react/src/components/builder-blocks.component.tsx
+++ b/packages/react/src/components/builder-blocks.component.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React from 'react';
-import { Builder } from '@builder.io/sdk';
+import { Builder, BuilderElement } from '@builder.io/sdk';
 import { BuilderBlock } from './builder-block.component';
 // TODO: fetch these for user and send them with same response like graphql
 import { Size } from '../constants/device-sizes.constant';
@@ -35,7 +35,23 @@ export class BuilderBlocks extends React.Component<BuilderBlocksProps, BuilderBl
 
   get noBlocks() {
     const { blocks } = this.props;
-    return !(blocks && (blocks as any).length); // TODO: allow react nodes
+
+    if (!blocks || (blocks as any).length === 0) {
+      return true;
+    }
+
+    // could be containing just a pixel element, then consider it as empty or no-block
+    if ((blocks as any).length === 1) {
+      const firstBlock = (blocks as any)[0] as BuilderElement;
+
+      if (firstBlock?.id?.startsWith('builder-pixel-')) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+
+    return false;
   }
   get path() {
     const pathPrefix = 'component.options.';

--- a/packages/react/src/components/builder-blocks.component.tsx
+++ b/packages/react/src/components/builder-blocks.component.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React from 'react';
-import { Builder, BuilderElement } from '@builder.io/sdk';
+import { Builder } from '@builder.io/sdk';
 import { BuilderBlock } from './builder-block.component';
 // TODO: fetch these for user and send them with same response like graphql
 import { Size } from '../constants/device-sizes.constant';

--- a/packages/react/src/components/builder-blocks.component.tsx
+++ b/packages/react/src/components/builder-blocks.component.tsx
@@ -35,23 +35,7 @@ export class BuilderBlocks extends React.Component<BuilderBlocksProps, BuilderBl
 
   get noBlocks() {
     const { blocks } = this.props;
-
-    if (!blocks || (blocks as any).length === 0) {
-      return true;
-    }
-
-    // could be containing just a pixel element, then consider it as empty or no-block
-    if ((blocks as any).length === 1) {
-      const firstBlock = (blocks as any)[0] as BuilderElement;
-
-      if (firstBlock?.id?.startsWith('builder-pixel-')) {
-        return true;
-      } else {
-        return false;
-      }
-    }
-
-    return false;
+    return !(blocks && (blocks as any).length); // TODO: allow react nodes
   }
   get path() {
     const pathPrefix = 'component.options.';

--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -1076,7 +1076,7 @@ export class BuilderComponent extends React.Component<
                           block.id?.startsWith('builder-pixel')
                         );
 
-                        if (data && !hasPixel && !(Builder.isEditing || Builder.isPreviewing)) {
+                        if (data && !hasPixel && blocks.length > 0) {
                           blocks.push(getBuilderPixel(builder.apiKey!));
                         }
 

--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -1076,7 +1076,7 @@ export class BuilderComponent extends React.Component<
                           block.id?.startsWith('builder-pixel')
                         );
 
-                        if (data && !hasPixel) {
+                        if (data && !hasPixel && !(Builder.isEditing || Builder.isPreviewing)) {
                           blocks.push(getBuilderPixel(builder.apiKey!));
                         }
 

--- a/packages/react/test/__snapshots__/basic.test.tsx.snap
+++ b/packages/react/test/__snapshots__/basic.test.tsx.snap
@@ -1,6 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Builder Pixel Should be added automatically if missing in blocks array 1`] = `
+exports[`Builder Pixel Should NOT be added if missing in blocksString 1`] = `
+<div
+  className="builder-component builder-component-id"
+  data-name="page"
+  data-source="Rendered by Builder.io"
+  onClick={[Function]}
+>
+  <div
+    builder-content-id="id"
+    builder-model="page"
+    className="builder-content"
+    onClick={[Function]}
+  >
+    <div
+      data-builder-component="page"
+      data-builder-content-id="id"
+      data-builder-variation-id="id"
+    >
+      
+      <div
+        builder-type="blocks"
+        className="builder-blocks no-blocks css-h47494"
+        onClick={[Function]}
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Builder Pixel Should NOT be added again if already present in blocks array 1`] = `
 <div
   className="builder-component builder-component-id"
   data-name="page"
@@ -38,7 +67,7 @@ exports[`Builder Pixel Should be added automatically if missing in blocks array 
 </div>
 `;
 
-exports[`Builder Pixel Should be added automatically if missing in blocksString 1`] = `
+exports[`Builder Pixel Should NOT be added if missing in blocks array 1`] = `
 <div
   className="builder-component builder-component-id"
   data-name="page"
@@ -59,24 +88,15 @@ exports[`Builder Pixel Should be added automatically if missing in blocksString 
       
       <div
         builder-type="blocks"
-        className="builder-blocks css-h47494"
+        className="builder-blocks no-blocks css-h47494"
         onClick={[Function]}
-      >
-        <img
-          aria-hidden="true"
-          builder-id="builder-pixel-4fzzzxjylrx"
-          className="builder-block builder-pixel-4fzzzxjylrx css-1mvsfya"
-          role="presentation"
-          src="https://cdn.builder.io/api/v1/pixel?apiKey=null"
-          style={Object {}}
-        />
-      </div>
+      />
     </div>
   </div>
 </div>
 `;
 
-exports[`Builder Pixel Should not be added if already present in blocks array 1`] = `
+exports[`Builder Pixel Should be added if pixel is missing and blocks array has other block(s) 1`] = `
 <div
   className="builder-component builder-component-id"
   data-name="page"
@@ -100,6 +120,24 @@ exports[`Builder Pixel Should not be added if already present in blocks array 1`
         className="builder-blocks css-h47494"
         onClick={[Function]}
       >
+        <div
+          builder-id="builder-270035a08d734ae88ea177daff3595c0"
+          className="builder-block builder-270035a08d734ae88ea177daff3595c0 builder-has-component css-hgfgng"
+          style={Object {}}
+        >
+          <span
+            className="builder-text css-1qggkls"
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<p>some text...</p>",
+              }
+            }
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            onKeyDown={[Function]}
+          />
+        </div>
         <img
           aria-hidden="true"
           builder-id="builder-pixel-4fzzzxjylrx"

--- a/packages/react/test/basic.test.tsx
+++ b/packages/react/test/basic.test.tsx
@@ -184,7 +184,7 @@ describe('Content changes when new content provided', () => {
 });
 
 describe('Builder Pixel', () => {
-  it('Should be added automatically if missing in blocksString', () => {
+  it('Should NOT be added if missing in blocksString', () => {
     const renderedBlock = reactTestRenderer.create(
       <BuilderPage
         model="page"
@@ -199,7 +199,7 @@ describe('Builder Pixel', () => {
     expect(renderedBlock).toMatchSnapshot();
   });
 
-  it('Should be added automatically if missing in blocks array', () => {
+  it('Should NOT be added if missing in blocks array', () => {
     const renderedBlock = reactTestRenderer.create(
       <BuilderPage
         model="page"
@@ -215,7 +215,7 @@ describe('Builder Pixel', () => {
     expect(renderedBlock).toMatchSnapshot();
   });
 
-  it('Should not be added if already present in blocks array', () => {
+  it('Should NOT be added again if already present in blocks array', () => {
     const renderedBlock = reactTestRenderer.create(
       <BuilderPage
         model="page"
@@ -223,6 +223,46 @@ describe('Builder Pixel', () => {
           id: 'id',
           data: {
             blocks: [getBuilderPixel('null')],
+          },
+        }}
+      />
+    );
+
+    expect(renderedBlock).toMatchSnapshot();
+  });
+
+  it('Should be added if pixel is missing and blocks array has other block(s)', () => {
+    const renderedBlock = reactTestRenderer.create(
+      <BuilderPage
+        model="page"
+        content={{
+          id: 'id',
+          data: {
+            blocks: [
+              {
+                '@type': '@builder.io/sdk:Element',
+                '@version': 2,
+                id: 'builder-270035a08d734ae88ea177daff3595c0',
+                component: {
+                  name: 'Text',
+                  options: {
+                    text: '<p>some text...</p>',
+                  },
+                },
+                responsiveStyles: {
+                  large: {
+                    display: 'flex',
+                    flexDirection: 'column',
+                    position: 'relative',
+                    flexShrink: '0',
+                    boxSizing: 'border-box',
+                    marginTop: '20px',
+                    lineHeight: 'normal',
+                    height: 'auto',
+                  },
+                },
+              },
+            ],
           },
         }}
       />


### PR DESCRIPTION
## Description

Updated the missing-pixel-block-addition logic to apply only when there is atleast a block already available in `data.blocks`

_Screenshot_
on local dev server - 
<img width="1187" alt="image" src="https://user-images.githubusercontent.com/98028693/205933876-b2bff9a2-c087-4c4e-a002-bc9367263c9b.png">
