### PR TITLE
[SDKs][Fix] ENG-3913 Updated docs for GetContentOptions type and implemented missing fields in generated url

### DIFF
--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -300,13 +300,14 @@ export type GetContentOptions = AllowEnrich & {
    */
   includeUrl?: boolean;
   /**
-   * Follow references. If you use the `reference` field to pull in other content without this
+   * Include content of references in the response.
+   * If you use the `reference` field to pull in other content without this
    * enabled we will not fetch that content for the final response.
    * @deprecated use `enrich` instead
    */
   includeRefs?: boolean;
   /**
-   * How long in seconds content should be cached for. Sets the max-age of the cache-control header
+   * Seconds to cache content. Sets the max-age of the cache-control header
    * response header.
    *
    * Use a higher value for better performance, lower for content that will change more frequently
@@ -363,7 +364,7 @@ export type GetContentOptions = AllowEnrich & {
    */
   extractCss?: boolean;
   /**
-   * Pagination results offset. Defaults to zero.
+   * Use to specify an offset for pagination of results. The default is 0.
    */
   offset?: number;
   /**
@@ -401,13 +402,21 @@ export type GetContentOptions = AllowEnrich & {
    * @hidden
    */
   alias?: string;
+  /**
+   * Only include these fields.
+   *
+   * @example
+   * ```
+   * fields: 'id, name, data.customField'
+   * ```
+   */
   fields?: string;
   /**
    * Omit only these fields.
    *
    * @example
    * ```
-   * &omit=data.bigField,data.blocks
+   * omit: 'data.bigField,data.blocks'
    * ```
    */
   omit?: string;
@@ -460,6 +469,26 @@ export type GetContentOptions = AllowEnrich & {
    * @deprecated use `enrich` instead
    */
   noTraverse?: boolean;
+
+  /**
+   * Property to order results by.
+   * Use 1 for ascending and -1 for descending.
+   *
+   * The key is what you're sorting on, so the following example sorts by createdDate
+   * and because the value is 1, the sort is ascending.
+   *
+   * @example
+   * ```
+   * createdDate: 1
+   * ```
+   */
+  sort?: { [key: string]: 1 | -1 };
+
+  /**
+   * Include content entries in a response that are still in
+   * draft mode and un-archived.
+   */
+  includeUnpublished?: boolean;
 };
 
 export type Class = {
@@ -2342,6 +2371,17 @@ export class Builder {
     }
     if ('noTraverse' in queue[0]) {
       queryParams.noTraverse = queue[0].noTraverse;
+    }
+    if ('includeUnpublished' in queue[0]) {
+      queryParams.includeUnpublished = queue[0].includeUnpublished;
+    }
+    if (queue[0].sort) {
+      try {
+        queryParams.sort = JSON.stringify(queue[0].sort);
+      } catch (ex) {
+        console.error(`Error stringifying sort field with value ${queue[0].sort} !`, ex);
+        delete queryParams.sort;
+      }
     }
 
     const pageQueryParams: ParamsMap =

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -2378,12 +2378,7 @@ export class Builder {
       queryParams.includeUnpublished = queue[0].includeUnpublished;
     }
     if (queue[0].sort) {
-      try {
-        queryParams.sort = JSON.stringify(queue[0].sort);
-      } catch (ex) {
-        console.error(`Error stringifying sort field with value ${queue[0].sort} !`, ex);
-        delete queryParams.sort;
-      }
+      queryParams.sort = queue[0].sort;
     }
 
     const pageQueryParams: ParamsMap =

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -331,6 +331,10 @@ export type GetContentOptions = AllowEnrich & {
    */
   limit?: number;
   /**
+   * Use to specify an offset for pagination of results. The default is 0.
+   */
+  offset?: number;
+  /**
    * Mongodb style query of your data. E.g.:
    *
    * ```js
@@ -363,10 +367,6 @@ export type GetContentOptions = AllowEnrich & {
    * Extract any styles to a separate css property when generating HTML.
    */
   extractCss?: boolean;
-  /**
-   * Use to specify an offset for pagination of results. The default is 0.
-   */
-  offset?: number;
   /**
    * @package
    *
@@ -404,6 +404,7 @@ export type GetContentOptions = AllowEnrich & {
   alias?: string;
   /**
    * Only include these fields.
+   * Note: 'omit' takes precedence over 'fields'
    *
    * @example
    * ```
@@ -413,6 +414,7 @@ export type GetContentOptions = AllowEnrich & {
   fields?: string;
   /**
    * Omit only these fields.
+   * Note: 'omit' takes precedence over 'fields'
    *
    * @example
    * ```
@@ -486,7 +488,7 @@ export type GetContentOptions = AllowEnrich & {
 
   /**
    * Include content entries in a response that are still in
-   * draft mode and un-archived.
+   * draft mode and un-archived. Default is false.
    */
   includeUnpublished?: boolean;
 };

--- a/packages/sdks/src/functions/get-content/__snapshots__/generate-content-url.test.ts.snap
+++ b/packages/sdks/src/functions/get-content/__snapshots__/generate-content-url.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`Generate Content URL > Handles overrides correctly 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
 
+exports[`Generate Content URL > generate content url when given invalid values of offset, includeUnpublished, cacheSeconds, staleCacheSeconds 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed&includeUnpublished=false"`;
+
 exports[`Generate Content URL > generate content url with apiVersion as default 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
 
 exports[`Generate Content URL > generate content url with apiVersion as v2 1`] = `"https://cdn.builder.io/api/v2/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
@@ -29,5 +31,7 @@ exports[`Generate Content URL > generate content url with noTraverse option true
 exports[`Generate Content URL > generate content url with noTraverse option true and limit set to 1 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=1&noTraverse=true&includeRefs=true&omit=meta.componentsUsed"`;
 
 exports[`Generate Content URL > generate content url with noTraverse option true and limit set to 2 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=2&noTraverse=true&includeRefs=true&omit=meta.componentsUsed"`;
+
+exports[`Generate Content URL > generate content url with omit, fields, offset, includeUnpublished, cacheSeconds, staleCacheSeconds and sort combination 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=someId%2C+some.nested.id&fields=id%2C+nested.property&offset=1&includeUnpublished=true&cacheSeconds=5&staleCacheSeconds=10&sort.updatedDate=-1&sort.createdDate=1"`;
 
 exports[`Generate Content URL > generates the proper value for a simple query 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed&query.id=%22c1b81bab59704599b997574eb0736def%22"`;

--- a/packages/sdks/src/functions/get-content/__snapshots__/generate-content-url.test.ts.snap
+++ b/packages/sdks/src/functions/get-content/__snapshots__/generate-content-url.test.ts.snap
@@ -1,33 +1,33 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Generate Content URL > Handles overrides correctly 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
+exports[`Generate Content URL > Handles overrides correctly 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
 
-exports[`Generate Content URL > generate content url with apiVersion as default 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
+exports[`Generate Content URL > generate content url with apiVersion as default 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
 
-exports[`Generate Content URL > generate content url with apiVersion as v2 1`] = `"https://cdn.builder.io/api/v2/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
+exports[`Generate Content URL > generate content url with apiVersion as v2 1`] = `"https://cdn.builder.io/api/v2/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
 
-exports[`Generate Content URL > generate content url with apiVersion as v3 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
+exports[`Generate Content URL > generate content url with apiVersion as v3 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
 
-exports[`Generate Content URL > generate content url with enrich option not present 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true"`;
+exports[`Generate Content URL > generate content url with enrich option not present 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed"`;
 
-exports[`Generate Content URL > generate content url with enrich option true 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&enrich=true"`;
+exports[`Generate Content URL > generate content url with enrich option true 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&enrich=true&omit=meta.componentsUsed"`;
 
-exports[`Generate Content URL > generate content url with limit set to 1 and check for noTraverse 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=1&noTraverse=false&includeRefs=true"`;
+exports[`Generate Content URL > generate content url with limit set to 1 and check for noTraverse 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=1&noTraverse=false&includeRefs=true&omit=meta.componentsUsed"`;
 
-exports[`Generate Content URL > generate content url with limit set to 2 and check for noTraverse 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=2&noTraverse=true&includeRefs=true"`;
+exports[`Generate Content URL > generate content url with limit set to 2 and check for noTraverse 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=2&noTraverse=true&includeRefs=true&omit=meta.componentsUsed"`;
 
-exports[`Generate Content URL > generate content url with limit unset and check for noTraverse 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true"`;
+exports[`Generate Content URL > generate content url with limit unset and check for noTraverse 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed"`;
 
-exports[`Generate Content URL > generate content url with noTraverse option false 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=false&includeRefs=true"`;
+exports[`Generate Content URL > generate content url with noTraverse option false 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=false&includeRefs=true&omit=meta.componentsUsed"`;
 
-exports[`Generate Content URL > generate content url with noTraverse option false and limit set to 1 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=1&noTraverse=false&includeRefs=true"`;
+exports[`Generate Content URL > generate content url with noTraverse option false and limit set to 1 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=1&noTraverse=false&includeRefs=true&omit=meta.componentsUsed"`;
 
-exports[`Generate Content URL > generate content url with noTraverse option false and limit set to 2 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=2&noTraverse=false&includeRefs=true"`;
+exports[`Generate Content URL > generate content url with noTraverse option false and limit set to 2 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=2&noTraverse=false&includeRefs=true&omit=meta.componentsUsed"`;
 
-exports[`Generate Content URL > generate content url with noTraverse option true 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true"`;
+exports[`Generate Content URL > generate content url with noTraverse option true 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed"`;
 
-exports[`Generate Content URL > generate content url with noTraverse option true and limit set to 1 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=1&noTraverse=true&includeRefs=true"`;
+exports[`Generate Content URL > generate content url with noTraverse option true and limit set to 1 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=1&noTraverse=true&includeRefs=true&omit=meta.componentsUsed"`;
 
-exports[`Generate Content URL > generate content url with noTraverse option true and limit set to 2 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=2&noTraverse=true&includeRefs=true"`;
+exports[`Generate Content URL > generate content url with noTraverse option true and limit set to 2 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=2&noTraverse=true&includeRefs=true&omit=meta.componentsUsed"`;
 
-exports[`Generate Content URL > generates the proper value for a simple query 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
+exports[`Generate Content URL > generates the proper value for a simple query 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed&query.id=%22c1b81bab59704599b997574eb0736def%22"`;

--- a/packages/sdks/src/functions/get-content/generate-content-url.test.ts
+++ b/packages/sdks/src/functions/get-content/generate-content-url.test.ts
@@ -193,4 +193,34 @@ describe('Generate Content URL', () => {
     });
     expect(output).toMatchSnapshot();
   });
+
+  test('generate content url with omit, fields, offset, includeUnpublished, cacheSeconds, staleCacheSeconds and sort combination', () => {
+    const output = generateContentUrl({
+      apiKey: testKey,
+      model: testModel,
+      omit: 'someId, some.nested.id',
+      fields: 'id, nested.property',
+      offset: 1,
+      includeUnpublished: true,
+      cacheSeconds: 5,
+      staleCacheSeconds: 10,
+      sort: {
+        updatedDate: -1,
+        createdDate: 1,
+      },
+    });
+    expect(output).toMatchSnapshot();
+  });
+
+  test('generate content url when given invalid values of offset, includeUnpublished, cacheSeconds, staleCacheSeconds', () => {
+    const output = generateContentUrl({
+      apiKey: testKey,
+      model: testModel,
+      offset: -10,
+      includeUnpublished: false,
+      cacheSeconds: -5,
+      staleCacheSeconds: -10,
+    });
+    expect(output).toMatchSnapshot();
+  });
 });

--- a/packages/sdks/src/functions/get-content/generate-content-url.ts
+++ b/packages/sdks/src/functions/get-content/generate-content-url.ts
@@ -78,11 +78,9 @@ export const generateContentUrl = (options: GetContentOptions): URL => {
   }
 
   if (sort) {
-    try {
-      const stringifiedSortValue = JSON.stringify(sort);
-      url.searchParams.set('sort', stringifiedSortValue);
-    } catch (ex) {
-      console.error(`Error stringifying sort field with value ${sort} !`, ex);
+    const flattened = flatten({ sort });
+    for (const key in flattened) {
+      url.searchParams.set(key, JSON.stringify((flattened as any)[key]));
     }
   }
 

--- a/packages/sdks/src/functions/get-content/generate-content-url.ts
+++ b/packages/sdks/src/functions/get-content/generate-content-url.ts
@@ -61,6 +61,10 @@ export const generateContentUrl = (options: GetContentOptions): URL => {
     url.searchParams.set('fields', fields);
   }
 
+  if (Number.isFinite(offset) && offset! > -1) {
+    url.searchParams.set('offset', String(Math.floor(offset!)));
+  }
+
   if (typeof includeUnpublished === 'boolean') {
     url.searchParams.set('includeUnpublished', String(includeUnpublished));
   }

--- a/packages/sdks/src/functions/get-content/generate-content-url.ts
+++ b/packages/sdks/src/functions/get-content/generate-content-url.ts
@@ -6,6 +6,9 @@ import {
 import type { GetContentOptions } from './types.js';
 import { DEFAULT_API_VERSION } from '../../types/api-version.js';
 
+const isPositiveNumber = (thing: unknown) =>
+  typeof thing === 'number' && !isNaN(thing) && thing >= 0;
+
 export const generateContentUrl = (options: GetContentOptions): URL => {
   let { noTraverse = false } = options;
 
@@ -19,6 +22,13 @@ export const generateContentUrl = (options: GetContentOptions): URL => {
     enrich,
     locale,
     apiVersion = DEFAULT_API_VERSION,
+    fields,
+    omit,
+    offset,
+    cacheSeconds,
+    staleCacheSeconds,
+    sort,
+    includeUnpublished,
   } = options;
 
   if (!apiKey) {
@@ -44,6 +54,35 @@ export const generateContentUrl = (options: GetContentOptions): URL => {
       locale ? `&locale=${locale}` : ''
     }${enrich ? `&enrich=${enrich}` : ''}`
   );
+
+  url.searchParams.set('omit', omit || 'meta.componentsUsed');
+
+  if (fields) {
+    url.searchParams.set('fields', fields);
+  }
+
+  if (typeof includeUnpublished === 'boolean') {
+    url.searchParams.set('includeUnpublished', String(includeUnpublished));
+  }
+
+  if (cacheSeconds && isPositiveNumber(cacheSeconds)) {
+    url.searchParams.set('cacheSeconds', String(cacheSeconds));
+  }
+
+  if (staleCacheSeconds && isPositiveNumber(staleCacheSeconds)) {
+    url.searchParams.set('staleCacheSeconds', String(staleCacheSeconds));
+  }
+
+  if (sort) {
+    try {
+      const stringifiedSortValue = JSON.stringify(sort);
+      url.searchParams.set('sort', stringifiedSortValue);
+    } catch (ex) {
+      console.error(`Error stringifying sort field with value ${sort} !`, ex);
+    }
+  }
+
+  // TODO: how to express 'offset' in the url - as direct queryparam or as flattened in options[key] ?
 
   const queryOptions = {
     ...getBuilderSearchParamsFromWindow(),

--- a/packages/sdks/src/functions/get-content/types.ts
+++ b/packages/sdks/src/functions/get-content/types.ts
@@ -9,6 +9,11 @@ export interface GetContentOptions {
   limit?: number;
 
   /**
+   * Use to specify an offset for pagination of results. The default is 0.
+   */
+  offset?: number;
+
+  /**
    * User attribute key value pairs to be used for targeting
    * https://www.builder.io/c/docs/custom-targeting-attributes
    *
@@ -87,6 +92,7 @@ export interface GetContentOptions {
 
   /**
    * Only include these fields.
+   * Note: 'omit' takes precedence over 'fields'
    *
    * @example
    * ```
@@ -97,6 +103,7 @@ export interface GetContentOptions {
 
   /**
    * Omit only these fields.
+   * Note: 'omit' takes precedence over 'fields'
    *
    * @example
    * ```
@@ -104,11 +111,6 @@ export interface GetContentOptions {
    * ```
    */
   omit?: string;
-
-  /**
-   * Use to specify an offset for pagination of results. The default is 0.
-   */
-  offset?: number;
 
   /**
    * Seconds to cache content. Sets the max-age of the cache-control header
@@ -148,7 +150,7 @@ export interface GetContentOptions {
 
   /**
    * Include content entries in a response that are still in
-   * draft mode and un-archived.
+   * draft mode and un-archived. Default is false.
    */
   includeUnpublished?: boolean;
 }

--- a/packages/sdks/src/functions/get-content/types.ts
+++ b/packages/sdks/src/functions/get-content/types.ts
@@ -8,10 +8,37 @@ export interface GetContentOptions {
   /** Number of items to fetch. Default is 1 */
   limit?: number;
 
-  /** User attributes to target on, such as { urlPath: '/foo', device: 'mobile', ...etc } */
+  /**
+   * User attribute key value pairs to be used for targeting
+   * https://www.builder.io/c/docs/custom-targeting-attributes
+   *
+   * e.g.
+   * ```js
+   * userAttributes: {
+   *   urlPath: '/',
+   *   returnVisitor: true,
+   *   device: 'mobile'
+   * }
+   * ```
+   */
   userAttributes?: (Record<string, string> & { urlPath?: string }) | null;
 
-  /** Custom query */
+  /**
+   * Mongodb style query of your data. E.g.:
+   *
+   * ```js
+   * query: {
+   *  id: 'abc123',
+   *  data: {
+   *    myCustomField: { $gt: 20 },
+   *  }
+   * }
+   * ```
+   *
+   * See more info on MongoDB's query operators and format.
+   *
+   * @see {@link https://docs.mongodb.com/manual/reference/operator/query/}
+   */
   query?: Record<string, any>;
 
   /**
@@ -36,7 +63,7 @@ export interface GetContentOptions {
   canTrack?: boolean;
 
   /**
-   * Include references in the response. Defaults to `true`.
+   * Include content of references in the response. Defaults to `true`.
    * @deprecated use `enrich` instead
    */
   includeRefs?: boolean;
@@ -57,4 +84,71 @@ export interface GetContentOptions {
    * Defaults to `v3`.
    */
   apiVersion?: 'v2' | 'v3';
+
+  /**
+   * Only include these fields.
+   *
+   * @example
+   * ```
+   * fields: 'id, name, data.customField'
+   * ```
+   */
+  fields?: string;
+
+  /**
+   * Omit only these fields.
+   *
+   * @example
+   * ```
+   * omit: 'data.bigField,data.blocks'
+   * ```
+   */
+  omit?: string;
+
+  /**
+   * Use to specify an offset for pagination of results. The default is 0.
+   */
+  offset?: number;
+
+  /**
+   * Seconds to cache content. Sets the max-age of the cache-control header
+   * response header.
+   *
+   * Use a higher value for better performance, lower for content that will change more frequently
+   *
+   * @see {@link https://www.builder.io/c/docs/query-api#__next:~:text=%26includeRefs%3Dtrue-,cacheSeconds,-No}
+   */
+  cacheSeconds?: number;
+
+  /**
+   * Builder.io uses stale-while-revalidate caching at the CDN level. This means we always serve
+   * from edge cache and update caches in the background for maximum possible performance. This also
+   * means that the more frequently content is requested, the more fresh it will be. The longest we
+   * will ever hold something in stale cache is 1 day by default, and you can set this to be shorter
+   * yourself as well. We suggest keeping this high unless you have content that must change rapidly
+   * and gets very little traffic.
+   *
+   * @see {@link https://www.fastly.com/blog/prevent-application-network-instability-serve-stale-content}
+   */
+  staleCacheSeconds?: number;
+
+  /**
+   * Property to order results by.
+   * Use 1 for ascending and -1 for descending.
+   *
+   * The key is what you're sorting on, so the following example sorts by createdDate
+   * and because the value is 1, the sort is ascending.
+   *
+   * @example
+   * ```
+   * createdDate: 1
+   * ```
+   */
+  sort?: { [key: string]: 1 | -1 };
+
+  /**
+   * Include content entries in a response that are still in
+   * draft mode and un-archived.
+   */
+  includeUnpublished?: boolean;
 }


### PR DESCRIPTION
## Description

This syncs the 'GetContentOptions' type in gen1 and gen2 sdks with the properties outlined in the [docs](https://www.builder.io/c/docs/content-api)

implemented few missing options like 'cacheSeconds, staleCacheSeconds' in gen2 sdks and 'sort, includeUnpublished' in gen1 sdks

