### PR TITLE
[Admin CLI] Fix Admin SDK to respect cases with multiple content entries with same name

### DIFF
--- a/packages/cli/src/admin-sdk.ts
+++ b/packages/cli/src/admin-sdk.ts
@@ -77,7 +77,7 @@ export const importSpace = async (
       );
       await Promise.all(
         content.map(async (entry, index) => {
-          let filename = `${directory}/${modelName}/${kebabCase(entry.name)}-${index}.json`;
+          const filename = `${directory}/${modelName}/${kebabCase(entry.name)}-${index}.json`;
           await fse.outputFile(filename, JSON.stringify(entry, undefined, 2));
           modelProgress.increment(1, { name: ` ${modelName}: ${filename} ` });
         })
@@ -110,12 +110,6 @@ export const newSpace = async (
 
   const spaceSettings = await readAsJson(`${directory}/settings.json`);
   try {
-    console.log('Calling create space with', {
-      settings: {
-        ...omit(spaceSettings, 'cloneInfo'),
-        name: name || spaceSettings.name,
-      },
-    });
     const { organization, privateKey: newSpacePrivateKey } = await graphqlClient.chain.mutation
       .createSpace({
         settings: {

--- a/packages/cli/src/admin-sdk.ts
+++ b/packages/cli/src/admin-sdk.ts
@@ -77,7 +77,7 @@ export const importSpace = async (
       );
       await Promise.all(
         content.map(async (entry, index) => {
-          const filename = `${directory}/${modelName}/${kebabCase(entry.name)}.json`;
+          let filename = `${directory}/${modelName}/${kebabCase(entry.name)}-${index}.json`;
           await fse.outputFile(filename, JSON.stringify(entry, undefined, 2));
           modelProgress.increment(1, { name: ` ${modelName}: ${filename} ` });
         })
@@ -110,6 +110,12 @@ export const newSpace = async (
 
   const spaceSettings = await readAsJson(`${directory}/settings.json`);
   try {
+    console.log('Calling create space with', {
+      settings: {
+        ...omit(spaceSettings, 'cloneInfo'),
+        name: name || spaceSettings.name,
+      },
+    });
     const { organization, privateKey: newSpacePrivateKey } = await graphqlClient.chain.mutation
       .createSpace({
         settings: {


### PR DESCRIPTION
## Description

Fixing bug found which blows up when there are multiple content entries with the same name while importing. Because we were using the name of the content entry as the file name, and there were multiple file writes happening at the same time to the same file, there were collisions causing broken JSON.

This changes the files to be generated with the index so that collisions cannot happen.