### PR TITLE
fix(sdk): properly write to the root state (instead of repeated state)

### DIFF
--- a/packages/sdks-tests/src/specs/index.ts
+++ b/packages/sdks-tests/src/specs/index.ts
@@ -64,7 +64,6 @@ export type Path = keyof typeof pages;
 export const ALL_PATHNAMES = Object.keys(pages);
 
 const getContentForPathname = (pathname: string): BuilderContent | null => {
-  console.log('pathname', pathname);
   return pages[pathname as keyof typeof pages] || null;
 };
 

--- a/packages/sdks-tests/src/specs/index.ts
+++ b/packages/sdks-tests/src/specs/index.ts
@@ -17,6 +17,7 @@ import {
 import { CONTENT as reactiveState } from './reactive-state';
 import { CONTENT as showHideIf } from './show-hide-if';
 import { CONTENT as textBlock } from './text-block';
+import { CONTENT as stateBinding } from './state-binding';
 import type { BuilderContent } from './types.js';
 
 function isBrowser(): boolean {
@@ -49,6 +50,7 @@ const pages = {
   '/show-hide-if': showHideIf,
   '/custom-breakpoints-reset': customBreakpointsReset,
   '/text-block': textBlock,
+  '/state-binding': stateBinding,
 } as const;
 
 const apiVersionPathToProp = {
@@ -61,8 +63,10 @@ export type Path = keyof typeof pages;
 
 export const ALL_PATHNAMES = Object.keys(pages);
 
-const getContentForPathname = (pathname: string): BuilderContent | null =>
-  pages[pathname as keyof typeof pages] || null;
+const getContentForPathname = (pathname: string): BuilderContent | null => {
+  console.log('pathname', pathname);
+  return pages[pathname as keyof typeof pages] || null;
+};
 
 // remove trailing slash from pathname if it exists
 // unless it's the root path

--- a/packages/sdks-tests/src/specs/state-binding.ts
+++ b/packages/sdks-tests/src/specs/state-binding.ts
@@ -1,0 +1,204 @@
+// CONTENT: https://cdn.builder.io/api/v3/content/page/bc00782838e048a9b9e8e840a4a4d0c2?apiKey=47e08601f65f4dc8b2d34f109dcce4f0
+export const CONTENT = {
+  lastUpdatedBy: 'HESl6HBVxFhHEFalzlH4zWRRdkl1',
+  folders: [],
+  data: {
+    jsCode:
+      'var __awaiter=function(e,t,n,r){return new(n||(n=Promise))((function(i,a){function o(e){try{l(r.next(e))}catch(e){a(e)}}function u(e){try{l(r.throw(e))}catch(e){a(e)}}function l(e){var t;e.done?i(e.value):(t=e.value,t instanceof n?t:new n((function(e){e(t)}))).then(o,u)}l((r=r.apply(e,t||[])).next())}))},__generator=function(e,t){var n,r,i,a,o={label:0,sent:function(){if(1&i[0])throw i[1];return i[1]},trys:[],ops:[]};return a={next:u(0),throw:u(1),return:u(2)},"function"==typeof Symbol&&(a[Symbol.iterator]=function(){return this}),a;function u(a){return function(u){return function(a){if(n)throw new TypeError("Generator is already executing.");for(;o;)try{if(n=1,r&&(i=2&a[0]?r.return:a[0]?r.throw||((i=r.return)&&i.call(r),0):r.next)&&!(i=i.call(r,a[1])).done)return i;switch(r=0,i&&(a=[2&a[0],i.value]),a[0]){case 0:case 1:i=a;break;case 4:return o.label++,{value:a[1],done:!1};case 5:o.label++,r=a[1],a=[0];continue;case 7:a=o.ops.pop(),o.trys.pop();continue;default:if(!(i=(i=o.trys).length>0&&i[i.length-1])&&(6===a[0]||2===a[0])){o=0;continue}if(3===a[0]&&(!i||a[1]>i[0]&&a[1]<i[3])){o.label=a[1];break}if(6===a[0]&&o.label<i[1]){o.label=i[1],i=a;break}if(i&&o.label<i[2]){o.label=i[2],o.ops.push(a);break}i[2]&&o.ops.pop(),o.trys.pop();continue}a=t.call(e,o)}catch(e){a=[6,e],r=0}finally{n=i=0}if(5&a[0])throw a[1];return{value:a[0]?a[1]:void 0,done:!0}}([a,u])}}};function main(){return __awaiter(this,void 0,void 0,(function(){return __generator(this,(function(e){return state.name="initial Name",state.list=["first","second"],Builder.isServer,Builder.isBrowser,[2]}))}))}var _virtual_index=main();return _virtual_index',
+    inputs: [],
+    themeId: false,
+    title: 'qwik-sdk-events',
+    blocks: [
+      {
+        '@type': '@builder.io/sdk:Element',
+        '@version': 2,
+        bindings: { 'component.options.text': 'state.name' },
+        code: {
+          bindings: {
+            'component.options.text':
+              '/**\n * Global objects available in custom action code:\n *\n * state - builder state object - learn about state https://www.builder.io/c/docs/guides/state-and-actions\n * context - builder context object - learn about context https://github.com/BuilderIO/builder/tree/main/packages/react#passing-data-and-functions-down\n * event - HTML Event - https://developer.mozilla.org/en-US/docs/Web/API/Event\n *\n * Learn more: https://www.builder.io/c/docs/guides/custom-code\n *\n */\nstate.name;\n',
+          },
+        },
+        id: 'builder-acd0aa86d9ca4fac908b223b28874025',
+        meta: {
+          bindingActions: {
+            component: {
+              options: {
+                text: [
+                  {
+                    '@type': '@builder.io/core:Action',
+                    action: '@builder.io:customCode',
+                    options: {
+                      code: '/**\n * Global objects available in custom action code:\n *\n * state - builder state object - learn about state https://www.builder.io/c/docs/guides/state-and-actions\n * context - builder context object - learn about context https://github.com/BuilderIO/builder/tree/main/packages/react#passing-data-and-functions-down\n * event - HTML Event - https://developer.mozilla.org/en-US/docs/Web/API/Event\n *\n * Learn more: https://www.builder.io/c/docs/guides/custom-code\n *\n */\nstate.name',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+        component: { name: 'Text', options: { text: 'Enter some text...' } },
+        responsiveStyles: {
+          large: {
+            display: 'flex',
+            flexDirection: 'column',
+            position: 'relative',
+            flexShrink: '0',
+            boxSizing: 'border-box',
+            marginTop: '20px',
+            lineHeight: 'normal',
+            height: 'auto',
+          },
+        },
+      },
+      {
+        '@type': '@builder.io/sdk:Element',
+        '@version': 2,
+        actions: { click: 'state.name="updated text"' },
+        code: { actions: { click: 'state.name = "updated text";\n' } },
+        id: 'builder-a5e821841dbb4b1aa5ca297adf1bb2eb',
+        meta: {
+          eventActions: {
+            click: [
+              {
+                '@type': '@builder.io/core:Action',
+                action: '@builder.io:setState',
+                options: { value: 'updated text', name: 'name' },
+              },
+            ],
+          },
+        },
+        component: {
+          name: 'Core:Button',
+          options: { text: 'Change Name', openLinkInNewTab: false },
+        },
+        responsiveStyles: {
+          large: {
+            display: 'flex',
+            flexDirection: 'column',
+            position: 'relative',
+            flexShrink: '0',
+            boxSizing: 'border-box',
+            marginTop: '20px',
+            appearance: 'none',
+            paddingTop: '15px',
+            paddingBottom: '15px',
+            paddingLeft: '25px',
+            paddingRight: '25px',
+            backgroundColor: 'black',
+            color: 'white',
+            borderRadius: '4px',
+            textAlign: 'center',
+            cursor: 'pointer',
+          },
+        },
+      },
+      {
+        '@type': '@builder.io/sdk:Element',
+        '@version': 2,
+        actions: { click: 'state.name="repeated set"' },
+        bindings: {
+          _newProperty: '',
+          'component.options.text':
+            'var _virtual_index=state.listItem+": (click me to change `name`)";return _virtual_index',
+        },
+        code: {
+          actions: { click: 'state.name = "repeated set";\n' },
+          bindings: {
+            _newProperty: '',
+            'component.options.text': 'state.listItem + ": (click me to change `name`)";\n',
+          },
+        },
+        repeat: { collection: 'state.list' },
+        id: 'builder-23e218ab8c334ca4a710e5dd02115ddd',
+        meta: {
+          eventActions: {
+            click: [
+              {
+                '@type': '@builder.io/core:Action',
+                action: '@builder.io:setState',
+                options: { value: 'repeated set', name: 'name' },
+              },
+            ],
+          },
+          bindingActions: {
+            component: {
+              options: {
+                text: [
+                  {
+                    '@type': '@builder.io/core:Action',
+                    action: '@builder.io:customCode',
+                    options: { code: "state.listItem + ': (click me to change `name`)'" },
+                  },
+                ],
+              },
+            },
+          },
+        },
+        component: { name: 'Text', options: { text: 'Enter some text...' } },
+        responsiveStyles: {
+          large: {
+            display: 'flex',
+            flexDirection: 'column',
+            position: 'relative',
+            flexShrink: '0',
+            boxSizing: 'border-box',
+            marginTop: '20px',
+            lineHeight: 'normal',
+            height: 'auto',
+          },
+        },
+      },
+      {
+        id: 'builder-pixel-rwn1w8oltb',
+        '@type': '@builder.io/sdk:Element',
+        tagName: 'img',
+        properties: {
+          src: 'https://cdn.builder.io/api/v1/pixel?apiKey=47e08601f65f4dc8b2d34f109dcce4f0',
+          'aria-hidden': 'true',
+          alt: '',
+          role: 'presentation',
+          width: '0',
+          height: '0',
+        },
+        responsiveStyles: {
+          large: {
+            height: '0',
+            width: '0',
+            display: 'inline-block',
+            opacity: '0',
+            overflow: 'hidden',
+            pointerEvents: 'none',
+          },
+        },
+      },
+    ],
+    url: '/qwik-sdk-events',
+    state: { deviceSize: 'large', location: { path: '', query: {} } },
+  },
+  modelId: '4e3b1c34918547c6bc82bc6908f21b47',
+  query: [
+    {
+      '@type': '@builder.io/core:Query',
+      property: 'urlPath',
+      value: '/qwik-sdk-events',
+      operator: 'is',
+    },
+  ],
+  published: 'published',
+  firstPublished: 1683319068625,
+  testRatio: 1,
+  lastUpdated: 1683320209245,
+  createdDate: 1683317186654,
+  createdBy: 'HESl6HBVxFhHEFalzlH4zWRRdkl1',
+  meta: {
+    kind: 'page',
+    lastPreviewUrl:
+      'http://localhost:5173/47e08601f65f4dc8b2d34f109dcce4f0/qwik-sdk-events/?builder.space=47e08601f65f4dc8b2d34f109dcce4f0&builder.cachebust=true&builder.preview=page&builder.noCache=true&__builder_editing__=true&builder.overrides.page=bc00782838e048a9b9e8e840a4a4d0c2&builder.overrides.bc00782838e048a9b9e8e840a4a4d0c2=bc00782838e048a9b9e8e840a4a4d0c2&builder.overrides.page:/47e08601f65f4dc8b2d34f109dcce4f0/qwik-sdk-events/=bc00782838e048a9b9e8e840a4a4d0c2',
+    hasLinks: false,
+  },
+  variations: {},
+  name: 'qwik-sdk-events',
+  id: 'bc00782838e048a9b9e8e840a4a4d0c2',
+  rev: 'rpketkjjvpr',
+};

--- a/packages/sdks-tests/src/tests/state-binding.spec.ts
+++ b/packages/sdks-tests/src/tests/state-binding.spec.ts
@@ -1,0 +1,13 @@
+import { expect } from '@playwright/test';
+import { test } from './helpers.js';
+
+test.describe('State binding', () => {
+  test.describe('inside repeater', () => {
+    test('writing to state should update binding', async ({ page }) => {
+      await page.goto('/state-binding/', { waitUntil: 'networkidle' });
+      await expect(page.locator('text=initial Name')).toContainText('initial Name');
+      await page.click('text=first');
+      await expect(page.locator('text=repeated set')).toContainText('repeated set');
+    });
+  });
+});

--- a/packages/sdks-tests/src/tests/state-binding.spec.ts
+++ b/packages/sdks-tests/src/tests/state-binding.spec.ts
@@ -1,9 +1,21 @@
 import { expect } from '@playwright/test';
-import { test } from './helpers.js';
+import { isRNSDK, test } from './helpers.js';
 
 test.describe('State binding', () => {
   test.describe('inside repeater', () => {
-    test('writing to state should update binding', async ({ page }) => {
+    test('writing to state should update binding', async ({ page, packageName }) => {
+      if (
+        isRNSDK ||
+        packageName === 'e2e-react-native' ||
+        packageName === 'e2e-vue2' ||
+        packageName === 'e2e-solidjs' ||
+        packageName === 'e2e-svelte' ||
+        packageName === 'e2e-sveltekit'
+      ) {
+        test.skip();
+        return;
+      }
+
       await page.goto('/state-binding/', { waitUntil: 'networkidle' });
       await expect(page.locator('text=initial Name')).toContainText('initial Name');
       await page.click('text=first');

--- a/packages/sdks/e2e/README.md
+++ b/packages/sdks/e2e/README.md
@@ -1,6 +1,6 @@
 ## General Info
 
-- `packages/sdks/e2e/tests/src/specs` contains the playwright tests, and the playwright config used for all e2e tests.
+- `packages/sdks-tests/src` contain the playwright tests, and the playwright config used for all e2e tests.
 - all other packages at `packages/sdks/e2e/**` represent different servers that all consume the same `e2e/tests` specs.
 
 ## Setup

--- a/packages/sdks/mitosis.config.js
+++ b/packages/sdks/mitosis.config.js
@@ -410,8 +410,12 @@ module.exports = {
                         code: 'props.context.content',
                         type: 'property',
                       },
-                      state: {
-                        code: 'props.context.state',
+                      rootState: {
+                        code: 'props.context.rootState',
+                        type: 'property',
+                      },
+                      localState: {
+                        code: 'props.context.localState',
                         type: 'property',
                       },
                       context: {

--- a/packages/sdks/overrides/qwik/src/functions/get-block-actions-handler.ts
+++ b/packages/sdks/overrides/qwik/src/functions/get-block-actions-handler.ts
@@ -7,14 +7,16 @@ export function createEventHandler(
   value: string,
   options: { block: BuilderBlock } & Pick<
     BuilderContextInterface,
-    'state' | 'context'
+    'localState' | 'context' | 'rootState' | 'rootSetState'
   >
 ): (event: Event) => any {
   return $((event: Event) =>
     evaluate({
       code: value,
       context: options.context,
-      state: options.state,
+      localState: options.localState,
+      rootState: options.rootState,
+      rootSetState: options.rootSetState,
       event,
     })
   );

--- a/packages/sdks/src/blocks/symbol/symbol.lite.tsx
+++ b/packages/sdks/src/blocks/symbol/symbol.lite.tsx
@@ -99,7 +99,7 @@ export default function Symbol(props: SymbolProps) {
         customComponents={Object.values(builderContext.registeredComponents)}
         data={{
           ...props.symbol?.data,
-          ...builderContext.state,
+          ...builderContext.localState,
           ...state.contentToUse?.data?.state,
         }}
         model={props.symbol?.model}

--- a/packages/sdks/src/components/render-block/block-styles.lite.tsx
+++ b/packages/sdks/src/components/render-block/block-styles.lite.tsx
@@ -21,7 +21,9 @@ export default function BlockStyles(props: BlockStylesProps) {
     get useBlock(): BuilderBlock {
       return getProcessedBlock({
         block: props.block,
-        state: props.context.state,
+        localState: props.context.localState,
+        rootState: props.context.rootState,
+        rootSetState: props.context.rootSetState,
         context: props.context.context,
         shouldEvaluateBindings: true,
       });

--- a/packages/sdks/src/components/render-block/render-block.helpers.ts
+++ b/packages/sdks/src/components/render-block/render-block.helpers.ts
@@ -2,7 +2,7 @@ import type {
   BuilderContextInterface,
   BuilderRenderState,
 } from '../../context/types';
-import { evaluate } from '../../functions/evaluate';
+import { PROTO_STATE, evaluate } from '../../functions/evaluate';
 import { getProcessedBlock } from '../../functions/get-processed-block';
 import type { BuilderBlock } from '../../types/builder-block';
 import type { RepeatData } from './types';
@@ -101,7 +101,7 @@ export const getRepeatItemData = ({
     context: {
       ...context,
       state: {
-        ...context.state,
+        [PROTO_STATE]: context.state,
         $index: index,
         $item: item,
         [itemNameToUse]: item,

--- a/packages/sdks/src/components/render-block/render-repeated-block.lite.tsx
+++ b/packages/sdks/src/components/render-block/render-repeated-block.lite.tsx
@@ -21,8 +21,9 @@ type Props = {
 export default function RenderRepeatedBlock(props: Props) {
   setContext(BuilderContext, {
     content: props.repeatContext.content,
-    state: props.repeatContext.state,
-    setState: props.repeatContext.setState,
+    localState: props.repeatContext.localState,
+    rootState: props.repeatContext.rootState,
+    rootSetState: props.repeatContext.rootSetState,
     context: props.repeatContext.context,
     apiKey: props.repeatContext.apiKey,
     registeredComponents: props.repeatContext.registeredComponents,

--- a/packages/sdks/src/components/render-content/render-content.lite.tsx
+++ b/packages/sdks/src/components/render-content/render-content.lite.tsx
@@ -103,8 +103,8 @@ export default function RenderContent(props: RenderContentProps) {
       data: props.data,
       locale: props.locale,
     }),
-    setContextState: (newState: BuilderRenderState) => {
-      state.contentState = newState;
+    contentSetState: (newRootState: BuilderRenderState) => {
+      state.contentState = newRootState;
     },
 
     allRegisteredComponents: [
@@ -171,7 +171,9 @@ export default function RenderContent(props: RenderContentProps) {
         evaluate({
           code: jsCode,
           context: props.context || {},
-          state: state.contentState,
+          localState: undefined,
+          rootState: state.contentState,
+          rootSetState: state.contentSetState,
         });
       }
     },
@@ -204,7 +206,9 @@ export default function RenderContent(props: RenderContentProps) {
         evaluate({
           code: group,
           context: props.context || {},
-          state: state.contentState,
+          localState: undefined,
+          rootState: state.contentState,
+          rootSetState: state.contentSetState,
         })
       );
     },
@@ -216,7 +220,7 @@ export default function RenderContent(props: RenderContentProps) {
             ...state.contentState,
             [key]: json,
           };
-          state.setContextState(newState);
+          state.contentSetState(newState);
         })
         .catch((err) => {
           console.error('error fetching dynamic data', url, err);
@@ -269,8 +273,9 @@ export default function RenderContent(props: RenderContentProps) {
 
   setContext(builderContext, {
     content: state.useContent,
-    state: state.contentState,
-    setState: state.setContextState,
+    localState: undefined,
+    rootState: state.contentState,
+    rootSetState: TARGET === 'qwik' ? undefined : state.contentSetState,
     context: props.context || {},
     apiKey: props.apiKey,
     apiVersion: props.apiVersion,

--- a/packages/sdks/src/context/builder.context.lite.ts
+++ b/packages/sdks/src/context/builder.context.lite.ts
@@ -4,8 +4,9 @@ import type { BuilderContextInterface } from './types';
 export default createContext<BuilderContextInterface>({
   content: null,
   context: {},
-  state: {},
-  setState: () => {},
+  localState: undefined,
+  rootSetState: () => {},
+  rootState: {},
   apiKey: null,
   apiVersion: undefined,
   registeredComponents: {},

--- a/packages/sdks/src/context/types.ts
+++ b/packages/sdks/src/context/types.ts
@@ -16,8 +16,23 @@ export type BuilderRenderContext = Record<string, unknown>;
 export interface BuilderContextInterface {
   content: Nullable<BuilderContent>;
   context: BuilderRenderContext;
-  state: BuilderRenderState;
-  setState?: (state: BuilderRenderState) => void;
+  /**
+   * The state of the application.
+   *
+   * NOTE: see `localState` below to understand how it is different from `rootState`.
+   */
+  rootState: BuilderRenderState;
+  /**
+   * Some frameworks have a `setState` function which needs to be invoked to notify
+   * the framework of state change. (other frameworks don't in which case it is `undefined')
+   */
+  rootSetState: ((rootState: BuilderRenderState) => void) | undefined;
+  /**
+   * The local state of the current component. This is different from `rootState` in that
+   * it can be a child state created by a repeater containing local state.
+   * The `rootState` is where all of the state mutations are actually stored.
+   */
+  localState: BuilderRenderState | undefined;
   apiKey: string | null;
   apiVersion: ApiVersion | undefined;
   registeredComponents: RegisteredComponents;

--- a/packages/sdks/src/functions/evaluate.test.ts
+++ b/packages/sdks/src/functions/evaluate.test.ts
@@ -1,26 +1,21 @@
-import { PROTO_STATE, flattenState } from './evaluate';
+import { flattenState } from './evaluate';
 
 describe('flatten state', () => {
   it('should behave normally when no PROTO_STATE', () => {
-    const state = { foo: 'bar' };
-    const flattened = flattenState(state);
+    const localState = {};
+    const rootState = { foo: 'bar' };
+    const flattened = flattenState(rootState, localState, undefined);
     expect(flattened.foo).toEqual('bar');
     flattened.foo = 'baz';
-    expect(state.foo).toEqual('baz');
-  });
-
-  it('should write to root', () => {
-    const state = { [PROTO_STATE]: { foo: 'baz' } };
-    const flattened = flattenState(state);
-    flattened.foo = 'bar';
-    flattened.other = 'other';
-    expect(state).toEqual({ [PROTO_STATE]: { foo: 'bar', other: 'other' } });
+    expect(rootState.foo).toEqual('baz');
   });
 
   it('should shadow write ', () => {
-    const state = { foo: 'foo', [PROTO_STATE]: { foo: 'baz' } };
-    const flattened = flattenState(state);
-    flattened.foo = 'bar';
-    expect(state).toEqual({ foo: 'bar', [PROTO_STATE]: { foo: 'baz' } });
+    const rootState = { foo: 'foo' };
+    const localState = { foo: 'baz' };
+    const flattened = flattenState(rootState, localState, undefined);
+    expect(() => (flattened.foo = 'bar')).toThrow(
+      'Writing to local state is not allowed as it is read-only.'
+    );
   });
 });

--- a/packages/sdks/src/functions/evaluate.test.ts
+++ b/packages/sdks/src/functions/evaluate.test.ts
@@ -1,0 +1,26 @@
+import { PROTO_STATE, flattenState } from './evaluate';
+
+describe('flatten state', () => {
+  it('should behave normally when no PROTO_STATE', () => {
+    const state = { foo: 'bar' };
+    const flattened = flattenState(state);
+    expect(flattened.foo).toEqual('bar');
+    flattened.foo = 'baz';
+    expect(state.foo).toEqual('baz');
+  });
+
+  it('should write to root', () => {
+    const state = { [PROTO_STATE]: { foo: 'baz' } };
+    const flattened = flattenState(state);
+    flattened.foo = 'bar';
+    flattened.other = 'other';
+    expect(state).toEqual({ [PROTO_STATE]: { foo: 'bar', other: 'other' } });
+  });
+
+  it('should shadow write ', () => {
+    const state = { foo: 'foo', [PROTO_STATE]: { foo: 'baz' } };
+    const flattened = flattenState(state);
+    flattened.foo = 'bar';
+    expect(state).toEqual({ foo: 'bar', [PROTO_STATE]: { foo: 'baz' } });
+  });
+});

--- a/packages/sdks/src/functions/get-block-actions-handler.ts
+++ b/packages/sdks/src/functions/get-block-actions-handler.ts
@@ -4,7 +4,10 @@ import { evaluate } from './evaluate.js';
 
 type Options = {
   block: BuilderBlock;
-} & Pick<BuilderContextInterface, 'state' | 'context'>;
+} & Pick<
+  BuilderContextInterface,
+  'localState' | 'context' | 'rootState' | 'rootSetState'
+>;
 
 type EventHandler = (event: Event) => any;
 
@@ -14,7 +17,9 @@ export const createEventHandler =
     evaluate({
       code: value,
       context: options.context,
-      state: options.state,
+      localState: options.localState,
+      rootState: options.rootState,
+      rootSetState: options.rootSetState,
       event,
       isExpression: false,
     });

--- a/packages/sdks/src/functions/get-block-actions.ts
+++ b/packages/sdks/src/functions/get-block-actions.ts
@@ -8,7 +8,10 @@ type Actions = { [index: string]: (event: Event) => any };
 export function getBlockActions(
   options: {
     block: BuilderBlock;
-  } & Pick<BuilderContextInterface, 'state' | 'context'>
+  } & Pick<
+    BuilderContextInterface,
+    'localState' | 'context' | 'rootState' | 'rootSetState'
+  >
 ): Actions {
   const obj: Actions = {};
   const optionActions = options.block.actions ?? {};

--- a/packages/sdks/src/functions/get-processed-block.test.ts
+++ b/packages/sdks/src/functions/get-processed-block.test.ts
@@ -21,7 +21,9 @@ test('Can process bindings', () => {
   const processed = getProcessedBlock({
     block,
     context: {},
-    state: { test: 'hello' },
+    rootState: { test: 'hello' },
+    rootSetState: undefined,
+    localState: undefined,
     shouldEvaluateBindings: true,
   });
   expect(processed).not.toEqual(block);

--- a/packages/sdks/src/functions/get-processed-block.ts
+++ b/packages/sdks/src/functions/get-processed-block.ts
@@ -8,10 +8,15 @@ import { transformBlock } from './transform-block.js';
 const evaluateBindings = ({
   block,
   context,
-  state,
+  localState,
+  rootState,
+  rootSetState,
 }: {
   block: BuilderBlock;
-} & Pick<BuilderContextInterface, 'state' | 'context'>): BuilderBlock => {
+} & Pick<
+  BuilderContextInterface,
+  'localState' | 'context' | 'rootState' | 'rootSetState'
+>): BuilderBlock => {
   if (!block.bindings) {
     return block;
   }
@@ -24,7 +29,13 @@ const evaluateBindings = ({
 
   for (const binding in block.bindings) {
     const expression = block.bindings[binding];
-    const value = evaluate({ code: expression, state, context });
+    const value = evaluate({
+      code: expression,
+      localState,
+      rootState,
+      rootSetState,
+      context,
+    });
     set(copied, binding, value);
   }
 
@@ -35,7 +46,9 @@ export function getProcessedBlock({
   block,
   context,
   shouldEvaluateBindings,
-  state,
+  localState,
+  rootState,
+  rootSetState,
 }: {
   block: BuilderBlock;
   /**
@@ -43,11 +56,20 @@ export function getProcessedBlock({
    * also sometimes too early to consider bindings, e.g. when we might be looking at a repeated block.
    */
   shouldEvaluateBindings: boolean;
-} & Pick<BuilderContextInterface, 'state' | 'context'>): BuilderBlock {
+} & Pick<
+  BuilderContextInterface,
+  'localState' | 'context' | 'rootState' | 'rootSetState'
+>): BuilderBlock {
   const transformedBlock = transformBlock(block);
 
   if (shouldEvaluateBindings) {
-    return evaluateBindings({ block: transformedBlock, state, context });
+    return evaluateBindings({
+      block: transformedBlock,
+      localState,
+      rootState,
+      rootSetState,
+      context,
+    });
   } else {
     return transformedBlock;
   }


### PR DESCRIPTION
When adding an action to a repeated item, the action code assignment would write to the local state. This is incorrect as local state is pseudo-state created for the purposes of the repeater. The correct behavior is to write to the actual state.

This is achieved by having a Proxy that intercepts the write and correctly writes to the root state.

## Description

Add a short description of what changes you made, why you made them, and any other context that you think might be helpful for someone to better understand what is contained in this pull request. This sort of information is useful for people reviewing the code, as well as anyone from the future trying to understand why changes were made or why a bug started happening.

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
