### PR TITLE
Feature: SDK version

### DIFF
--- a/packages/sdks/output/qwik/package.json
+++ b/packages/sdks/output/qwik/package.json
@@ -22,10 +22,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "build": "tsc && vite build --mode lib",
-    "release:patch": "yarn run build && npm version patch && npm publish",
-    "release:minor": "yarn run build && npm version minor && npm publish",
-    "release:dev": "yarn run build && npm version prerelease && npm publish --tag dev"
+    "build": "tsc && vite build --mode lib"
   },
   "devDependencies": {
     "@builder.io/qwik": "^1.0.0",

--- a/packages/sdks/output/react-native/package.json
+++ b/packages/sdks/output/react-native/package.json
@@ -13,10 +13,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
-    "release:patch": "yarn run build && npm version patch && npm publish",
-    "release:minor": "yarn run build && npm version minor && npm publish",
-    "release:dev": "yarn run build && npm version prerelease && npm publish --tag dev"
+    "build": "tsc"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.17.10",

--- a/packages/sdks/output/react/package.json
+++ b/packages/sdks/output/react/package.json
@@ -14,10 +14,7 @@
     "build:types:server": "tsc -p ./tsconfig.server.json",
     "build:types:sdk": "tsc -p ./tsconfig.sdk.json",
     "build:types": "yarn build:types:sdk",
-    "build": "yarn build:types",
-    "release:patch": "yarn run build && npm version patch && npm publish",
-    "release:minor": "yarn run build && npm version minor && npm publish",
-    "release:dev": "yarn run build && npm version prerelease && npm publish --tag dev"
+    "build": "yarn build:types"
   },
   "peerDependencies": {
     "react": "^18.2.0"

--- a/packages/sdks/output/solid/package.json
+++ b/packages/sdks/output/solid/package.json
@@ -12,10 +12,7 @@
     }
   },
   "scripts": {
-    "build": "echo 'no need to build solid SDK'",
-    "release:patch": "yarn run build && npm version patch && npm publish",
-    "release:minor": "yarn run build && npm version minor && npm publish",
-    "release:dev": "yarn run build && npm version prerelease && npm publish --tag dev"
+    "build": "echo 'no need to build solid SDK'"
   },
   "dependencies": {
     "solid-styled-components": "^0.27.6"

--- a/packages/sdks/output/svelte/package.json
+++ b/packages/sdks/output/svelte/package.json
@@ -28,9 +28,6 @@
   },
   "types": "./package/index.d.ts",
   "scripts": {
-    "release:patch": "yarn run build && npm version patch && npm publish",
-    "release:minor": "yarn run build && npm version minor && npm publish",
-    "release:dev": "yarn run build && npm version prerelease && npm publish --tag dev",
     "dev": "vite dev",
     "build": "svelte-kit sync && svelte-package",
     "build:watch": "svelte-kit sync && svelte-package --watch",

--- a/packages/sdks/output/vue/package.json
+++ b/packages/sdks/output/vue/package.json
@@ -39,10 +39,7 @@
   "scripts": {
     "add-debug": "bash ./scripts/add-debug.sh",
     "remove-debug": "bash ./scripts/remove-debug.sh",
-    "build": "yarn workspaces foreach run build",
-    "release:patch": "yarn run build && npm version patch && npm publish",
-    "release:minor": "yarn run build && npm version minor && npm publish",
-    "release:dev": "yarn run build && npm version prerelease && npm publish --tag dev"
+    "build": "yarn workspaces foreach run build"
   },
   "peerDependencies": {
     "vue": ">= 2"

--- a/packages/sdks/package.json
+++ b/packages/sdks/package.json
@@ -48,6 +48,7 @@
     "e2e:run:all": "yarn run-s e2e:run:*",
     "release-sdk": "bash ./scripts/release-sdk.sh",
     "release:all": "yarn build:mitosis && bash ./scripts/loop-command.sh release-sdk \"svelte react-native solid qwik react vue\"",
+    "set-sdk-version": "bash ./scripts/set-sdk-version.sh",
     "upgrade-example": "bash ./scripts/upgrade-example.sh",
     "upgrade-example:all": "bash ./scripts/loop-command.sh upgrade-example \"svelte react-native solid qwik react vue\""
   },

--- a/packages/sdks/package.json
+++ b/packages/sdks/package.json
@@ -46,11 +46,14 @@
     "e2e:run:old-react": "SDK=oldReact yarn e2e:run",
     "e2e:build:all": "yarn workspaces foreach --exclude @builder.io/e2e-rsc --verbose run build",
     "e2e:run:all": "yarn run-s e2e:run:*",
+    "loop": "bash ./scripts/loop-command.sh",
     "release-sdk": "bash ./scripts/release-sdk.sh",
-    "release:all": "yarn build:mitosis && bash ./scripts/loop-command.sh release-sdk \"svelte react-native solid qwik react vue\"",
+    "release:all:patch": "yarn build:mitosis && yarn loop release-sdk patch",
+    "release:all:minor": "yarn build:mitosis && yarn loop release-sdk minor",
+    "release:all:dev": "yarn build:mitosis && yarn loop release-sdk dev",
     "set-sdk-version": "bash ./scripts/set-sdk-version.sh",
     "upgrade-example": "bash ./scripts/upgrade-example.sh",
-    "upgrade-example:all": "bash ./scripts/loop-command.sh upgrade-example \"svelte react-native solid qwik react vue\""
+    "upgrade-example:all": "yarn loop upgrade-example latest"
   },
   "dependencies": {
     "@builder.io/mitosis": "^0.0.98",

--- a/packages/sdks/scripts/loop-command.sh
+++ b/packages/sdks/scripts/loop-command.sh
@@ -1,11 +1,15 @@
+set -eo nounset
+
 # doing this for each SDK is getting tedious, and I'm lazy.
-echo "looping cmd \"$1\" over args \"$2\""
+echo "looping cmd \"$1\" over all SDKs."
+
+VERSION=${2:-'patch'}
 
 # run these loop commands in parallel
-for i in $2; do
-  echo "running $1 on $i"
-  yarn run $1 $i loop
+for i in svelte react-native solid qwik react vue; do
+  yarn run $1 $i $VERSION loop
   # use this line to run these loop commands in parallel
+  # TO-DO: breaks on publish due to npm OTP prompts
   # yarn run $1 $i &
 done
 

--- a/packages/sdks/scripts/loop-command.sh
+++ b/packages/sdks/scripts/loop-command.sh
@@ -1,10 +1,10 @@
 # doing this for each SDK is getting tedious, and I'm lazy.
-echo "looping cmd \"$1\" over args \"$2\"";
+echo "looping cmd \"$1\" over args \"$2\""
 
 # run these loop commands in parallel
 for i in $2; do
-  echo "running $1 on $i";
-  yarn run $1 $i;
+  echo "running $1 on $i"
+  yarn run $1 $i loop
   # use this line to run these loop commands in parallel
   # yarn run $1 $i &
 done

--- a/packages/sdks/scripts/release-sdk.sh
+++ b/packages/sdks/scripts/release-sdk.sh
@@ -6,9 +6,9 @@ VERSION=${2:-'patch'}
 LOOP=${3:-'not-loop'}
 
 if [[ "$VERSION" != 'dev' && "$LOOP" == 'not-loop' ]]; then
-  echo "Error: cannot release $VERSION version of one SDK. You must release all SDKs at once to keep them in sync."
-  echo "Error: only 'dev' versions are allowed to be done on an individual basis."
-  echo "Error: please run 'yarn release:all' to release all SDKs."
+  echo "Error: cannot release $VERSION version of only one SDK. You must release all SDKs at once to keep them in sync."
+  echo "Error: only 'dev' versions are allowed to be released on a per-SDK basis."
+  echo "Error: please run 'yarn release:all:$VERSION' to release all SDKs, or 'yarn release-sdk $1 dev' to release a dev version of $1."
   echo "Exiting."
   exit 1
 fi

--- a/packages/sdks/scripts/release-sdk.sh
+++ b/packages/sdks/scripts/release-sdk.sh
@@ -1,4 +1,42 @@
+set -eo nounset
+
 # doing this for each SDK is getting tedious, and I'm lazy.
-VERSION=${2:-'patch'}    
-echo "releasing $VERSION version of SDK $1";
-cd "output/$1" && npm run release:$VERSION && echo "released $1";
+VERSION=${2:-'patch'}
+
+LOOP=${3:-'not-loop'}
+
+if [[ "$VERSION" != 'dev' && "$LOOP" == 'not-loop' ]]; then
+  echo "Error: cannot release $VERSION version of one SDK. You must release all SDKs at once to keep them in sync."
+  echo "Error: only 'dev' versions are allowed to be done on an individual basis."
+  echo "Error: please run 'yarn release:all' to release all SDKs."
+  echo "Exiting."
+  exit 1
+fi
+
+echo "Releasing a new '$VERSION' version of '$1' SDK."
+
+cd "output/$1"
+
+# bump the version number
+
+if [[ "$VERSION" == 'dev' ]]; then
+  npm version prerelease
+else
+  npm version $VERSION
+fi
+
+# set the SDK version number in `sdk-version` files
+yarn workspace @builder.io/sdks set-sdk-version $1
+
+echo "Building SDK..."
+yarn run build
+
+echo "Publishing SDK..."
+
+if [[ "$VERSION" == 'dev' ]]; then
+  npm publish --tag dev
+else
+  npm publish
+fi
+
+echo "released $1!"

--- a/packages/sdks/scripts/set-sdk-version.sh
+++ b/packages/sdks/scripts/set-sdk-version.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# This file updates all `sdk-version.ts` and `sdk-version.js` files in an SDK to the current npm package version.
+#
+# This is important to do after running `npm version` (which bumps the version number), but before publishing the
+# new version of the package.
+
+set -o nounset
+
+# We expect to run this script from repo root. So we need to `cd` into the correct directory.
+# PS: Calling it using 'yarn workspace @builder.io/sdks set-sdk-version' is equivalent to running it from the root.
+cd "output/$1"
+
+LOCAL_DIR=$(pwd)
+if [[ "$LOCAL_DIR" =~ .*sdks\/output\/[a-z\|-]*$ ]]; then
+  echo "Setting SDK Version for '$1' in '$LOCAL_DIR'."
+else
+  echo "Must run this script from the root of an SDK directory, e.g. 'sdks/output/<sdk-name>'."
+  echo "Instead, you ran it from '$LOCAL_DIR'."
+  echo "Exiting."
+  exit 1
+fi
+
+# get version from package.json
+VERSION=$(grep -o '"version": *"[^"]*"' package.json | sed 's/"version": "\(.*\)"/\1/')
+echo "Found version number: $VERSION"
+
+# create new file content
+NEW_FILE_CONTENT="export const SDK_VERSION = \"$VERSION\""
+
+# find all files named sdk-version.js or sdk-version.ts in the current directory (recursively)
+FILES=$(find . -type f \( -name "sdk-version.js" -o -name "sdk-version.ts" \))
+
+for FILE in $FILES; do
+  echo "Updating $FILE..."
+
+  # replace file content
+  echo $NEW_FILE_CONTENT >$FILE
+
+  echo "Updated $FILE."
+done

--- a/packages/sdks/scripts/set-sdk-version.sh
+++ b/packages/sdks/scripts/set-sdk-version.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
+
 # This file updates all `sdk-version.ts` and `sdk-version.js` files in an SDK to the current npm package version.
+# It stores the package version that is sent to the visual editor.
 #
-# This is important to do after running `npm version` (which bumps the version number), but before publishing the
-# new version of the package.
+# This script must execute after `npm version` (which bumps the version number), but before `npm publish`.
 
 set -o nounset
 

--- a/packages/sdks/scripts/upgrade-example.sh
+++ b/packages/sdks/scripts/upgrade-example.sh
@@ -1,5 +1,5 @@
 # doing this for each SDK is getting tedious, and I'm lazy.
-VERSION=${2:-'latest'}    
-echo "Upgrading SDK $1@$VERSION usage in examples";
+VERSION=${2:-'latest'}
+echo "Upgrading @builder.io/sdk-$1@$VERSION usage in examples"
 
 cd "../../" && npm run update-npm-dependency -- --force-lib-upgrade --lib="@builder.io/sdk-$1" --version=$VERSION

--- a/packages/sdks/src/constants/sdk-version.ts
+++ b/packages/sdks/src/constants/sdk-version.ts
@@ -1,0 +1,1 @@
+export const SDK_VERSION = 'UNKNOWN_VERSION';

--- a/packages/sdks/src/scripts/init-editing.ts
+++ b/packages/sdks/src/scripts/init-editing.ts
@@ -1,3 +1,4 @@
+import { SDK_VERSION } from '../constants/sdk-version.js';
 import { TARGET } from '../constants/target.js';
 import { isBrowser } from '../functions/is-browser.js';
 import { register } from '../functions/register.js';
@@ -40,6 +41,7 @@ export const setupBrowserForEditing = (
         type: 'builder.sdkInfo',
         data: {
           target: TARGET,
+          version: SDK_VERSION,
           // TODO: compile these in
           // type: process.env.SDK_TYPE,
           // version: process.env.SDK_VERSION,


### PR DESCRIPTION
## Description

SDKs:

- add `SDK_VERSION` constant that is sent to editor
- add scripting logic that will update value using `package.json`'s `package` field after `npm version` but before `npm publish`
- centralized release scripts into `release-sdk.sh` to guarantee that we don't manually try to publish, which could cause issues:
  - by forgetting to run the `set-sdk-version.sh` script
  - by publishing 1 SDK without the others (except for dev)