### PR TITLE
SDKs: fix canTrack

### DIFF
--- a/packages/sdks/e2e/nextjs-react/pages/[[...index]].tsx
+++ b/packages/sdks/e2e/nextjs-react/pages/[[...index]].tsx
@@ -20,3 +20,11 @@ function App() {
 }
 
 export default App;
+
+// we have this empty fn to force NextJS to opt out of static optimization
+// https://nextjs.org/docs/advanced-features/automatic-static-optimization
+export async function getServerSideProps(context) {
+  return {
+    props: {}, // will be passed to the page component as props
+  };
+}

--- a/packages/sdks/e2e/nextjs-react/pages/[[...index]].tsx
+++ b/packages/sdks/e2e/nextjs-react/pages/[[...index]].tsx
@@ -1,11 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { RenderContent } from '@builder.io/sdk-react';
-import { getContentForPathname } from '@builder.io/sdks-e2e-tests';
+import { getProps } from '@builder.io/sdks-e2e-tests';
 import { useRouter } from 'next/router';
-
-// TODO: enter your public API key
-const BUILDER_PUBLIC_API_KEY = 'f1a790f8c3204b3b8c5c1795aeac4660'; // ggignore
 
 const getPathname = (x: string) => {
   if (x === '/[[...index]]') {
@@ -18,16 +15,8 @@ const getPathname = (x: string) => {
 function App() {
   const router = useRouter();
 
-  const content = getContentForPathname(getPathname(router.asPath));
-  return content ? (
-    <RenderContent
-      content={content}
-      model="page"
-      apiKey={BUILDER_PUBLIC_API_KEY}
-    />
-  ) : (
-    <div>Content Not Found</div>
-  );
+  const props = getProps(getPathname(router.asPath));
+  return props ? <RenderContent {...props} /> : <div>Content Not Found</div>;
 }
 
 export default App;

--- a/packages/sdks/e2e/nextjs-react/pages/[[...index]].tsx
+++ b/packages/sdks/e2e/nextjs-react/pages/[[...index]].tsx
@@ -23,7 +23,7 @@ export default App;
 
 // we have this empty fn to force NextJS to opt out of static optimization
 // https://nextjs.org/docs/advanced-features/automatic-static-optimization
-export async function getServerSideProps(context) {
+export async function getServerSideProps() {
   return {
     props: {}, // will be passed to the page component as props
   };

--- a/packages/sdks/e2e/qwik/src/main.tsx
+++ b/packages/sdks/e2e/qwik/src/main.tsx
@@ -1,18 +1,16 @@
 import { component$ } from '@builder.io/qwik';
 import { RenderContent } from '@builder.io/sdk-qwik';
-import { getContentForPathname } from '@builder.io/sdks-e2e-tests';
+import { getProps } from '@builder.io/sdks-e2e-tests';
 
 export interface MainProps {
   url: string;
 }
 export const BUILDER_PUBLIC_API_KEY = 'f1a790f8c3204b3b8c5c1795aeac4660'; // ggignore
 export const Main = component$((props: MainProps) => {
-  const content = getContentForPathname(new URL(props.url).pathname);
-  return (
-    <RenderContent
-      model="page"
-      content={content}
-      apiKey={BUILDER_PUBLIC_API_KEY}
-    />
+  const contentProps = getProps(new URL(props.url).pathname);
+  return contentProps ? (
+    <RenderContent {...contentProps} />
+  ) : (
+    <div>Content Not Found</div>
   );
 });

--- a/packages/sdks/e2e/react-native/App.jsx
+++ b/packages/sdks/e2e/react-native/App.jsx
@@ -1,13 +1,10 @@
 import { StatusBar } from 'expo-status-bar';
 import { Text, View } from 'react-native';
 import React, { Fragment } from 'react';
-import { getContentForPathname } from '@builder.io/sdks-e2e-tests';
+import { getProps } from '@builder.io/sdks-e2e-tests';
 import { RenderContent } from '@builder.io/sdk-react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-
-// TO-DO: add your own public Builder API key here
-const BUILDER_API_KEY = 'f1a790f8c3204b3b8c5c1795aeac4660'; // ggignore
 
 const linking = {
   prefixes: ['http://localhost:19006'],
@@ -21,19 +18,11 @@ const linking = {
 };
 
 const BuilderContent = ({ route }) => {
-  const content = getContentForPathname(route.path);
+  const props = getProps(route.path);
 
   return (
     <Fragment>
-      {content ? (
-        <RenderContent
-          apiKey={BUILDER_API_KEY}
-          model="page"
-          content={content}
-        />
-      ) : (
-        <Text>Not Found.</Text>
-      )}
+      {props ? <RenderContent {...props} /> : <Text>Not Found.</Text>}
       <StatusBar style="auto" />
     </Fragment>
   );

--- a/packages/sdks/e2e/react/src/App.tsx
+++ b/packages/sdks/e2e/react/src/App.tsx
@@ -1,22 +1,11 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { RenderContent } from '@builder.io/sdk-react';
-import { getContentForPathname } from '@builder.io/sdks-e2e-tests';
-
-// TODO: enter your public API key
-const BUILDER_PUBLIC_API_KEY = 'f1a790f8c3204b3b8c5c1795aeac4660'; // ggignore
+import { getProps } from '@builder.io/sdks-e2e-tests';
 
 function App() {
-  const content = getContentForPathname();
-  return content ? (
-    <RenderContent
-      content={content}
-      model="page"
-      apiKey={BUILDER_PUBLIC_API_KEY}
-    />
-  ) : (
-    <div>Content Not Found</div>
-  );
+  const props = getProps();
+  return props ? <RenderContent {...props} /> : <div>Content Not Found</div>;
 }
 
 export default App;

--- a/packages/sdks/e2e/solidjs/src/App.tsx
+++ b/packages/sdks/e2e/solidjs/src/App.tsx
@@ -2,23 +2,12 @@ import type { Component } from 'solid-js';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { RenderContent } from '@builder.io/sdk-solid';
-import { getContentForPathname } from '@builder.io/sdks-e2e-tests';
-
-// TODO: enter your public API key
-const BUILDER_PUBLIC_API_KEY = 'f1a790f8c3204b3b8c5c1795aeac4660'; // ggignore
+import { getProps } from '@builder.io/sdks-e2e-tests';
 
 const App: Component = () => {
-  const content = getContentForPathname();
+  const props = getProps();
 
-  return content ? (
-    <RenderContent
-      content={content}
-      model="page"
-      apiKey={BUILDER_PUBLIC_API_KEY}
-    />
-  ) : (
-    <div>Content Not Found</div>
-  );
+  return props ? <RenderContent {...props} /> : <div>Content Not Found</div>;
 };
 
 export default App;

--- a/packages/sdks/e2e/svelte/src/App.svelte
+++ b/packages/sdks/e2e/svelte/src/App.svelte
@@ -1,11 +1,8 @@
 <script>
   import { RenderContent } from '@builder.io/sdk-svelte';
-  import { getContentForPathname } from '@builder.io/sdks-e2e-tests';
+  import { getProps } from '@builder.io/sdks-e2e-tests';
 
-  // TODO: enter your public API key
-  const BUILDER_PUBLIC_API_KEY = 'f1a790f8c3204b3b8c5c1795aeac4660'; // ggignore
-
-  $: content = getContentForPathname();
+  $: props = getProps();
 </script>
 
 <svelte:head>
@@ -13,8 +10,8 @@
 </svelte:head>
 
 <main>
-  {#if content}
-    <RenderContent model="page" {content} apiKey={BUILDER_PUBLIC_API_KEY} />
+  {#if props}
+    <RenderContent {...props} />
   {:else}
     Content Not Found
   {/if}

--- a/packages/sdks/e2e/tests/src/index.ts
+++ b/packages/sdks/e2e/tests/src/index.ts
@@ -1,1 +1,1 @@
-export { getContentForPathname } from './specs/index.js';
+export { getProps } from './specs/index.js';

--- a/packages/sdks/e2e/tests/src/specs/index.ts
+++ b/packages/sdks/e2e/tests/src/specs/index.ts
@@ -34,6 +34,7 @@ export const getContentForPathname = (
 ): BuilderContent | null => {
   let contentWithoutBreakpoints = undefined;
   switch (pathname) {
+    case '/can-track-false':
     case '/':
       return homepage;
     case '/columns':
@@ -76,9 +77,17 @@ export const getProps = (
     return null;
   }
 
+  const extraProps =
+    pathname === '/can-track-false'
+      ? {
+          canTrack: false,
+        }
+      : {};
+
   return {
     content,
     apiKey: 'f1a790f8c3204b3b8c5c1795aeac4660',
     model: 'page',
+    ...extraProps,
   };
 };

--- a/packages/sdks/e2e/tests/src/specs/index.ts
+++ b/packages/sdks/e2e/tests/src/specs/index.ts
@@ -62,3 +62,23 @@ export const getContentForPathname = (
       return null;
   }
 };
+
+export const getProps = (
+  pathname = getPathnameFromWindow()
+): {
+  model: string;
+  content: BuilderContent;
+  apiKey: string;
+} | null => {
+  const content = getContentForPathname(pathname);
+
+  if (!content) {
+    return null;
+  }
+
+  return {
+    content,
+    apiKey: 'f1a790f8c3204b3b8c5c1795aeac4660',
+    model: 'page',
+  };
+};

--- a/packages/sdks/e2e/tests/src/tests/main.spec.ts
+++ b/packages/sdks/e2e/tests/src/tests/main.spec.ts
@@ -64,6 +64,7 @@ test.describe(targetContext.name, () => {
         (cookie) => cookie.name === 'builderSessionId'
       );
 
+      // react native sdk does not use cookies
       if (isRNSDK) {
         expect(builderSessionCookie).toBeUndefined();
       } else {

--- a/packages/sdks/e2e/tests/src/tests/main.spec.ts
+++ b/packages/sdks/e2e/tests/src/tests/main.spec.ts
@@ -68,21 +68,6 @@ const getBuilderSessionIdCookie = async ({
 
 test.describe(targetContext.name, () => {
   test.describe('cookies', () => {
-    test('appear by default', async ({ page, context }) => {
-      // by waiting for network requests, we guarantee that impression tracking POST was made,
-      // which guarantees that the cookie was set
-      await page.goto('/', { waitUntil: 'networkidle' });
-
-      const builderSessionCookie = await getBuilderSessionIdCookie({ context });
-
-      console.log({ builderSessionCookie });
-      // react native sdk does not use cookies
-      if (isRNSDK) {
-        expect(builderSessionCookie).toBeUndefined();
-      } else {
-        expect(builderSessionCookie).toBeDefined();
-      }
-    });
     test('do not appear if canTrack=false', async ({ page, context }) => {
       // by waiting for network requests, we guarantee that impression tracking POST was (NOT) made,
       // which guarantees that the cookie was set or not.
@@ -93,6 +78,20 @@ test.describe(targetContext.name, () => {
         (cookie) => cookie.name === 'builderSessionId'
       );
       expect(builderSessionCookie).toBeUndefined();
+    });
+    test('appear by default', async ({ page, context }) => {
+      // by waiting for network requests, we guarantee that impression tracking POST was made,
+      // which guarantees that the cookie was set
+      await page.goto('/', { waitUntil: 'networkidle' });
+
+      const builderSessionCookie = await getBuilderSessionIdCookie({ context });
+
+      // react native sdk does not use cookies
+      if (isRNSDK) {
+        expect(builderSessionCookie).toBeUndefined();
+      } else {
+        expect(builderSessionCookie).toBeDefined();
+      }
     });
   });
   test('homepage', async ({ page }) => {

--- a/packages/sdks/e2e/tests/src/tests/main.spec.ts
+++ b/packages/sdks/e2e/tests/src/tests/main.spec.ts
@@ -55,6 +55,26 @@ const expectStylesForElement = async ({
 };
 
 test.describe(targetContext.name, () => {
+  test.describe('cookies', () => {
+    test('appear by default', async ({ page, context }) => {
+      await page.goto('/');
+
+      const cookies = await context.cookies();
+      const builderSessionCookie = cookies.find(
+        (cookie) => cookie.name === 'builderSessionId'
+      );
+      expect(builderSessionCookie).toBeDefined();
+    });
+    test('do not appear if canTrack=false', async ({ page, context }) => {
+      await page.goto('/can-track-false');
+
+      const cookies = await context.cookies();
+      const builderSessionCookie = cookies.find(
+        (cookie) => cookie.name === 'builderSessionId'
+      );
+      expect(builderSessionCookie).toBeUndefined();
+    });
+  });
   test('homepage', async ({ page }) => {
     await page.goto('/');
 

--- a/packages/sdks/e2e/tests/src/tests/main.spec.ts
+++ b/packages/sdks/e2e/tests/src/tests/main.spec.ts
@@ -63,7 +63,12 @@ test.describe(targetContext.name, () => {
       const builderSessionCookie = cookies.find(
         (cookie) => cookie.name === 'builderSessionId'
       );
-      expect(builderSessionCookie).toBeDefined();
+
+      if (isRNSDK) {
+        expect(builderSessionCookie).toBeDefined();
+      } else {
+        expect(builderSessionCookie).toBeUndefined();
+      }
     });
     test('do not appear if canTrack=false', async ({ page, context }) => {
       await page.goto('/can-track-false');

--- a/packages/sdks/e2e/tests/src/tests/main.spec.ts
+++ b/packages/sdks/e2e/tests/src/tests/main.spec.ts
@@ -65,9 +65,9 @@ test.describe(targetContext.name, () => {
       );
 
       if (isRNSDK) {
-        expect(builderSessionCookie).toBeDefined();
-      } else {
         expect(builderSessionCookie).toBeUndefined();
+      } else {
+        expect(builderSessionCookie).toBeDefined();
       }
     });
     test('do not appear if canTrack=false', async ({ page, context }) => {

--- a/packages/sdks/e2e/tests/src/tests/main.spec.ts
+++ b/packages/sdks/e2e/tests/src/tests/main.spec.ts
@@ -1,4 +1,4 @@
-import type { Locator, Page } from '@playwright/test';
+import type { BrowserContext, Locator, Page } from '@playwright/test';
 import { test, expect } from '@playwright/test';
 
 import { targetContext } from './context.js';
@@ -54,16 +54,28 @@ const expectStylesForElement = async ({
   }
 };
 
+const getBuilderSessionIdCookie = async ({
+  context,
+}: {
+  context: BrowserContext;
+}) => {
+  const cookies = await context.cookies();
+  const builderSessionCookie = cookies.find(
+    (cookie) => cookie.name === 'builderSessionId'
+  );
+  return builderSessionCookie;
+};
+
 test.describe(targetContext.name, () => {
   test.describe('cookies', () => {
     test('appear by default', async ({ page, context }) => {
-      await page.goto('/');
+      // by waiting for network requests, we guarantee that impression tracking POST was made,
+      // which guarantees that the cookie was set
+      await page.goto('/', { waitUntil: 'networkidle' });
 
-      const cookies = await context.cookies();
-      const builderSessionCookie = cookies.find(
-        (cookie) => cookie.name === 'builderSessionId'
-      );
+      const builderSessionCookie = await getBuilderSessionIdCookie({ context });
 
+      console.log({ builderSessionCookie });
       // react native sdk does not use cookies
       if (isRNSDK) {
         expect(builderSessionCookie).toBeUndefined();
@@ -72,7 +84,9 @@ test.describe(targetContext.name, () => {
       }
     });
     test('do not appear if canTrack=false', async ({ page, context }) => {
-      await page.goto('/can-track-false');
+      // by waiting for network requests, we guarantee that impression tracking POST was (NOT) made,
+      // which guarantees that the cookie was set or not.
+      await page.goto('/can-track-false', { waitUntil: 'networkidle' });
 
       const cookies = await context.cookies();
       const builderSessionCookie = cookies.find(

--- a/packages/sdks/e2e/vue-2/src/App.vue
+++ b/packages/sdks/e2e/vue-2/src/App.vue
@@ -1,13 +1,13 @@
 <template>
-  <div v-if="content">
-    <builder-render-content model="page" :content="content" />
+  <div v-if="props.content">
+    <builder-render-content v-bind="props" />
   </div>
   <div v-else>Content not Found</div>
 </template>
 <script lang="ts">
-import { RenderContent } from '@builder.io/sdk-vue/vue2';
+import { RenderContent } from '@builder.io/sdk-vue';
 import '@builder.io/sdk-vue/vue2/css';
-import { getContentForPathname } from '@builder.io/sdks-e2e-tests';
+import { getProps } from '@builder.io/sdks-e2e-tests';
 
 export default {
   name: 'DynamicallyRenderBuilderPage',
@@ -15,8 +15,8 @@ export default {
     'builder-render-content': RenderContent,
   },
   computed: {
-    content(): any {
-      return getContentForPathname();
+    props() {
+      return getProps();
     },
   },
 };

--- a/packages/sdks/e2e/vue-3/src/App.vue
+++ b/packages/sdks/e2e/vue-3/src/App.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { RenderContent } from '@builder.io/sdk-vue/vue3';
 import '@builder.io/sdk-vue/vue3/css';
-import { getContentForPathname } from '@builder.io/sdks-e2e-tests';
+import { getProps } from '@builder.io/sdks-e2e-tests';
 
 export default {
   name: 'DynamicallyRenderBuilderPage',
@@ -9,16 +9,16 @@ export default {
     'builder-render-content': RenderContent,
   },
   computed: {
-    content(): any {
-      return getContentForPathname();
+    props() {
+      return getProps();
     },
   },
 };
 </script>
 
 <template>
-  <div v-if="content">
-    <builder-render-content model="page" :content="content" />
+  <div v-if="props">
+    <builder-render-content v-bind="props" />
   </div>
   <div v-else>Content not Found</div>
 </template>

--- a/packages/sdks/package.json
+++ b/packages/sdks/package.json
@@ -30,7 +30,7 @@
     "ci:lint": "yarn run prettier --check && yarn run eslint",
     "ci:build": "yarn run typecheck && yarn run build",
     "ci:test": "yarn run test",
-    "e2e:install-playwright": "playwright install --with-deps",
+    "e2e:install-playwright": "playwright install chromium --with-deps",
     "e2e:build:specs": "yarn workspace @builder.io/sdks-e2e-tests build",
     "e2e:build:svelte": "yarn workspaces foreach --verbose --include \"@builder.io/e2e-svelte*\" run build",
     "e2e:build:react-native": "yarn workspaces foreach --verbose --include \"@builder.io/e2e-react-native*\" run build",

--- a/packages/sdks/src/components/render-content/render-content.lite.tsx
+++ b/packages/sdks/src/components/render-content/render-content.lite.tsx
@@ -39,6 +39,7 @@ import {
   registerInsertMenu,
   setupBrowserForEditing,
 } from '../../scripts/init-editing.js';
+import { checkIsDefined } from '../../helpers/nullable.js';
 
 useMetadata({
   qwik: {
@@ -108,7 +109,7 @@ export default function RenderContent(props: RenderContentProps) {
     update: 0,
     useBreakpoints: null as Nullable<Breakpoints>,
     get canTrackToUse(): boolean {
-      return props.canTrack || true;
+      return checkIsDefined(props.canTrack) ? props.canTrack : true;
     },
     overrideState: {} as BuilderRenderState,
     get contentState(): BuilderRenderState {

--- a/packages/sdks/src/helpers/cookie.ts
+++ b/packages/sdks/src/helpers/cookie.ts
@@ -1,5 +1,6 @@
 import { isBrowser } from '../functions/is-browser.js';
 import type { CanTrack } from '../types/can-track.js';
+import { checkIsDefined } from './nullable.js';
 import { getTopLevelDomain } from './url.js';
 
 /**
@@ -40,7 +41,10 @@ type CookieConfiguration = Array<
 >;
 
 const stringifyCookie = (cookie: CookieConfiguration): string =>
-  cookie.map(([key, value]) => (value ? `${key}=${value}` : key)).join('; ');
+  cookie
+    .map(([key, value]) => (value ? `${key}=${value}` : key))
+    .filter(checkIsDefined)
+    .join('; ');
 
 const SECURE_CONFIG: CookieConfiguration = [
   ['secure', ''],

--- a/packages/sdks/src/helpers/sessionId.ts
+++ b/packages/sdks/src/helpers/sessionId.ts
@@ -5,11 +5,7 @@ import { uuid } from './uuid.js';
 
 const SESSION_LOCAL_STORAGE_KEY = 'builderSessionId';
 
-export const getSessionId = async ({ canTrack }: CanTrack) => {
-  if (!canTrack) {
-    return undefined;
-  }
-
+const _getSessionId = async ({ canTrack }: CanTrack): Promise<string> => {
   const sessionId = await getCookie({
     name: SESSION_LOCAL_STORAGE_KEY,
     canTrack,
@@ -20,7 +16,21 @@ export const getSessionId = async ({ canTrack }: CanTrack) => {
   } else {
     const newSessionId = createSessionId();
     setSessionId({ id: newSessionId, canTrack });
+
+    return newSessionId;
   }
+};
+
+export const getSessionId = async ({
+  canTrack,
+}: CanTrack): Promise<string | undefined> => {
+  if (!canTrack) {
+    return undefined;
+  }
+
+  const sessionId = await _getSessionId({ canTrack });
+
+  return sessionId;
 };
 
 export const createSessionId = () => uuid();

--- a/packages/sdks/src/helpers/url.test.ts
+++ b/packages/sdks/src/helpers/url.test.ts
@@ -13,4 +13,11 @@ describe('getTopLevelDomain', () => {
     const output = getTopLevelDomain('www.example.co.uk');
     expect(output).toBe('example.co.uk');
   });
+  test('handles localhost', () => {
+    const output = getTopLevelDomain('localhost');
+    expect(output).toBe('localhost');
+
+    const output2 = getTopLevelDomain('127.0.0.1');
+    expect(output2).toBe('127.0.0.1');
+  });
 });

--- a/packages/sdks/src/helpers/url.ts
+++ b/packages/sdks/src/helpers/url.ts
@@ -4,6 +4,10 @@
  * www.example.co.uk -> example.co.uk
  */
 export const getTopLevelDomain = (host: string) => {
+  if (host === 'localhost' || host === '127.0.0.1') {
+    return host;
+  }
+
   const parts = host.split('.');
   if (parts.length > 2) {
     return parts.slice(1).join('.');


### PR DESCRIPTION
## Description

- improve e2e tests to handle more props cases
- fix cookie generation
- fix sessionId being sent w/ first tracking events
- fix canTrack code to respect `canTrack: false`