### PR TITLE
Add meta field to Component and ComponentInfo

### DIFF
--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -765,6 +765,11 @@ export interface Component {
    * for more information on permissions in builder check https://www.builder.io/c/docs/guides/roles-and-permissions
    */
   requiredPermissions?: Array<Permission>;
+
+  /**
+   * Used to store additional component information.
+   */
+  meta?: Record<string, any>;
 }
 
 type Permission = 'read' | 'publish' | 'editCode' | 'editDesigns' | 'admin' | 'create';

--- a/packages/sdks/src/types/components.ts
+++ b/packages/sdks/src/types/components.ts
@@ -113,6 +113,11 @@ export interface ComponentInfo {
 
   // TO-DO: is this used?
   hidden?: boolean;
+
+  /**
+   * Used to store additional component information.
+   */
+  meta?: Record<string, any>;
 }
 
 type Permission =


### PR DESCRIPTION
Add meta to the Component interface. This is will be useful to when linking the Figma main component to a registered component. This is only for types, and no changes to the runtime.