### PR TITLE
SDKs: cleanup css testing

### DIFF
--- a/packages/sdks-tests/playwright.config.ts
+++ b/packages/sdks-tests/playwright.config.ts
@@ -57,8 +57,7 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: 2,
+  retries: 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/packages/sdks-tests/src/tests/blocks.spec.ts
+++ b/packages/sdks-tests/src/tests/blocks.spec.ts
@@ -7,7 +7,6 @@ import {
   findTextInPage,
   isRNSDK,
   excludeReactNative,
-  expectStylesForElement,
   testOnlyOldReact,
   testExcludeOldReact,
   isOldReactSDK,
@@ -63,41 +62,30 @@ test.describe('Blocks', () => {
     const soloPTag = await textBlocks.nth(1).locator('*').first();
     const pTags = await textBlocks.nth(2).locator('*').all();
 
-    const NO_MARGIN_STYLES = {
-      'margin-top': '0px',
-      'margin-bottom': '0px',
-      'margin-left': '0px',
-      'margin-right': '0px',
-    };
-
     for (const child of paragraphClasses) {
-      await expectStylesForElement({
-        locator: child,
-        expected: NO_MARGIN_STYLES,
-      });
+      await expect(child).toHaveCSS('margin-top', '0px');
+      await expect(child).toHaveCSS('margin-bottom', '0px');
+      await expect(child).toHaveCSS('margin-left', '0px');
+      await expect(child).toHaveCSS('margin-right', '0px');
     }
-    await expectStylesForElement({
-      locator: soloPTag,
-      expected: NO_MARGIN_STYLES,
-    });
+
+    await expect(soloPTag).toHaveCSS('margin-top', '0px');
+    await expect(soloPTag).toHaveCSS('margin-bottom', '0px');
+    await expect(soloPTag).toHaveCSS('margin-left', '0px');
+    await expect(soloPTag).toHaveCSS('margin-right', '0px');
 
     const [firstPTag, ...otherPTags] = pTags;
 
-    await expectStylesForElement({
-      locator: firstPTag,
-      expected: NO_MARGIN_STYLES,
-    });
+    await expect(firstPTag).toHaveCSS('margin-top', '0px');
+    await expect(firstPTag).toHaveCSS('margin-bottom', '0px');
+    await expect(firstPTag).toHaveCSS('margin-left', '0px');
+    await expect(firstPTag).toHaveCSS('margin-right', '0px');
 
     for (const child of otherPTags) {
-      await expectStylesForElement({
-        locator: child,
-        expected: {
-          'margin-top': '16px',
-          'margin-bottom': '16px',
-          'margin-left': '0px',
-          'margin-right': '0px',
-        },
-      });
+      await expect(child).toHaveCSS('margin-top', '16px');
+      await expect(child).toHaveCSS('margin-bottom', '16px');
+      await expect(child).toHaveCSS('margin-left', '0px');
+      await expect(child).toHaveCSS('margin-right', '0px');
     }
   });
   /**
@@ -144,7 +132,10 @@ test.describe('Blocks', () => {
 
     for (const { val, i } of Object.values(expectedVals)) {
       const image = imageLocator.nth(i);
-      await expectStylesForElement({ locator: image, expected: val });
+      const expected = val;
+      for (const property of Object.keys(expected)) {
+        await expect(image).toHaveCSS(property, expected[property]);
+      }
     }
   });
 
@@ -253,7 +244,7 @@ test.describe('Blocks', () => {
       },
     };
 
-    const NO_LEFT_MARGIN = { 'margin-left': '0px' };
+    const NO_LEFT_MARGIN = { 'margin-left': '0px' } as const;
 
     const expected: Record<ColumnTypes, Record<SizeName, ColStyles> & { index: number }> = {
       stackAtTablet: {
@@ -306,25 +297,27 @@ test.describe('Blocks', () => {
               : page.locator('.builder-columns');
 
             await expect(columns).toHaveCount(5);
-            await expectStylesForElement({
-              locator: columns.nth(styles.index),
-              expected: styles[sizeName].columns,
-            });
+            for (const property of Object.keys(styles[sizeName].columns)) {
+              await expect(columns.nth(styles.index)).toHaveCSS(
+                property,
+                styles[sizeName].columns[property]
+              );
+            }
 
             const columnLocator = isRNSDK
               ? columns.nth(styles.index).locator('[data-builder-block-name=builder-column]')
               : columns.nth(styles.index).locator('.builder-column');
 
             // first column should never have left margin
-            await expectStylesForElement({
-              locator: columnLocator.nth(0),
-              expected: NO_LEFT_MARGIN,
-            });
+            await expect(columnLocator.nth(0)).toHaveCSS(
+              'margin-left',
+              NO_LEFT_MARGIN['margin-left']
+            );
 
-            await expectStylesForElement({
-              locator: columnLocator.nth(1),
-              expected: styles[sizeName].column,
-            });
+            const expected = styles[sizeName].column;
+            for (const property of Object.keys(expected)) {
+              await expect(columnLocator.nth(1)).toHaveCSS(property, expected[property]);
+            }
           });
         }
       });

--- a/packages/sdks-tests/src/tests/blocks.spec.ts
+++ b/packages/sdks-tests/src/tests/blocks.spec.ts
@@ -6,7 +6,6 @@ import {
   test,
   findTextInPage,
   isRNSDK,
-  expectStyleForElement,
   excludeReactNative,
   expectStylesForElement,
   testOnlyOldReact,
@@ -35,19 +34,11 @@ const testSymbols = async (page: Page) => {
   // these are desktop and tablet styles, and will never show up in react native
   if (!isRNSDK) {
     // check desktop styles
-    await expectStyleForElement({
-      locator: firstSymbolText,
-      cssProperty: 'color',
-      expectedValue: 'rgb(255, 0, 0)',
-    });
+    await expect(firstSymbolText).toHaveCSS('color', 'rgb(255, 0, 0)');
 
     // resize to tablet
     await page.setViewportSize({ width: 930, height: 1000 });
-    await expectStyleForElement({
-      locator: firstSymbolText,
-      cssProperty: 'color',
-      expectedValue: 'rgb(0, 255, 6)',
-    });
+    await expect(firstSymbolText).toHaveCSS('color', 'rgb(0, 255, 6)');
 
     // resize to mobile
     await page.setViewportSize({ width: 400, height: 1000 });
@@ -56,11 +47,7 @@ const testSymbols = async (page: Page) => {
   // TO-DO: fix react native style inheritance for symbols->Text (using HTML renderer component), so we can unblock this.
   if (!isRNSDK) {
     // check mobile styles
-    await expectStyleForElement({
-      locator: firstSymbolText,
-      cssProperty: 'color',
-      expectedValue: 'rgb(0, 255, 255)',
-    });
+    await expect(firstSymbolText).toHaveCSS('color', 'rgb(0, 255, 255)');
   }
 };
 

--- a/packages/sdks-tests/src/tests/helpers.ts
+++ b/packages/sdks-tests/src/tests/helpers.ts
@@ -107,43 +107,18 @@ export const getElementStyleValue = async ({
   }, cssProperty);
 };
 
-export const expectStyleForElement = async ({
-  expectedValue,
-  locator,
-  cssProperty,
-  checkVisibility = true,
-}: {
-  locator: Locator;
-  cssProperty: string;
-  expectedValue: string;
-  checkVisibility?: boolean;
-}) => {
-  // we need to wait for the element to be visible, otherwise we might run the style check on a removed DOM node.
-  if (checkVisibility) {
-    await expect(locator).toBeVisible();
-  }
-
-  await expect(await getElementStyleValue({ locator, cssProperty })).toBe(expectedValue);
-};
-
 export type ExpectedStyles = Record<string, string>;
 
 export const expectStylesForElement = async ({
   expected,
   locator,
-  checkVisibility,
 }: {
   locator: Locator;
   expected: ExpectedStyles;
   checkVisibility?: boolean;
 }) => {
   for (const property of Object.keys(expected)) {
-    await expectStyleForElement({
-      cssProperty: property,
-      locator,
-      expectedValue: expected[property],
-      checkVisibility,
-    });
+    await expect(locator).toHaveCSS(property, expected[property]);
   }
 };
 

--- a/packages/sdks-tests/src/tests/helpers.ts
+++ b/packages/sdks-tests/src/tests/helpers.ts
@@ -115,7 +115,6 @@ export const expectStylesForElement = async ({
 }: {
   locator: Locator;
   expected: ExpectedStyles;
-  checkVisibility?: boolean;
 }) => {
   for (const property of Object.keys(expected)) {
     await expect(locator).toHaveCSS(property, expected[property]);

--- a/packages/sdks-tests/src/tests/main.spec.ts
+++ b/packages/sdks-tests/src/tests/main.spec.ts
@@ -343,7 +343,6 @@ test.describe(targetContext.name, () => {
             await expectStylesForElement({
               locator: image,
               expected: expectedImageCss,
-              checkVisibility: false,
             });
           }
         });
@@ -372,7 +371,6 @@ test.describe(targetContext.name, () => {
             await expectStylesForElement({
               locator: image,
               expected: expectedImageCss,
-              checkVisibility: false,
             });
           }
         });
@@ -459,7 +457,6 @@ test.describe(targetContext.name, () => {
             await expectStylesForElement({
               locator: image,
               expected: expectedImageCss,
-              checkVisibility: false,
             });
           }
         });

--- a/packages/sdks-tests/src/tests/main.spec.ts
+++ b/packages/sdks-tests/src/tests/main.spec.ts
@@ -3,7 +3,6 @@ import { expect } from '@playwright/test';
 import { targetContext } from './context.js';
 import {
   excludeReactNative,
-  expectStyleForElement,
   expectStylesForElement,
   findTextInPage,
   getBuilderSessionIdCookie,
@@ -282,11 +281,7 @@ test.describe(targetContext.name, () => {
             expectedTextColor = 'rgb(65, 117, 5)'; // greenish text color
           }
 
-          await expectStyleForElement({
-            locator: breakpointsParam,
-            cssProperty: 'color',
-            expectedValue: expectedTextColor,
-          });
+          await expect(breakpointsParam).toHaveCSS('color', expectedTextColor);
 
           const column2 = page.locator(`text=Column 2`);
 
@@ -295,11 +290,7 @@ test.describe(targetContext.name, () => {
             expectedColumnTextColor = 'rgb(126, 211, 33)'; // greenish text color
           }
 
-          await expectStyleForElement({
-            locator: column2,
-            cssProperty: 'color',
-            expectedValue: expectedColumnTextColor,
-          });
+          await expect(column2).toHaveCSS('color', expectedColumnTextColor);
 
           // Skipping this image test for react-native.
           // Its difficult to locate the image in react-native as css selectors don't work as expected.
@@ -329,11 +320,7 @@ test.describe(targetContext.name, () => {
             expectedTextColor = 'rgb(65, 117, 5)'; // greenish text color
           }
 
-          await expectStyleForElement({
-            locator: breakpointsPara,
-            cssProperty: 'color',
-            expectedValue: expectedTextColor,
-          });
+          await expect(breakpointsPara).toHaveCSS('color', expectedTextColor);
 
           const column2 = page.locator(`text=Column 2`);
 
@@ -342,11 +329,7 @@ test.describe(targetContext.name, () => {
             expectedColumnTextColor = 'rgb(126, 211, 33)'; // greenish text color
           }
 
-          await expectStyleForElement({
-            locator: column2,
-            cssProperty: 'color',
-            expectedValue: expectedColumnTextColor,
-          });
+          await expect(column2).toHaveCSS('color', expectedColumnTextColor);
 
           // Skipping this image test for react-native.
           // Its difficult to locate the image in react-native as css selectors don't work as expected.
@@ -370,18 +353,10 @@ test.describe(targetContext.name, () => {
           await page.goto('/custom-breakpoints');
 
           const breakpointsPara = page.locator(`text=BREAKPOINTS 500 - 800`);
-          await expectStyleForElement({
-            locator: breakpointsPara,
-            cssProperty: 'color',
-            expectedValue: 'rgb(65, 117, 5)',
-          });
+          await expect(breakpointsPara).toHaveCSS('color', 'rgb(65, 117, 5)');
 
           const column2 = page.locator(`text=Column 2`);
-          await expectStyleForElement({
-            locator: column2,
-            cssProperty: 'color',
-            expectedValue: 'rgb(126, 211, 33)', // greenish text color
-          });
+          await expect(column2).toHaveCSS('color', 'rgb(126, 211, 33)');
 
           // Skipping this image test for react-native.
           // Its difficult to locate the image in react-native as css selectors don't work as expected.
@@ -422,11 +397,7 @@ test.describe(targetContext.name, () => {
             expectedTextColor = 'rgb(65, 117, 5)'; // greenish text color
           }
 
-          await expectStyleForElement({
-            locator: breakpointsPara,
-            cssProperty: 'color',
-            expectedValue: expectedTextColor, // black text color
-          });
+          await expect(breakpointsPara).toHaveCSS('color', expectedTextColor);
 
           const column2 = page.locator(`text=Column 2`);
 
@@ -435,11 +406,7 @@ test.describe(targetContext.name, () => {
             expectedColumnTextColor = 'rgb(126, 211, 33)'; // greenish text color
           }
 
-          await expectStyleForElement({
-            locator: column2,
-            cssProperty: 'color',
-            expectedValue: expectedColumnTextColor,
-          });
+          await expect(column2).toHaveCSS('color', expectedColumnTextColor);
 
           // Skipping this image test for react-native.
           // Its difficult to locate the image in react-native as css selectors don't work as expected.
@@ -469,11 +436,7 @@ test.describe(targetContext.name, () => {
             expectedTextColor = 'rgb(65, 117, 5)'; // greenish text color
           }
 
-          await expectStyleForElement({
-            locator: breakpointsPara,
-            cssProperty: 'color',
-            expectedValue: expectedTextColor,
-          });
+          await expect(breakpointsPara).toHaveCSS('color', expectedTextColor);
 
           const column2 = page.locator(`text=Column 2`);
 
@@ -482,11 +445,7 @@ test.describe(targetContext.name, () => {
             expectedColumnTextColor = 'rgb(126, 211, 33)'; // greenish text color
           }
 
-          await expectStyleForElement({
-            locator: column2,
-            cssProperty: 'color',
-            expectedValue: expectedColumnTextColor,
-          });
+          await expect(column2).toHaveCSS('color', expectedColumnTextColor);
 
           // Skipping this image test for react-native.
           // Its difficult to locate the image in react-native as css selectors don't work as expected.
@@ -511,19 +470,11 @@ test.describe(targetContext.name, () => {
 
           const breakpointsPara = page.locator(`text=BREAKPOINTS 500 - 800`);
 
-          await expectStyleForElement({
-            locator: breakpointsPara,
-            cssProperty: 'color',
-            expectedValue: 'rgb(65, 117, 5)', // greenish text color
-          });
+          await expect(breakpointsPara).toHaveCSS('color', 'rgb(65, 117, 5)');
 
           const column2 = page.locator(`text=Column 2`);
 
-          await expectStyleForElement({
-            locator: column2,
-            cssProperty: 'color',
-            expectedValue: 'rgb(126, 211, 33)', // greenish text color
-          });
+          await expect(column2).toHaveCSS('color', 'rgb(126, 211, 33)');
 
           // Skipping this image test for react-native.
           // Its difficult to locate the image in react-native as css selectors don't work as expected.

--- a/packages/sdks-tests/src/tests/styles.spec.ts
+++ b/packages/sdks-tests/src/tests/styles.spec.ts
@@ -1,7 +1,7 @@
+import { expect } from '@playwright/test';
 import {
   test,
   excludeReactNative,
-  expectStyleForElement,
   isRNSDK,
   expectStylesForElement,
   findTextInPage,
@@ -16,11 +16,10 @@ test.describe('Styles', () => {
     }
 
     await page.goto('/data-binding-styles');
-    await expectStyleForElement({
-      locator: page.locator(`text="This text should be red..."`),
-      cssProperty: 'color',
-      expectedValue: 'rgb(255, 0, 0)',
-    });
+    await expect(page.locator(`text="This text should be red..."`)).toHaveCSS(
+      'color',
+      'rgb(255, 0, 0)'
+    );
   });
 
   test.describe('Style Bindings', () => {
@@ -94,11 +93,7 @@ test.describe('Styles', () => {
       ? page.locator('img').nth(1).locator('..').locator('..').locator('..').locator('..')
       : page.locator('picture').nth(1).locator('..').locator('..').locator('..');
 
-    await expectStyleForElement({
-      locator,
-      cssProperty: 'margin-left',
-      expectedValue: '0px',
-    });
+    await expect(locator).toHaveCSS('margin-left', '0px');
   });
 
   const excludeReactNativeAndOldReact = excludeTestFor({
@@ -112,17 +107,9 @@ test.describe('Styles', () => {
     await page.goto('./css-nesting');
 
     const blueText = page.locator('text=blue');
-    await expectStyleForElement({
-      locator: blueText,
-      cssProperty: 'color',
-      expectedValue: 'rgb(0, 0, 255)',
-    });
+    await expect(blueText).toHaveCSS('color', 'rgb(0, 0, 255)');
 
     const redText = page.locator('text=green');
-    await expectStyleForElement({
-      locator: redText,
-      cssProperty: 'color',
-      expectedValue: 'rgb(65, 117, 5)',
-    });
+    await expect(redText).toHaveCSS('color', 'rgb(65, 117, 5)');
   });
 });


### PR DESCRIPTION
## Description

- the old way might've been causing flakiness, and the new way is much simpler