### PR TITLE
fix(sfcc-sync) disable url updates in favor of the dynamic url feature

### DIFF
--- a/plugins/sfcc-sync/package-lock.json
+++ b/plugins/sfcc-sync/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-sfcc-sync",
-  "version": "0.0.8",
+  "version": "0.0.9-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/plugins/sfcc-sync/package.json
+++ b/plugins/sfcc-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-sfcc-sync",
-  "version": "0.0.8",
+  "version": "0.0.9-1",
   "description": "",
   "keywords": [],
   "main": "dist/plugin.system.js",

--- a/plugins/sfcc-sync/src/on-editor-load.ts
+++ b/plugins/sfcc-sync/src/on-editor-load.ts
@@ -14,6 +14,10 @@ interface ContentEditorActions {
 }
 
 export const onContentEditorLoad = ({ safeReaction, updatePreviewUrl }: ContentEditorActions) => {
+  const pluginSettings = appState.user.organization.value.settings.plugins?.get(pkg.name);
+  if (pluginSettings?.get('disableURLUpdates')) {
+    return;
+  }
   safeReaction(
     () =>
       appState.designerState.editingContentModel?.meta.get('sfccPreviewOptions') ||

--- a/plugins/sfcc-sync/src/plugin.ts
+++ b/plugins/sfcc-sync/src/plugin.ts
@@ -51,6 +51,13 @@ Builder.register('plugin', {
       type: 'url',
       helperText: 'An optional URL prefix for the preview area, e.g: /us/en/',
     },
+    {
+      name: 'disableURLUpdates',
+      friendlyName: 'Disable preview URL updates',
+      type: 'boolean',
+      advanced: true,
+      helperText: 'by default the preview URL will be updated to match the SFCC preview URL, disable this if you want to use your own preview URL',
+    },
   ],
 
   ctaText: 'Connect',

--- a/plugins/sfcc-sync/src/plugin.ts
+++ b/plugins/sfcc-sync/src/plugin.ts
@@ -56,7 +56,8 @@ Builder.register('plugin', {
       friendlyName: 'Disable preview URL updates',
       type: 'boolean',
       advanced: true,
-      helperText: 'by default the preview URL will be updated to match the SFCC preview URL, disable this if you want to use your own preview URL',
+      helperText:
+        'by default the preview URL will be updated to match the SFCC preview URL, disable this if you want to use your own preview URL',
     },
   ],
 


### PR DESCRIPTION
This was added before we had the dynamic URL feature, and it proved problematic in some cases, adding an option here as a first step to deprecating the behavior completely