### PR TITLE
Fix 404 link in docs

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,6 +1,6 @@
 # Builder.io React SDK
 
-NOTE: for Next v13 app directory support, you will need to use our beta version of the SDK. You can find more about it [here](../sdks/outputs/react).
+NOTE: for Next v13 app directory support, you will need to use our beta version of the SDK. You can find more about it [here](../sdks/output/react).
 
 ## Integration
 


### PR DESCRIPTION
Typo in the URL.

<img width="1115" alt="image" src="https://github.com/BuilderIO/builder/assets/8061997/28a84707-732f-4c39-8d9e-cf2c414d9314">
