### PR TITLE
Upgraded to use latest webcomponents version to get support for custom breakpoints

### DIFF
--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -41,6 +41,7 @@ Install:
 
 ```
 npm install @builder.io/angular
+npm install @angular/elements
 ```
 
 Add the module:

--- a/packages/angular/src/app/modules/builder/components/builder-component/builder-component.component.ts
+++ b/packages/angular/src/app/modules/builder/components/builder-component/builder-component.component.ts
@@ -109,7 +109,6 @@ export class BuilderComponentComponent implements OnDestroy, OnInit, OnChanges {
   ) {}
 
   async ensureWCScriptLoaded() {
-    const SCRIPT_ID = 'builder-wc-script';
     if (!Builder.isBrowser || wcScriptInserted || document.getElementById(SCRIPT_ID)) {
       return;
     }
@@ -125,8 +124,6 @@ export class BuilderComponentComponent implements OnDestroy, OnInit, OnChanges {
       return null;
     }
     const script = document.createElement('script');
-    // TODO remove hardcoded version, maybe a release tag?
-    const ANGULAR_LATEST_VERSION = '1.3.47';
     const wcVersion = getQueryParam(location.href, 'builder.wcVersion') || ANGULAR_LATEST_VERSION;
     script.id = SCRIPT_ID;
     // TODO: detect builder.wcVersion and if customEleemnts exists and do

--- a/packages/angular/src/app/modules/builder/utils/constants.ts
+++ b/packages/angular/src/app/modules/builder/utils/constants.ts
@@ -1,0 +1,3 @@
+// TODO remove hardcoded version, maybe a release tag?
+const ANGULAR_LATEST_VERSION = '1.3.49';
+const SCRIPT_ID = 'builder-wc-script';


### PR DESCRIPTION
## Description
Upgraded the webcomponents sdk script version used in the sdk to recent version, that uses the latest react sdk (supporting custom breakpoints feature)

Note: This change needs to be deployed after the webcomponents change with v1.3.49 is deployed.