### PR TITLE
New command for CLI tool: add-model

### DIFF
--- a/packages/cli/src/admin-sdk.ts
+++ b/packages/cli/src/admin-sdk.ts
@@ -4,7 +4,6 @@ import { kebabCase, omit } from 'lodash';
 import chalk from 'chalk';
 import { readAsJson, getFiles, getDirectories, replaceField, updateIdsMap, replaceIds } from './utils';
 import cliProgress from 'cli-progress';
-import traverse from 'traverse';
 
 const MULTIBAR = new cliProgress.MultiBar(
   {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@
 
 import program from 'commander';
 import chalk from 'chalk';
-import { importSpace, newSpace } from './admin-sdk';
+import { importSpace, newSpace, addModel } from './admin-sdk';
 import { integrateWithLocalCodebase } from './integrate';
 const figlet = require('figlet');
 
@@ -50,5 +50,15 @@ program
   .action(async options => {
     await integrateWithLocalCodebase(options);
   });
+
+program
+  .command('add-model')
+  .description('Add a Builder model to an existing space')
+  .option('-k,--key <key>', 'Private key')
+  .option('-i,--input <input>', 'Path to folder default to ./builder', './builder')
+  .option('-m,--model <model>', 'name of the model that you want to add')
+  .action(options => {
+    addModel(options.key, options.input, options.model)
+  })
 
 program.parse(process.argv);


### PR DESCRIPTION
## Description

Create a new command for the CLI tool: `add-model`, uploads a model definition downloaded from `builder import` to a target space.

Example:

`builder add-model -k bpk-******** -m my-model -i ./downloaded-builder-content`
