### PR TITLE
Fix inline editing of interpolated text in react sdk

### DIFF
--- a/packages/react/src/blocks/Text.tsx
+++ b/packages/react/src/blocks/Text.tsx
@@ -25,7 +25,26 @@ class TextComponent extends React.Component<TextProps> {
   }
 
   evalExpression(expression: string, state: any) {
+    // Don't interpolate when inline editing
+    if (this.allowTextEdit) {
+      return String(expression);
+    }
     return String(expression).replace(/{{([^}]+)}}/g, (match, group) => tryEval(group, state));
+  }
+
+  get allowTextEdit() {
+    return (
+      Builder.isBrowser &&
+      Builder.isEditing &&
+      location.search.includes('builder.allowTextEdit=true') &&
+      !(
+        this.props.builderBlock &&
+        this.props.builderBlock.bindings &&
+        (this.props.builderBlock.bindings['component.options.text'] ||
+          this.props.builderBlock.bindings['options.text'] ||
+          this.props.builderBlock.bindings['text'])
+      )
+    );
   }
 
   render() {


### PR DESCRIPTION
## Description

Inline editing was operating on the post-interpolated text causing interpolations to be lost. This change makes the interpolations visible when inline editing so that they can be modified inline without getting lost.

https://www.loom.com/share/a0f65ab46c9c4fa09eb2813deb3929b9?sid=6a854ae5-f723-41e2-b9e5-4877924edc70