### PR TITLE
[Sdk] Set 'noTraverse' to true as default when using getAll builder api

### DIFF
--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -2667,10 +2667,10 @@ export class Builder {
 
     if (!options.options) {
       options.options = {
-        enrich: false,
+        noTraverse: true,
       };
-    } else if (!('enrich' in options.options)) {
-      options.options.enrich = false;
+    } else if (!('noTraverse' in options.options)) {
+      options.options.noTraverse = true;
     }
 
     return instance

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -2665,6 +2665,7 @@ export class Builder {
       }
     }
 
+    // Set noTraverse=true if NOT already passed by user, for query performance
     if (!options.options) {
       options.options = {
         noTraverse: true,

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -453,6 +453,13 @@ export type GetContentOptions = AllowEnrich & {
    * content thinking they should updates when they actually shouldn't.
    */
   noEditorUpdates?: boolean;
+
+  /**
+   * If set to `true`, it will lazy load symbols/references.
+   * If set to `false`, it will render the entire content tree eagerly.
+   * @deprecated use `enrich` instead
+   */
+  noTraverse?: boolean;
 };
 
 export type Class = {
@@ -2332,6 +2339,9 @@ export class Builder {
     }
     if (queue[0].format) {
       queryParams.format = queue[0].format;
+    }
+    if (queue[0].noTraverse) {
+      queryParams.noTraverse = queue[0].noTraverse;
     }
 
     const pageQueryParams: ParamsMap =

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -2337,7 +2337,7 @@ export class Builder {
     const pageQueryParams: ParamsMap =
       typeof location !== 'undefined'
         ? QueryString.parseDeep(location.search.substr(1))
-        : undefined || {};
+        : undefined || {}; // TODO: WHAT about SSR (this.request) ?
 
     const userAttributes =
       // FIXME: HACK: only checks first in queue for user attributes overrides, should check all
@@ -2663,6 +2663,14 @@ export class Builder {
       if (options.apiVersion && !this.apiVersion) {
         this.apiVersion = options.apiVersion;
       }
+    }
+
+    if (!options.options) {
+      options.options = {
+        enrich: false,
+      };
+    } else if (!('enrich' in options.options)) {
+      options.options.enrich = false;
     }
 
     return instance

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -2340,7 +2340,7 @@ export class Builder {
     if (queue[0].format) {
       queryParams.format = queue[0].format;
     }
-    if (queue[0].noTraverse) {
+    if ('noTraverse' in queue[0]) {
       queryParams.noTraverse = queue[0].noTraverse;
     }
 
@@ -2676,12 +2676,8 @@ export class Builder {
     }
 
     // Set noTraverse=true if NOT already passed by user, for query performance
-    if (!options.options) {
-      options.options = {
-        noTraverse: true,
-      };
-    } else if (!('noTraverse' in options.options)) {
-      options.options.noTraverse = true;
+    if (!('noTraverse' in options)) {
+      options.noTraverse = true;
     }
 
     return instance

--- a/packages/sdks/src/functions/get-content/__snapshots__/generate-content-url.test.ts.snap
+++ b/packages/sdks/src/functions/get-content/__snapshots__/generate-content-url.test.ts.snap
@@ -1,15 +1,33 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Generate Content URL > Handles overrides correctly 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=false&includeRefs=true&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
+exports[`Generate Content URL > Handles overrides correctly 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
 
-exports[`Generate Content URL > generate content url with apiVersion as default 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=false&includeRefs=true&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
+exports[`Generate Content URL > generate content url with apiVersion as default 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
 
-exports[`Generate Content URL > generate content url with apiVersion as v2 1`] = `"https://cdn.builder.io/api/v2/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=false&includeRefs=true&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
+exports[`Generate Content URL > generate content url with apiVersion as v2 1`] = `"https://cdn.builder.io/api/v2/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
 
-exports[`Generate Content URL > generate content url with apiVersion as v3 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=false&includeRefs=true&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
+exports[`Generate Content URL > generate content url with apiVersion as v3 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
 
-exports[`Generate Content URL > generate content url with enrich option not present 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=false&includeRefs=true"`;
+exports[`Generate Content URL > generate content url with enrich option not present 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true"`;
 
-exports[`Generate Content URL > generate content url with enrich option true 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=false&includeRefs=true&enrich=true"`;
+exports[`Generate Content URL > generate content url with enrich option true 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&enrich=true"`;
 
-exports[`Generate Content URL > generates the proper value for a simple query 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=false&includeRefs=true&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
+exports[`Generate Content URL > generate content url with limit set to 1 and check for noTraverse 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=1&noTraverse=false&includeRefs=true"`;
+
+exports[`Generate Content URL > generate content url with limit set to 2 and check for noTraverse 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=2&noTraverse=true&includeRefs=true"`;
+
+exports[`Generate Content URL > generate content url with limit unset and check for noTraverse 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true"`;
+
+exports[`Generate Content URL > generate content url with noTraverse option false 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=false&includeRefs=true"`;
+
+exports[`Generate Content URL > generate content url with noTraverse option false and limit set to 1 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=1&noTraverse=false&includeRefs=true"`;
+
+exports[`Generate Content URL > generate content url with noTraverse option false and limit set to 2 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=2&noTraverse=false&includeRefs=true"`;
+
+exports[`Generate Content URL > generate content url with noTraverse option true 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true"`;
+
+exports[`Generate Content URL > generate content url with noTraverse option true and limit set to 1 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=1&noTraverse=true&includeRefs=true"`;
+
+exports[`Generate Content URL > generate content url with noTraverse option true and limit set to 2 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=2&noTraverse=true&includeRefs=true"`;
+
+exports[`Generate Content URL > generates the proper value for a simple query 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&query.id=%22c1b81bab59704599b997574eb0736def%22"`;

--- a/packages/sdks/src/functions/get-content/generate-content-url.test.ts
+++ b/packages/sdks/src/functions/get-content/generate-content-url.test.ts
@@ -109,4 +109,88 @@ describe('Generate Content URL', () => {
     });
     expect(output).toMatchSnapshot();
   });
+
+  test('generate content url with limit unset and check for noTraverse', () => {
+    const output = generateContentUrl({
+      apiKey: testKey,
+      model: testModel,
+    });
+    expect(output).toMatchSnapshot();
+  });
+
+  test('generate content url with noTraverse option true', () => {
+    const output = generateContentUrl({
+      apiKey: testKey,
+      model: testModel,
+      noTraverse: true,
+    });
+    expect(output).toMatchSnapshot();
+  });
+
+  test('generate content url with noTraverse option false', () => {
+    const output = generateContentUrl({
+      apiKey: testKey,
+      model: testModel,
+      noTraverse: false,
+    });
+    expect(output).toMatchSnapshot();
+  });
+
+  test('generate content url with noTraverse option true and limit set to 2', () => {
+    const output = generateContentUrl({
+      apiKey: testKey,
+      model: testModel,
+      noTraverse: true,
+      limit: 2,
+    });
+    expect(output).toMatchSnapshot();
+  });
+
+  test('generate content url with noTraverse option false and limit set to 2', () => {
+    const output = generateContentUrl({
+      apiKey: testKey,
+      model: testModel,
+      noTraverse: false,
+      limit: 2,
+    });
+    expect(output).toMatchSnapshot();
+  });
+
+  test('generate content url with limit set to 2 and check for noTraverse', () => {
+    const output = generateContentUrl({
+      apiKey: testKey,
+      model: testModel,
+      limit: 2,
+    });
+    expect(output).toMatchSnapshot();
+  });
+
+  test('generate content url with limit set to 1 and check for noTraverse', () => {
+    const output = generateContentUrl({
+      apiKey: testKey,
+      model: testModel,
+      limit: 1,
+    });
+    expect(output).toMatchSnapshot();
+  });
+
+  test('generate content url with noTraverse option true and limit set to 1', () => {
+    const output = generateContentUrl({
+      apiKey: testKey,
+      model: testModel,
+      noTraverse: true,
+      limit: 1,
+    });
+    expect(output).toMatchSnapshot();
+  });
+
+  test('generate content url with noTraverse option false and limit set to 1', () => {
+    const output = generateContentUrl({
+      apiKey: testKey,
+      model: testModel,
+      noTraverse: false,
+      limit: 1,
+    });
+    expect(output).toMatchSnapshot();
+  });
 });

--- a/packages/sdks/src/functions/get-content/generate-content-url.ts
+++ b/packages/sdks/src/functions/get-content/generate-content-url.ts
@@ -7,11 +7,12 @@ import type { GetContentOptions } from './types.js';
 import { DEFAULT_API_VERSION } from '../../types/api-version.js';
 
 export const generateContentUrl = (options: GetContentOptions): URL => {
+  let { noTraverse = false } = options;
+
   const {
     limit = 30,
     userAttributes,
     query,
-    noTraverse = false,
     model,
     apiKey,
     includeRefs = true,
@@ -28,6 +29,14 @@ export const generateContentUrl = (options: GetContentOptions): URL => {
     throw new Error(
       `Invalid apiVersion: expected 'v2' or 'v3', received '${apiVersion}'`
     );
+  }
+
+  // Set noTraverse=true if NOT already passed by user, for query performance
+  if (
+    (options.limit === undefined || options.limit > 1) &&
+    !('noTraverse' in options)
+  ) {
+    noTraverse = true;
   }
 
   const url = new URL(

--- a/packages/sdks/src/functions/get-content/index.ts
+++ b/packages/sdks/src/functions/get-content/index.ts
@@ -47,6 +47,16 @@ type ContentResponse =
     };
 
 const _fetchContent = async (options: GetContentOptions) => {
+  if (options.limit === undefined || options.limit > 1) {
+    if (!options.options) {
+      options.options = {
+        enrich: false,
+      };
+    } else if (!('enrich' in options.options)) {
+      options.options.set('enrich', false);
+    }
+  }
+
   const url = generateContentUrl(options);
 
   const res = await fetch(url.href);

--- a/packages/sdks/src/functions/get-content/index.ts
+++ b/packages/sdks/src/functions/get-content/index.ts
@@ -47,13 +47,6 @@ type ContentResponse =
     };
 
 const _fetchContent = async (options: GetContentOptions) => {
-  // Set noTraverse=true if NOT already passed by user, for query performance
-  if (options.limit === undefined || options.limit > 1) {
-    if (!('noTraverse' in options)) {
-      options.noTraverse = true;
-    }
-  }
-
   const url = generateContentUrl(options);
 
   const res = await fetch(url.href);

--- a/packages/sdks/src/functions/get-content/index.ts
+++ b/packages/sdks/src/functions/get-content/index.ts
@@ -61,7 +61,7 @@ const _fetchContent = async (options: GetContentOptions) => {
   const url = generateContentUrl(options);
 
   const res = await fetch(url.href);
-  const content = await(res.json() as Promise<ContentResponse>);
+  const content = await (res.json() as Promise<ContentResponse>);
   return content;
 };
 

--- a/packages/sdks/src/functions/get-content/index.ts
+++ b/packages/sdks/src/functions/get-content/index.ts
@@ -47,6 +47,7 @@ type ContentResponse =
     };
 
 const _fetchContent = async (options: GetContentOptions) => {
+  // Set noTraverse=true if NOT already passed by user, for query performance
   if (options.limit === undefined || options.limit > 1) {
     if (!options.options) {
       options.options = {
@@ -60,7 +61,7 @@ const _fetchContent = async (options: GetContentOptions) => {
   const url = generateContentUrl(options);
 
   const res = await fetch(url.href);
-  const content = await (res.json() as Promise<ContentResponse>);
+  const content = await(res.json() as Promise<ContentResponse>);
   return content;
 };
 

--- a/packages/sdks/src/functions/get-content/index.ts
+++ b/packages/sdks/src/functions/get-content/index.ts
@@ -50,10 +50,10 @@ const _fetchContent = async (options: GetContentOptions) => {
   if (options.limit === undefined || options.limit > 1) {
     if (!options.options) {
       options.options = {
-        enrich: false,
+        noTraverse: true,
       };
-    } else if (!('enrich' in options.options)) {
-      options.options.set('enrich', false);
+    } else if (!('noTraverse' in options.options)) {
+      options.options.set('noTraverse', true);
     }
   }
 

--- a/packages/sdks/src/functions/get-content/index.ts
+++ b/packages/sdks/src/functions/get-content/index.ts
@@ -49,12 +49,8 @@ type ContentResponse =
 const _fetchContent = async (options: GetContentOptions) => {
   // Set noTraverse=true if NOT already passed by user, for query performance
   if (options.limit === undefined || options.limit > 1) {
-    if (!options.options) {
-      options.options = {
-        noTraverse: true,
-      };
-    } else if (!('noTraverse' in options.options)) {
-      options.options.set('noTraverse', true);
+    if (!('noTraverse' in options)) {
+      options.noTraverse = true;
     }
   }
 


### PR DESCRIPTION
## Description
Make 'noTraverse' option as true by default for getAll api invocation. It still can be overridden if user passes it.


