### PR TITLE
CLI: Fix `limit` option for `import` command

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,7 +14,18 @@ program
   .option('-k,--key <key>', 'Private Key')
   .option('-d,--debug', 'print debugging information')
   .option('-o,--output <output>', 'Path to folder default to ./builder', './builder')
-  .option('-l,--limit <limit>', 'Maximum number of content entries to request, default is 100')
+  .option(
+    '-l,--limit <limit>',
+    'Maximum number of content entries to request, default is 100',
+    (value) => {
+      const parsedValue = parseInt(value);
+      if (isNaN(parsedValue)) {
+        console.error(chalk.red('Error: provided value for `limit` option must be a number'));
+        process.exit(1);
+      }
+      return parsedValue;
+    }
+  )
   .action(options => {
     importSpace(options.key, options.output, options.debug, options.limit || 100);
   });


### PR DESCRIPTION
## Description

Currently, provided values for the `--limit` option for the `import` command are not being parsed as numbers resulting in an error like:

```
$ builder import -k $BUILDER_PRIVATE_API_KEY -o ./backup -l 10

Error importing space
ClientError: Response contains errors
{
  "message": "Variable \"$v1\" got invalid value \"10\" at \"v1.limit\"; Float cannot represent non numeric value: \"10\"",
  "locations": [
    {
      "line": 1,
      "column": 7
    }
  ],
  "extensions": {
    "code": "BAD_USER_INPUT"
  }
}
    at /Users/luke.johnson/Code/builder.io-kit/node_modules/graphql-typed-client/dist/client/createClient.js:85:19
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  errors: [
    {
      message: 'Variable "$v1" got invalid value "10" at "v1.limit"; Float cannot represent non numeric value: "10"',
      locations: [Array],
      extensions: [Object]
    }
  ]
}
```

This PR ensures provided values are parsed as integers, throwing an error if the value is not a number.

I'm not sure what the release process is for this package - let me know if there's anything else I need to include in the PR
