### PR TITLE
[Sdk][Core] ENG-4015 Re-introduce friendlyName for components

### DIFF
--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -750,7 +750,6 @@ export interface Component {
     query?: any;
   };
 
-  /** @hidden @deprecated */
   friendlyName?: string;
 
   /**

--- a/packages/sdks/src/types/components.ts
+++ b/packages/sdks/src/types/components.ts
@@ -102,7 +102,6 @@ export interface ComponentInfo {
     query?: any;
   };
 
-  /** not yet implemented */
   friendlyName?: string;
 
   /**


### PR DESCRIPTION
## Description
With the recent changes made to content editor to display friendlyName, when available, for custom components, we now de-deprecate the field so it can be utilized by sdk consumers.

Related content editor PR - [https://github.com/BuilderIO/builder-internal/pull/4978](https://github.com/BuilderIO/builder-internal/pull/4978)