### PR TITLE
make v3 as the default apiVersion for next Major release

### DIFF
--- a/packages/core/src/types/api-version.ts
+++ b/packages/core/src/types/api-version.ts
@@ -1,2 +1,2 @@
 export type ApiVersion = 'v1' | 'v3';
-export const DEFAULT_API_VERSION: ApiVersion = 'v1';
+export const DEFAULT_API_VERSION: ApiVersion = 'v3';

--- a/packages/sdks-tests/src/tests/blocks.spec.ts
+++ b/packages/sdks-tests/src/tests/blocks.spec.ts
@@ -170,7 +170,7 @@ test.describe('Blocks', () => {
 
     const urlMatch =
       sdk === 'oldReact'
-        ? 'https://cdn.builder.io/api/v1/query/abcd/symbol*'
+        ? 'https://cdn.builder.io/api/v3/query/abcd/symbol*'
         : /https:\/\/cdn\.builder\.io\/api\/v3\/content\/symbol\.*/;
 
     await page.route(urlMatch, route => {
@@ -313,7 +313,7 @@ test.describe('Blocks', () => {
       let x = 0;
 
       const urlMatch = isOldReactSDK
-        ? 'https://cdn.builder.io/api/v1/query/abcd/symbol*'
+        ? 'https://cdn.builder.io/api/v3/query/abcd/symbol*'
         : /.*cdn\.builder\.io\/api\/v3\/content\/symbol.*/;
 
       await page.route(urlMatch, route => {


### PR DESCRIPTION
## Description

This PR will make the changes which we will use to set `v3` as default apiVersion for next major versions of core and react SDK.
