### PR TITLE
fixed exclude from translation for non text elements

### DIFF
--- a/packages/utils/package-lock.json
+++ b/packages/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/utils",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "lockfileVersion": 1,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/utils",
-      "version": "1.1.15",
+      "version": "1.1.16",
       "dependencies": {
         "@types/lodash": "^4.14.182",
         "lodash": "^4.17.21",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/utils",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "Utils for working with Builder.io content",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/utils/src/translation-helpers.ts
+++ b/packages/utils/src/translation-helpers.ts
@@ -56,7 +56,7 @@ export function getTranslateableFields(
             });
         }
       }
-      if (el && el.id && el.component?.name === 'Text' && !el.meta?.excludeFromTranslation) {
+      if (el && el.id && !el.meta?.excludeFromTranslation) {
         results[`blocks.${el.id}#text`] = {
           value: el.component.options.text,
           instructions: el.meta?.instructions || defaultInstructions,

--- a/plugins/phrase-conector/package-lock.json
+++ b/plugins/phrase-conector/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/plugin-phrase-connector",
-  "version": "0.0.4",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-phrase-connector",
-      "version": "0.0.4",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "@builder.io/commerce-plugin-tools": "^0.3.0",

--- a/plugins/phrase-conector/package.json
+++ b/plugins/phrase-conector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-phrase-connector",
-  "version": "0.0.5",
+  "version": "0.0.7",
   "description": "",
   "keywords": [],
   "main": "dist/plugin.system.js",
@@ -126,7 +126,7 @@
   },
   "dependencies": {
     "@builder.io/commerce-plugin-tools": "^0.3.0",
-    "@builder.io/utils": "^1.1.15",
+    "@builder.io/utils": "^1.1.16",
     "fast-json-stable-stringify": "^2.1.0",
     "lodash": "^4.17.21",
     "object-hash": "^3.0.0",

--- a/plugins/phrase-conector/src/plugin.tsx
+++ b/plugins/phrase-conector/src/plugin.tsx
@@ -111,7 +111,7 @@ registerPlugin(
         }
         const element = selectedElements[0];
         const isExcluded = element.meta?.get(transcludedMetaKey);
-        return element.component?.name === 'Text' && !isExcluded;
+        return !isExcluded;
       },
       onClick(elements) {
         elements.forEach(el => el.meta.set('excludeFromTranslation', true));
@@ -127,7 +127,7 @@ registerPlugin(
         }
         const element = selectedElements[0];
         const isExcluded = element.meta?.get(transcludedMetaKey);
-        return element.component?.name === 'Text' && isExcluded;
+        return isExcluded;
       },
       onClick(elements) {
         elements.forEach(el => el.meta.set('excludeFromTranslation', false));

--- a/plugins/smartling/package-lock.json
+++ b/plugins/smartling/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/plugin-smartling",
-  "version": "0.0.10",
+  "version": "0.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-smartling",
-      "version": "0.0.10",
+      "version": "0.0.13",
       "license": "MIT",
       "dependencies": {
         "@builder.io/commerce-plugin-tools": "^0.3.0",

--- a/plugins/smartling/package.json
+++ b/plugins/smartling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-smartling",
-  "version": "0.0.11",
+  "version": "0.0.13",
   "description": "",
   "keywords": [],
   "main": "dist/plugin.system.js",
@@ -126,7 +126,7 @@
   },
   "dependencies": {
     "@builder.io/commerce-plugin-tools": "^0.3.0",
-    "@builder.io/utils": "^1.1.15",
+    "@builder.io/utils": "^1.1.16",
     "fast-json-stable-stringify": "^2.1.0",
     "lodash": "^4.17.21",
     "object-hash": "^3.0.0",

--- a/plugins/smartling/src/plugin.tsx
+++ b/plugins/smartling/src/plugin.tsx
@@ -217,7 +217,7 @@ registerPlugin(
         }
         const element = selectedElements[0];
         const isExcluded = element.meta?.get(transcludedMetaKey);
-        return element.component?.name === 'Text' && !isExcluded;
+        return !isExcluded;
       },
       onClick(elements) {
         elements.forEach(el => el.meta.set('excludeFromTranslation', true));
@@ -233,7 +233,7 @@ registerPlugin(
         }
         const element = selectedElements[0];
         const isExcluded = element.meta?.get(transcludedMetaKey);
-        return element.component?.name === 'Text' && isExcluded;
+        return isExcluded;
       },
       onClick(elements) {
         elements.forEach(el => el.meta.set('excludeFromTranslation', false));


### PR DESCRIPTION
Removed comparison to text element to exclude elements from translation

How to test:

1 - Install smartling or phrase plugin
2 - Enable localization
3 - Right click on a non text element and check if the exclude from translation options is displayed
