### PR TITLE
ENG-3574 fix setPixelProperties issue

### DIFF
--- a/packages/utils/src/set-pixel-properties.ts
+++ b/packages/utils/src/set-pixel-properties.ts
@@ -2,7 +2,7 @@ import { BuilderContent, BuilderElement } from '@builder.io/sdk';
 import traverse from 'traverse';
 
 const isBuilderPixel = (item: unknown): item is BuilderElement => {
-  return (item as any).id?.startsWith('builder-pixel');
+  return (item as any)?.id?.startsWith('builder-pixel');
 };
 
 export function setPixelProperties(


### PR DESCRIPTION
## Description

This PR adds a check for the item to be defined and not null before checking if its a Builder Pixel.
