### PR TITLE
Update CloudinaryImageEditor component buttons to make the `set credentials` button less prominent once credentials are set

### DIFF
--- a/plugins/cloudinary/src/CloudinaryImageEditor.tsx
+++ b/plugins/cloudinary/src/CloudinaryImageEditor.tsx
@@ -129,6 +129,10 @@ export default class CloudinaryImageEditor extends React.Component<
     return 'CHOOSE IMAGE';
   }
 
+  setCredentialsButtonText(): string {
+    return this.areCloudinaryCredentialsNotSet() ? 'Set credentials' : '...';
+  }
+
   componentDidMount() {
     this.appendMediaLibraryScriptToPlugin();
   }
@@ -138,7 +142,8 @@ export default class CloudinaryImageEditor extends React.Component<
     const setCredentialsButtonVariant = this.calculateChooseImageButtonVariant();
     const selectedPublicIdMessage = this.buildSelectedIdMessage();
     const chooseImageButtonText = this.buildChooseImageText();
-    const buttonStyle = { width: '45%', margin: '5px' };
+    const setCredentialsButtonText = this.setCredentialsButtonText();
+    const buttonContainerStyle = { display: 'grid', gap: '10px', gridTemplateColumns: '1fr max-content', marginTop: '5px', marginBottom: '5px' };
     return (
       <div css={{ padding: '15px 0' }}>
         <Typography variant="caption">Cloudinary image picker</Typography>
@@ -161,10 +166,9 @@ export default class CloudinaryImageEditor extends React.Component<
           />
         )}
 
-        <div>
+        <div css={buttonContainerStyle}>
           <Button
             disabled={this.areCloudinaryCredentialsNotSet()}
-            css={buttonStyle}
             color="primary"
             variant="contained"
             onClick={() => {
@@ -179,7 +183,6 @@ export default class CloudinaryImageEditor extends React.Component<
           <Button
             variant={setCredentialsButtonVariant}
             color="primary"
-            css={buttonStyle}
             onClick={() => {
               this.setState({
                 requestCredentials: true,
@@ -187,7 +190,7 @@ export default class CloudinaryImageEditor extends React.Component<
               });
             }}
           >
-            Set credentials
+            {setCredentialsButtonText}
           </Button>
         </div>
         <div>


### PR DESCRIPTION
Update CloudinaryImageEditor component buttons to make the `set credentials` button less prominent once credentials are set

This reduces accidental credential changing by non-technical users

## Description

This is a simple UX improvement to the Cloudinary plugin that makes changes the `Set credentials` button text to `...` after they are set, and makes the button smaller appropriately. Since there isn't a constant need to change the credentials for each image, it makes sense to make the button smaller.

<img width="345" alt="Screenshot 2023-12-04 at 18 03 49" src="https://github.com/BuilderIO/builder/assets/96472765/eb2a485e-779b-4385-abaa-eac129a18860">
