### PR TITLE
iOS Example Fixes

### DIFF
--- a/examples/swift/Shared/ContentView.swift
+++ b/examples/swift/Shared/ContentView.swift
@@ -1,8 +1,20 @@
 import SwiftUI
 import BuilderIO
 
+class BuilderContentWrapper: ObservableObject {
+    var content: BuilderContent? = nil;
+    init(content: BuilderContent? = nil) {
+        self.content = content
+    }
+    
+    func changeContent(_ newValue: BuilderContent?) {
+        self.content = newValue;
+        self.objectWillChange.send();
+    }
+}
+
 struct ContentView: View {
-    @State var content: BuilderContent? = nil
+    @ObservedObject var content: BuilderContentWrapper = BuilderContentWrapper();
     
     init() {
         registerComponent(name: "HeroComponent", factory: { (options, styles) in
@@ -12,15 +24,17 @@ struct ContentView: View {
     }
     
     func fetchContent() {
-        Content.getContent(model: "page", apiKey: "e084484c0e0241579f01abba29d9be10", url: "/custom-components") { content in
-            self.content = content
+        Content.getContent(model: "page", apiKey: "e084484c0e0241579f01abba29d9be10", url: "/custom-components", locale: "", preview: "") { content in
+            DispatchQueue.main.async {
+                self.content.changeContent(content);
+            }
         }
     }
     
     var body: some View {
         ScrollView {
-            if $content.wrappedValue != nil {
-                RenderContent(content: $content.wrappedValue!)
+            if $content.content.wrappedValue != nil {
+                RenderContent(content: $content.content.wrappedValue!)
             }
         }
         


### PR DESCRIPTION
## Description

* Add a wrapper and fire state change events to ensure that UI updates as soon as we have data instead of having to click Reload the first time