### PR TITLE
Add back getRequestUrl to fix issue dependency in angular sdk

### DIFF
--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -2211,6 +2211,13 @@ export class Builder {
     return observable;
   }
 
+  requestUrl(
+    url: string,
+    options?: { headers: { [header: string]: number | string | string[] | undefined } }
+  ) {
+    return fetch(url, options as SimplifiedFetchOptions).then(res => res.json());
+  }
+
   get host() {
     switch (this.env) {
       case 'qa':

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -2211,6 +2211,9 @@ export class Builder {
     return observable;
   }
 
+  // this is needed to satisfy the Angular SDK, which used to rely on the more complex version of `requestUrl`.
+  // even though we only use `fetch()` now, we prefer to keep the old behavior and use the `fetch` that comes from
+  // the core SDK for consistency
   requestUrl(
     url: string,
     options?: { headers: { [header: string]: number | string | string[] | undefined } }


### PR DESCRIPTION
## Description
`getRequestUrl` in Builder.class as refactored out. However, downstream modules like angular sdk still use them. This is a fix so that those modules keep working as before.
getRequestUrl now simply delegates to the 'fetch' helper.
