### PR TITLE
[examples/astro-solid] add jsx settings to tsconfig

### DIFF
--- a/examples/astro-solidjs/tsconfig.json
+++ b/examples/astro-solidjs/tsconfig.json
@@ -10,6 +10,8 @@
     // Enable stricter transpilation for better output.
     "isolatedModules": true,
     // Add type definitions for our Vite runtime.
-    "types": ["vite/client"]
+    "types": ["vite/client"],
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js"
   }
 }


### PR DESCRIPTION
## Description

Add `jsx` related setting in ts config complier options. These options give the typescript compiler jsx related info:
- to leave the jsx untouched
- the package path from where to import jsx elements (requried for `For` and `Show` components from solid-js)
