### PR TITLE
Fix: gen2 SDKs: transpile es2019 (React), change `fetchAllEntries` signature

### DIFF
--- a/.changeset/giant-gifts-judge.md
+++ b/.changeset/giant-gifts-judge.md
@@ -8,4 +8,4 @@
 '@builder.io/sdk-vue': minor
 ---
 
-Breaking: `fetchAllEntries`/`getAllContent` now returns the array of contents directly, instead of an object with a `results` property.
+🧨 Breaking: `fetchAllEntries`/`getAllContent` now returns the array of contents directly, instead of an object with a `results` property.

--- a/.changeset/giant-gifts-judge.md
+++ b/.changeset/giant-gifts-judge.md
@@ -1,0 +1,11 @@
+---
+'@builder.io/sdk-react': minor
+'@builder.io/sdk-react-nextjs': minor
+'@builder.io/sdk-qwik': minor
+'@builder.io/sdk-react-native': minor
+'@builder.io/sdk-solid': minor
+'@builder.io/sdk-svelte': minor
+'@builder.io/sdk-vue': minor
+---
+
+Breaking: `fetchAllEntries`/`getAllContent` now returns the array of contents directly, instead of an object with a `results` property.

--- a/.changeset/swift-rivers-swim.md
+++ b/.changeset/swift-rivers-swim.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/sdk-react': patch
+---
+
+compile SDK to ES2019 to support webpack 4 more easily.

--- a/packages/sdks-tests/src/specs/index.ts
+++ b/packages/sdks-tests/src/specs/index.ts
@@ -110,7 +110,7 @@ type ContentResponse = { results: BuilderContent[] };
 
 export const getProps = async (args: {
   pathname?: string;
-  _processContentResult?: (options: any, content: ContentResponse) => Promise<ContentResponse>;
+  _processContentResult?: (options: any, content: ContentResponse) => Promise<BuilderContent[]>;
   getContent?: (opts: any) => Promise<BuilderContent | null>;
   options?: any;
   data?: 'real' | 'mock';
@@ -160,7 +160,7 @@ export const getProps = async (args: {
   };
 
   const content = _processContentResult
-    ? (await _processContentResult(props, { results: [_content] })).results[0]
+    ? (await _processContentResult(props, { results: [_content] }))[0]
     : _content;
 
   return { ...props, content } as any;

--- a/packages/sdks/output/react/vite.config.js
+++ b/packages/sdks/output/react/vite.config.js
@@ -7,6 +7,8 @@ const SERVER_ENTRY = 'server-entry';
 export default defineConfig({
   plugins: [viteOutputGenerator({ pointTo: 'input' }), react()],
   build: {
+    // This is to allow Webpack 4 to consume the output.
+    target: 'es2019',
     lib: {
       entry: {
         index: './src/index.ts',

--- a/packages/sdks/src/functions/get-content/index.ts
+++ b/packages/sdks/src/functions/get-content/index.ts
@@ -22,7 +22,7 @@ export async function fetchOneEntry(
   const allContent = await fetchEntries({ ...options, limit: 1 });
 
   if (allContent) {
-    return allContent.results[0] || null;
+    return allContent[0] || null;
   }
 
   return null;
@@ -61,7 +61,7 @@ export const _processContentResult = async (
   options: GetContentOptions,
   content: ContentResults,
   url: URL = generateContentUrl(options)
-) => {
+): Promise<BuilderContent[]> => {
   const canTrack = getDefaultCanTrack(options.canTrack);
 
   const isPreviewing = url.search.includes(`preview=`);
@@ -75,8 +75,8 @@ export const _processContentResult = async (
     content.results = newResults;
   }
 
-  if (!canTrack) return content;
-  if (!(isBrowser() || TARGET === 'reactNative')) return content;
+  if (!canTrack) return content.results;
+  if (!(isBrowser() || TARGET === 'reactNative')) return content.results;
 
   /**
    * For client-side navigations, it is ideal to handle AB testing at this point instead of using our
@@ -94,7 +94,7 @@ export const _processContentResult = async (
     logger.error('Could not process A/B tests. ', e);
   }
 
-  return content;
+  return content.results;
 };
 
 /**


### PR DESCRIPTION
## Description

- `fetchAllEntries`: return `results` directly
- transpile to ES2019 for easier consumption by webpack 4