### PR TITLE
Emporix plugin access token expired after 4 hours and it wasn't refreshed

### DIFF
--- a/plugins/emporix/package.json
+++ b/plugins/emporix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-emporix",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "",
   "keywords": [],
   "main": "dist/plugin.system.js",

--- a/plugins/emporix/src/utils/emporix-client.ts
+++ b/plugins/emporix/src/utils/emporix-client.ts
@@ -13,6 +13,9 @@ export class AnonymousTokenHelper {
     if (!this._cache['access_token']) {
       await this.authenticate();
     }
+    if (this._cache['expires_at'] < Date.now()) {
+      await this.authenticate();
+    }
     return this._cache['access_token'];
   }
 
@@ -25,6 +28,7 @@ export class AnonymousTokenHelper {
       `https://api.emporix.io/customerlogin/auth/anonymous/login?client_id=${this._clientId}&tenant=${this._tenant}`
     );
     const data = await response.json();
+    data['expires_at'] = Date.now() + 1000 * data['expires_in'];
     this._cache = data;
   }
 }


### PR DESCRIPTION
## Description

In the initial version of the plugin there was no code responsible for checking if a cached token expired or not. In the pull request I've added a logic that stores information how long the token is valid and in case when the cached token expired then a new token is generated. I've also bumped up the plugin version

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
