### PR TITLE
Change element type of text components to div

### DIFF
--- a/packages/sdks-tests/src/specs/css-nesting.ts
+++ b/packages/sdks-tests/src/specs/css-nesting.ts
@@ -6,7 +6,7 @@ export const CONTENT = {
     title: 'css-nesting',
     themeId: false,
     cssCode:
-      "/*\n* Custom CSS styles\n*\n* Global by default, but use `&` to scope to just this content, e.g.\n*\n*   & .foo {\n*     color: 'red'\n*   }\n*/\n\n& > div > div > div {\n  color: rgb(0, 0, 255)\n}\n& > div > div > div > div {\n  color: rgb(65, 117, 5)\n}\n",
+      "/*\n* Custom CSS styles\n*\n* Global by default, but use `&` to scope to just this content, e.g.\n*\n*   & .foo {\n*     color: 'red'\n*   }\n*/\n\n& > div > div > div > .builder-text {\n  color: rgb(0, 0, 255)\n}\n& > div > div > div > div > .builder-text {\n  color: rgb(65, 117, 5)\n}\n",
     blocks: [
       {
         '@type': '@builder.io/sdk:Element',

--- a/packages/sdks/src/blocks/raw-text/raw-text.lite.tsx
+++ b/packages/sdks/src/blocks/raw-text/raw-text.lite.tsx
@@ -7,7 +7,7 @@ export interface RawTextProps {
 
 export default function RawText(props: RawTextProps) {
   return (
-    <span
+    <div
       class={useTarget(
         /**
          * We have to explicitly provide `class` so that Mitosis knows to merge it with `css`.

--- a/packages/sdks/src/blocks/text/text.lite.tsx
+++ b/packages/sdks/src/blocks/text/text.lite.tsx
@@ -2,7 +2,7 @@ import { useTarget } from '@builder.io/mitosis';
 
 export default function Text(props: { text?: string }) {
   return (
-    <span
+    <div
       class={
         /* NOTE: This class name must be "builder-text" for inline editing to work in the Builder editor */
         'builder-text'


### PR DESCRIPTION
## Description

Since the text components often contain block level elements like `p` I think they should be `div` rather than `span`. This will also mollify some html validation tools.

If there is some strong reason why we need to use `span` let me know so I can document it. 

Thanks!