### PR TITLE
allow observable to be awaited

### DIFF
--- a/packages/core/src/classes/observable.class.ts
+++ b/packages/core/src/classes/observable.class.ts
@@ -94,6 +94,10 @@ export class BehaviorSubject<T = any, ErrorType = any> {
   promise() {
     return this.toPromise();
   }
+
+  then: Promise<T>['then'] = (...args) => {
+    return this.toPromise().then(...args);
+  };
 }
 
 // TODO: make different classes


### PR DESCRIPTION
builder.get(...) has a quirk that it needs to end in `.promise()` in order ot be treated as a promise

this is unintuitive and leads to weird edge cases that are painful to debug, as demonstrated in our recent stream

this adds a `.then` function that allows builder.get to be awaited as people anticipate

aka it makes our observables "thenable" which means they get async/await support even if you forget to do the ugly .promise() or .toPromise() at the end