### PR TITLE
Support RSC

### DIFF
--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -2374,12 +2374,6 @@ export class Builder {
       }
     }
 
-    if (!Builder.isReact) {
-      // TODO: remove me once v1 page editors converted to v2
-      // queryParams.extractCss = true;
-      queryParams.prerender = true;
-    }
-
     for (const options of queue) {
       if (options.format) {
         queryParams.format = options.format;

--- a/packages/react/src/blocks/Button.tsx
+++ b/packages/react/src/blocks/Button.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import { withBuilder } from '../functions/with-builder';
 import { Link } from '../components/Link';

--- a/packages/react/src/blocks/Button.tsx
+++ b/packages/react/src/blocks/Button.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import React from 'react';
 import { withBuilder } from '../functions/with-builder';
 import { Link } from '../components/Link';

--- a/packages/react/src/blocks/CustomCode.tsx
+++ b/packages/react/src/blocks/CustomCode.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import { BuilderElement, Builder } from '@builder.io/sdk';
 import { withBuilder } from '../functions/with-builder';

--- a/packages/react/src/blocks/CustomCode.tsx
+++ b/packages/react/src/blocks/CustomCode.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import React from 'react';
 import { BuilderElement, Builder } from '@builder.io/sdk';
 import { withBuilder } from '../functions/with-builder';

--- a/packages/react/src/blocks/Embed.tsx
+++ b/packages/react/src/blocks/Embed.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import { Builder } from '@builder.io/sdk';
 import { withBuilder } from '../functions/with-builder';

--- a/packages/react/src/blocks/Embed.tsx
+++ b/packages/react/src/blocks/Embed.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import React from 'react';
 import { Builder } from '@builder.io/sdk';
 import { withBuilder } from '../functions/with-builder';

--- a/packages/react/src/blocks/Fragment.tsx
+++ b/packages/react/src/blocks/Fragment.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import React from 'react';
 import { BuilderElement } from '@builder.io/sdk';
 import { withBuilder } from '../functions/with-builder';

--- a/packages/react/src/blocks/Fragment.tsx
+++ b/packages/react/src/blocks/Fragment.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import { BuilderElement } from '@builder.io/sdk';
 import { withBuilder } from '../functions/with-builder';

--- a/packages/react/src/blocks/StateProvider.tsx
+++ b/packages/react/src/blocks/StateProvider.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import { BuilderElement } from '@builder.io/sdk';
 import { BuilderBlock as BuilderBlockComponent } from '../components/builder-block.component';

--- a/packages/react/src/blocks/StateProvider.tsx
+++ b/packages/react/src/blocks/StateProvider.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import React from 'react';
 import { BuilderElement } from '@builder.io/sdk';
 import { BuilderBlock as BuilderBlockComponent } from '../components/builder-block.component';

--- a/packages/react/src/blocks/forms/Button.tsx
+++ b/packages/react/src/blocks/forms/Button.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import { withBuilder } from '../../functions/with-builder';
 

--- a/packages/react/src/blocks/forms/Button.tsx
+++ b/packages/react/src/blocks/forms/Button.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import React from 'react';
 import { withBuilder } from '../../functions/with-builder';
 

--- a/packages/react/src/blocks/forms/Input.tsx
+++ b/packages/react/src/blocks/forms/Input.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import React from 'react';
 import { Builder } from '@builder.io/sdk';
 import { withBuilder } from '../../functions/with-builder';

--- a/packages/react/src/blocks/forms/Input.tsx
+++ b/packages/react/src/blocks/forms/Input.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import { Builder } from '@builder.io/sdk';
 import { withBuilder } from '../../functions/with-builder';

--- a/packages/react/src/blocks/forms/Label.tsx
+++ b/packages/react/src/blocks/forms/Label.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import { BuilderElement } from '@builder.io/sdk';
 import { BuilderBlockComponent } from '../../builder-react';

--- a/packages/react/src/blocks/forms/Label.tsx
+++ b/packages/react/src/blocks/forms/Label.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import React from 'react';
 import { BuilderElement } from '@builder.io/sdk';
 import { BuilderBlockComponent } from '../../builder-react';

--- a/packages/react/src/blocks/forms/Select.tsx
+++ b/packages/react/src/blocks/forms/Select.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import React from 'react';
 import { Builder } from '@builder.io/sdk';
 import { withBuilder } from '../../functions/with-builder';

--- a/packages/react/src/blocks/forms/Select.tsx
+++ b/packages/react/src/blocks/forms/Select.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import { Builder } from '@builder.io/sdk';
 import { withBuilder } from '../../functions/with-builder';

--- a/packages/react/src/blocks/forms/TextArea.tsx
+++ b/packages/react/src/blocks/forms/TextArea.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import { withBuilder } from '../../functions/with-builder';
 

--- a/packages/react/src/blocks/forms/TextArea.tsx
+++ b/packages/react/src/blocks/forms/TextArea.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import React from 'react';
 import { withBuilder } from '../../functions/with-builder';
 

--- a/packages/react/src/blocks/raw/Img.tsx
+++ b/packages/react/src/blocks/raw/Img.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import { BuilderElement } from '@builder.io/sdk';
 import { withBuilder } from '../../functions/with-builder';

--- a/packages/react/src/blocks/raw/Img.tsx
+++ b/packages/react/src/blocks/raw/Img.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import React from 'react';
 import { BuilderElement } from '@builder.io/sdk';
 import { withBuilder } from '../../functions/with-builder';

--- a/packages/react/src/blocks/raw/RawText.tsx
+++ b/packages/react/src/blocks/raw/RawText.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import * as React from 'react';
 import { BuilderElement, Builder } from '@builder.io/sdk';
 

--- a/packages/react/src/blocks/raw/RawText.tsx
+++ b/packages/react/src/blocks/raw/RawText.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from 'react';
 import { BuilderElement, Builder } from '@builder.io/sdk';
 

--- a/packages/react/src/components/Link.tsx
+++ b/packages/react/src/components/Link.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import React from 'react';
 import { BuilderStoreContext } from '../store/builder-store';
 /**

--- a/packages/react/src/components/Link.tsx
+++ b/packages/react/src/components/Link.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import { BuilderStoreContext } from '../store/builder-store';
 /**

--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { jsx, css } from '@emotion/core';

--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { jsx, css } from '@emotion/core';

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import React from 'react';
 import {
   builder,

--- a/packages/react/src/components/builder-content.component.tsx
+++ b/packages/react/src/components/builder-content.component.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import {
   builder,

--- a/packages/react/src/components/no-wrap.tsx
+++ b/packages/react/src/components/no-wrap.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import React from 'react';
 
 export const NoWrap = (props: React.ComponentPropsWithoutRef<any>) => props.children;

--- a/packages/react/src/components/no-wrap.tsx
+++ b/packages/react/src/components/no-wrap.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 
 export const NoWrap = (props: React.ComponentPropsWithoutRef<any>) => props.children;

--- a/packages/react/src/components/variants-provider.component.tsx
+++ b/packages/react/src/components/variants-provider.component.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import * as React from 'react';
 import { builder, Builder, BuilderContent, BuilderContentVariation } from '@builder.io/sdk';
 

--- a/packages/react/src/components/variants-provider.component.tsx
+++ b/packages/react/src/components/variants-provider.component.tsx
@@ -1,3 +1,4 @@
+"use client";
 import * as React from 'react';
 import { builder, Builder, BuilderContent, BuilderContentVariation } from '@builder.io/sdk';
 

--- a/packages/react/src/functions/no-wrap.tsx
+++ b/packages/react/src/functions/no-wrap.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import { BuilderElement } from '@builder.io/sdk';
 import { BuilderBlock } from '../components/builder-block.component';

--- a/packages/react/src/functions/no-wrap.tsx
+++ b/packages/react/src/functions/no-wrap.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import React from 'react';
 import { BuilderElement } from '@builder.io/sdk';
 import { BuilderBlock } from '../components/builder-block.component';

--- a/packages/react/src/functions/try-eval.tsx
+++ b/packages/react/src/functions/try-eval.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Builder } from '@builder.io/sdk';
 import { safeDynamicRequire } from './safe-dynamic-require';
 

--- a/packages/react/src/functions/try-eval.tsx
+++ b/packages/react/src/functions/try-eval.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import { Builder } from '@builder.io/sdk';
 import { safeDynamicRequire } from './safe-dynamic-require';
 

--- a/packages/react/src/functions/with-children.tsx
+++ b/packages/react/src/functions/with-children.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from 'react';
 import { BuilderElement } from '@builder.io/sdk';
 import { BuilderBlock } from '../components/builder-block.component';

--- a/packages/react/src/functions/with-children.tsx
+++ b/packages/react/src/functions/with-children.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import React from 'react';
 import { BuilderElement } from '@builder.io/sdk';
 import { BuilderBlock } from '../components/builder-block.component';


### PR DESCRIPTION
Add "use client" to the top of all components

No longer default to `prerender: true` when using @builder.io/sdk directly