### PR TITLE
fix: add webp and gif formats

### DIFF
--- a/packages/sdks/src/blocks/img/component-info.ts
+++ b/packages/sdks/src/blocks/img/component-info.ts
@@ -12,7 +12,7 @@ export const componentInfo: ComponentInfo = {
       name: 'image',
       bubble: true,
       type: 'file',
-      allowedFileTypes: ['jpeg', 'jpg', 'png', 'svg'],
+      allowedFileTypes: ['jpeg', 'jpg', 'png', 'svg', 'gif', 'webp'],
       required: true,
     },
   ],


### PR DESCRIPTION
When trying to upload a gif / webp, while it's possible by drag and drop, it's not valid in the file picker!

<img width="565" alt="Screenshot 2023-06-15 at 10 07 47" src="https://github.com/BuilderIO/builder/assets/127379/d51f0ddb-fabb-4a8c-af54-32773e2f2e61">
<img width="230" alt="Screenshot 2023-06-15 at 10 08 20" src="https://github.com/BuilderIO/builder/assets/127379/ee96154b-e9c5-4be0-b1a3-07423a9c4c07">
