### PR TITLE
release "@builder.io/gatsby@4.0.0" with default URL being v3 content API

### DIFF
--- a/packages/gatsby/CHANGELOG.md
+++ b/packages/gatsby/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.0
+- Update SDK to hit the new Content V3 API by default. While the APIs are backwards compatible, please ensure you test your application after upgrading to this release.
+
 ## 3.0.3
 - Update peer dependencies to include gatsby 5
 

--- a/packages/gatsby/package-lock.json
+++ b/packages/gatsby/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/gatsby",
-  "version": "3.0.3",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/gatsby",
-      "version": "3.0.3",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^3.3.21",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/BuilderIO/builder.git",
     "directory": "packages/gatsby"
   },
-  "version": "3.0.3",
+  "version": "4.0.0",
   "keywords": [
     "gatsby",
     "gatsby-plugin",


### PR DESCRIPTION
## Description

Add files which were generated during `"@builder.io/gatsby@4.0.0"` release.

_Screenshot_
<img width="783" alt="image" src="https://github.com/BuilderIO/builder/assets/1625114/9946e82c-849c-45b2-9983-fbe35b1a5dde">
<img width="839" alt="image" src="https://github.com/BuilderIO/builder/assets/1625114/5108ab6b-1be0-4aef-a37f-9f2a9cd0262a">

