### PR TITLE
fix style declarations for remix

### DIFF
--- a/packages/angular/src/app/modules/builder/interfaces/element.interface.ts
+++ b/packages/angular/src/app/modules/builder/interfaces/element.interface.ts
@@ -1,5 +1,5 @@
 export interface Element {
-  style: Partial<CSSStyleDeclaration>;
+  style: Record<keyof CSSStyleDeclaration, string>;
   children: Element[];
   text?: string;
   tagName?: string;

--- a/packages/core/src/types/element.ts
+++ b/packages/core/src/types/element.ts
@@ -21,11 +21,11 @@ export interface BuilderElement {
   class?: string;
   children?: BuilderElement[];
   responsiveStyles?: {
-    large?: Partial<CSSStyleDeclaration>;
-    medium?: Partial<CSSStyleDeclaration>;
-    small?: Partial<CSSStyleDeclaration>;
+    large?: Record<keyof CSSStyleDeclaration, string>;
+    medium?: Record<keyof CSSStyleDeclaration, string>;
+    small?: Record<keyof CSSStyleDeclaration, string>;
     /** @deprecated */
-    xsmall?: Partial<CSSStyleDeclaration>;
+    xsmall?: Record<keyof CSSStyleDeclaration, string>;
   };
   component?: {
     name: string;

--- a/packages/json-schema/src/index.ts
+++ b/packages/json-schema/src/index.ts
@@ -41,11 +41,11 @@ export interface BuilderElement {
   class?: string;
   children?: BuilderElement[];
   responsiveStyles?: {
-    large?: Partial<CSSStyleDeclaration>;
-    medium?: Partial<CSSStyleDeclaration>;
-    small?: Partial<CSSStyleDeclaration>;
+    large?: Record<keyof CSSStyleDeclaration, string>;
+    medium?: Record<keyof CSSStyleDeclaration, string>;
+    small?: Record<keyof CSSStyleDeclaration, string>;
     /** @deprecated */
-    xsmall?: Partial<CSSStyleDeclaration>;
+    xsmall?: Record<keyof CSSStyleDeclaration, string>;
   };
   component?: {
     name: string;


### PR DESCRIPTION
I noticed we have an ugly workaround in our docs and examples

The problem with the workaround is it completely omits `content.data` which is a bad idea - people need to use `data` for custom fields, so this is the actual fix I [mentioned previously](https://github.com/BuilderIO/builder/issues/1387#issuecomment-1397442797)