### PR TITLE
[Fix][SDK] ENG-4263 Added the styles shipped in vue sdk to the Vue seed projects

### DIFF
--- a/examples/vue/nuxt-3-catchall/pages/[...app].vue
+++ b/examples/vue/nuxt-3-catchall/pages/[...app].vue
@@ -20,6 +20,7 @@
 
 <script setup>
 import { RenderContent, getContent, isPreviewing } from '@builder.io/sdk-vue/vue3';
+import '@builder.io/sdk-vue/vue3/css';
 
 import HelloWorldComponent from '../components/HelloWorld.vue';
 

--- a/examples/vue/nuxt-3/app.vue
+++ b/examples/vue/nuxt-3/app.vue
@@ -41,8 +41,7 @@ const REGISTERED_COMPONENTS = [
 ];
 
 // TODO: enter your public API key
-// const BUILDER_PUBLIC_API_KEY = '717f6f07a937428fb26823965e8bc41c'; // ggignore
-const BUILDER_PUBLIC_API_KEY = '27a7dd0a85424a03a17032d03fa429c6'; // ggignore
+const BUILDER_PUBLIC_API_KEY = 'f1a790f8c3204b3b8c5c1795aeac4660'; // ggignore
 
 const route = useRoute();
 

--- a/examples/vue/nuxt-3/app.vue
+++ b/examples/vue/nuxt-3/app.vue
@@ -20,6 +20,7 @@
 
 <script setup>
 import { RenderContent, getContent, isPreviewing } from '@builder.io/sdk-vue/vue3';
+import '@builder.io/sdk-vue/vue3/css';
 
 import HelloWorldComponent from './components/HelloWorld.vue';
 
@@ -40,7 +41,8 @@ const REGISTERED_COMPONENTS = [
 ];
 
 // TODO: enter your public API key
-const BUILDER_PUBLIC_API_KEY = 'f1a790f8c3204b3b8c5c1795aeac4660'; // ggignore
+// const BUILDER_PUBLIC_API_KEY = '717f6f07a937428fb26823965e8bc41c'; // ggignore
+const BUILDER_PUBLIC_API_KEY = '27a7dd0a85424a03a17032d03fa429c6'; // ggignore
 
 const route = useRoute();
 


### PR DESCRIPTION
## Description
VUE sdk ships a style.css which needs to be included explicitly by customers in their projects.
Our seed projects should also include it. 

Our VUE based examples have it but NUXT based ones are missing this inclusion.
`import '@builder.io/sdk-vue/vue3/css';`

Adding it now.

_Screenshot_
Before - 
<img width="1146" alt="image" src="https://github.com/BuilderIO/builder/assets/98028693/3f502c00-aa2d-4b26-b2fc-e4c3d6f07d52">

After - 
<img width="1207" alt="image" src="https://github.com/BuilderIO/builder/assets/98028693/d6b83d1e-5712-4c6e-89fa-0e6b1cd0c293">

