### PR TITLE
Fix: Sdks: Button styles

### DIFF
--- a/packages/sdks/src/blocks/button/button.lite.tsx
+++ b/packages/sdks/src/blocks/button/button.lite.tsx
@@ -14,7 +14,12 @@ export default function Button(props: ButtonProps) {
       else={
         <button
           css={{ all: 'unset' }}
-          class={props.attributes.class}
+          class={
+            /**
+             * We have to explicitly provide `class` so that Mitosis knows to merge it with `css`.
+             */
+            props.attributes.class
+          }
           {...props.attributes}
         >
           {props.text}

--- a/packages/sdks/src/blocks/button/button.lite.tsx
+++ b/packages/sdks/src/blocks/button/button.lite.tsx
@@ -12,7 +12,11 @@ export default function Button(props: ButtonProps) {
     <Show
       when={props.link}
       else={
-        <button css={{ all: 'unset' }} {...props.attributes}>
+        <button
+          css={{ all: 'unset' }}
+          class={props.attributes.class}
+          {...props.attributes}
+        >
           {props.text}
         </button>
       }


### PR DESCRIPTION
## Description

We have to explicitly provide `class` so that Mitosis knows to combine it with the `css` prop output