### PR TITLE
[fix] duplicate attributes being applied wrapper + block element

### DIFF
--- a/.changeset/nasty-lies-beam.md
+++ b/.changeset/nasty-lies-beam.md
@@ -8,4 +8,4 @@
 '@builder.io/sdk-vue': patch
 ---
 
-fix duplicate attributes getting applied to inner element
+Fix: duplicate attributes getting applied to both the block and its wrapper element.

--- a/.changeset/nasty-lies-beam.md
+++ b/.changeset/nasty-lies-beam.md
@@ -1,0 +1,11 @@
+---
+'@builder.io/sdk-react-nextjs': patch
+'@builder.io/sdk-qwik': patch
+'@builder.io/sdk-react': patch
+'@builder.io/sdk-react-native': patch
+'@builder.io/sdk-solid': patch
+'@builder.io/sdk-svelte': patch
+'@builder.io/sdk-vue': patch
+---
+
+fix duplicate attributes getting applied to inner element

--- a/packages/sdks-tests/src/specs/duplicate-attributes.ts
+++ b/packages/sdks-tests/src/specs/duplicate-attributes.ts
@@ -1,0 +1,33 @@
+export const DUPLICATE_ATTRIBUTES = {
+  data: {
+    themeId: false,
+    title: 'footer-test',
+    inputs: [],
+    blocks: [
+      {
+        '@type': '@builder.io/sdk:Element',
+        '@version': 2,
+        tagName: 'footer',
+        id: 'builder-6a8ccf9861154b7689ba9adfe4577a55',
+        meta: { previousId: 'builder-9d8032f86e844c0998e8815af7e6b110' },
+        component: { name: 'Core:Section', options: { maxWidth: 1200, lazyLoad: false } },
+        responsiveStyles: {
+          large: {
+            display: 'flex',
+            flexDirection: 'column',
+            position: 'relative',
+            flexShrink: '0',
+            boxSizing: 'border-box',
+            marginTop: '0px',
+            paddingLeft: '20px',
+            paddingRight: '20px',
+            paddingTop: '20px',
+            paddingBottom: '20px',
+            minHeight: '100px',
+            backgroundColor: 'rgba(253, 0, 0, 1)',
+          },
+        },
+      },
+    ],
+  },
+};

--- a/packages/sdks-tests/src/specs/index.ts
+++ b/packages/sdks-tests/src/specs/index.ts
@@ -29,6 +29,7 @@ import { CONTENT_WITHOUT_SYMBOLS, CONTENT as symbols } from './symbols.js';
 import { CONTENT as textBlock } from './text-block.js';
 import type { BuilderContent } from './types.js';
 import { CONTENT as video } from './video.js';
+import { DUPLICATE_ATTRIBUTES } from './duplicate-attributes.js';
 
 function isBrowser(): boolean {
   return typeof window !== 'undefined' && typeof document !== 'undefined';
@@ -71,6 +72,7 @@ const pages = {
   '/video': video,
   '/repeat-items-bindings': REPEAT_ITEMS_BINDINGS,
   '/input-default-value': INPUT_DEFAULT_VALUE,
+  '/duplicate-attributes': DUPLICATE_ATTRIBUTES,
 } as const;
 
 const apiVersionPathToProp = {

--- a/packages/sdks-tests/src/tests/duplicate-attributes.spec.ts
+++ b/packages/sdks-tests/src/tests/duplicate-attributes.spec.ts
@@ -3,6 +3,7 @@ import { test } from './helpers.js';
 
 test.describe('Duplicate Attributes', () => {
   test('wrapped block has no duplicate attributes', async ({ page, packageName }) => {
+    test.skip(packageName === 'react-native');
     await page.goto('/duplicate-attributes');
 
     const footer = await page.locator('footer');

--- a/packages/sdks-tests/src/tests/duplicate-attributes.spec.ts
+++ b/packages/sdks-tests/src/tests/duplicate-attributes.spec.ts
@@ -1,0 +1,22 @@
+import { expect } from '@playwright/test';
+import { test } from './helpers.js';
+
+test.describe('Duplicate Attributes', () => {
+  test('wrapped block has no duplicate attributes', async ({ page, packageName }) => {
+    await page.goto('/duplicate-attributes');
+
+    const footer = await page.locator(`footer`);
+    const section = await page.locator('section');
+
+    const footerId = await footer.getAttribute('builder-id');
+    const footerClass = await footer.getAttribute('class');
+
+    const sectionId = await section.getAttribute('builder-id');
+    const sectionClass = await section.getAttribute('class');
+
+    expect(footerId).toBe('builder-6a8ccf9861154b7689ba9adfe4577a55');
+    expect(sectionId).toBeNull();
+    expect(footerClass?.includes('builder-6a8ccf9861154b7689ba9adfe4577a55')).toBe(true);
+    expect(sectionClass?.includes('builder-6a8ccf9861154b7689ba9adfe4577a55')).toBe(false);
+  });
+});

--- a/packages/sdks-tests/src/tests/duplicate-attributes.spec.ts
+++ b/packages/sdks-tests/src/tests/duplicate-attributes.spec.ts
@@ -5,7 +5,7 @@ test.describe('Duplicate Attributes', () => {
   test('wrapped block has no duplicate attributes', async ({ page, packageName }) => {
     await page.goto('/duplicate-attributes');
 
-    const footer = await page.locator(`footer`);
+    const footer = await page.locator('footer');
     const section = await page.locator('section');
 
     const footerId = await footer.getAttribute('builder-id');
@@ -17,6 +17,6 @@ test.describe('Duplicate Attributes', () => {
     expect(footerId).toBe('builder-6a8ccf9861154b7689ba9adfe4577a55');
     expect(sectionId).toBeNull();
     expect(footerClass?.includes('builder-6a8ccf9861154b7689ba9adfe4577a55')).toBe(true);
-    expect(sectionClass?.includes('builder-6a8ccf9861154b7689ba9adfe4577a55')).toBe(false);
+    expect(!!sectionClass?.includes('builder-6a8ccf9861154b7689ba9adfe4577a55')).toBe(false);
   });
 });

--- a/packages/sdks/src/components/block/components/component-ref/component-ref.helpers.ts
+++ b/packages/sdks/src/components/block/components/component-ref/component-ref.helpers.ts
@@ -3,7 +3,6 @@ import type {
   BuilderContextInterface,
   RegisteredComponents,
 } from '../../../../context/types.js';
-import { getBlockActions } from '../../../../functions/get-block-actions.js';
 import { getBlockProperties } from '../../../../functions/get-block-properties.js';
 import type { BuilderBlock } from '../../../../types/builder-block.js';
 import type { PropsWithBuilderData } from '../../../../types/builder-props.js';
@@ -46,27 +45,20 @@ export const getWrapperProps = ({
      */
     ...(includeBlockProps
       ? {
-          attributes: {
-            ...getBlockProperties({
-              block: builderBlock,
-              context: contextValue,
-            }),
-            ...getBlockActions({
-              block: builderBlock,
-              rootState: contextValue.rootState,
-              rootSetState: contextValue.rootSetState,
-              localState: contextValue.localState,
-              context: contextValue.context,
-            }),
-          },
+          attributes: getBlockProperties({
+            block: builderBlock,
+            context: contextValue,
+          }),
         }
       : {}),
   };
+
   const interactiveElementProps: InteractiveElementProps = {
     Wrapper: componentRef,
     block: builderBlock,
     context,
-    wrapperProps: wrapperPropsWithAttributes,
+    wrapperProps: componentOptions,
+    includeBlockProps,
   };
 
   return isInteractive ? interactiveElementProps : wrapperPropsWithAttributes;

--- a/packages/sdks/src/components/block/components/component-ref/component-ref.helpers.ts
+++ b/packages/sdks/src/components/block/components/component-ref/component-ref.helpers.ts
@@ -37,28 +37,27 @@ export const getWrapperProps = ({
 }: Omit<ComponentProps, 'blockChildren' | 'registeredComponents'> & {
   contextValue: BuilderContextInterface;
 }) => {
+  const wrapperPropsWithAttributes = {
+    ...componentOptions,
+    /**
+     * If `noWrap` is set to `true`, then the block's props/attributes are provided to the
+     * component itself directly. Otherwise, they are provided to the wrapper element.
+     */
+    ...(includeBlockProps
+      ? {
+          attributes: getBlockProperties({
+            block: builderBlock,
+            context: contextValue,
+          }),
+        }
+      : {}),
+  };
   const interactiveElementProps: InteractiveElementProps = {
     Wrapper: componentRef,
     block: builderBlock,
     context,
-    wrapperProps: componentOptions,
+    wrapperProps: wrapperPropsWithAttributes,
   };
 
-  return isInteractive
-    ? interactiveElementProps
-    : {
-        ...componentOptions,
-        /**
-         * If `noWrap` is set to `true`, then the block's props/attributes are provided to the
-         * component itself directly. Otherwise, they are provided to the wrapper element.
-         */
-        ...(includeBlockProps
-          ? {
-              attributes: getBlockProperties({
-                block: builderBlock,
-                context: contextValue,
-              }),
-            }
-          : {}),
-      };
+  return isInteractive ? interactiveElementProps : wrapperPropsWithAttributes;
 };

--- a/packages/sdks/src/components/block/components/component-ref/component-ref.helpers.ts
+++ b/packages/sdks/src/components/block/components/component-ref/component-ref.helpers.ts
@@ -3,6 +3,7 @@ import type {
   BuilderContextInterface,
   RegisteredComponents,
 } from '../../../../context/types.js';
+import { getBlockActions } from '../../../../functions/get-block-actions.js';
 import { getBlockProperties } from '../../../../functions/get-block-properties.js';
 import type { BuilderBlock } from '../../../../types/builder-block.js';
 import type { PropsWithBuilderData } from '../../../../types/builder-props.js';
@@ -45,10 +46,19 @@ export const getWrapperProps = ({
      */
     ...(includeBlockProps
       ? {
-          attributes: getBlockProperties({
-            block: builderBlock,
-            context: contextValue,
-          }),
+          attributes: {
+            ...getBlockProperties({
+              block: builderBlock,
+              context: contextValue,
+            }),
+            ...getBlockActions({
+              block: builderBlock,
+              rootState: contextValue.rootState,
+              rootSetState: contextValue.rootSetState,
+              localState: contextValue.localState,
+              context: contextValue.context,
+            }),
+          },
         }
       : {}),
   };

--- a/packages/sdks/src/components/block/components/interactive-element.lite.tsx
+++ b/packages/sdks/src/components/block/components/interactive-element.lite.tsx
@@ -1,6 +1,5 @@
 import { useMetadata, type Signal } from '@builder.io/mitosis';
 import type { BuilderContextInterface } from '../../../context/types.js';
-import { getBlockActions } from '../../../functions/get-block-actions.js';
 import type { BuilderBlock } from '../../../types/builder-block.js';
 import type {
   Dictionary,
@@ -35,16 +34,7 @@ export default function InteractiveElement(
   return (
     <props.Wrapper
       {...props.wrapperProps}
-      attributes={{
-        ...props.wrapperProps.attributes,
-        ...getBlockActions({
-          block: props.block,
-          rootState: props.context.value.rootState,
-          rootSetState: props.context.value.rootSetState,
-          localState: props.context.value.localState,
-          context: props.context.value.context,
-        }),
-      }}
+      attributes={props.wrapperProps.attributes}
     >
       {props.children}
     </props.Wrapper>

--- a/packages/sdks/src/components/block/components/interactive-element.lite.tsx
+++ b/packages/sdks/src/components/block/components/interactive-element.lite.tsx
@@ -2,7 +2,10 @@ import { useMetadata, type Signal } from '@builder.io/mitosis';
 import type { BuilderContextInterface } from '../../../context/types.js';
 import { getBlockActions } from '../../../functions/get-block-actions.js';
 import type { BuilderBlock } from '../../../types/builder-block.js';
-import type { Dictionary, PropsWithChildren } from '../../../types/typescript.js';
+import type {
+  Dictionary,
+  PropsWithChildren,
+} from '../../../types/typescript.js';
 
 export type InteractiveElementProps = {
   Wrapper: any;

--- a/packages/sdks/src/components/block/components/interactive-element.lite.tsx
+++ b/packages/sdks/src/components/block/components/interactive-element.lite.tsx
@@ -1,5 +1,7 @@
 import { useMetadata, type Signal } from '@builder.io/mitosis';
 import type { BuilderContextInterface } from '../../../context/types.js';
+import { getBlockActions } from '../../../functions/get-block-actions.js';
+import { getBlockProperties } from '../../../functions/get-block-properties.js';
 import type { BuilderBlock } from '../../../types/builder-block.js';
 import type {
   Dictionary,
@@ -11,6 +13,7 @@ export type InteractiveElementProps = {
   block: BuilderBlock;
   context: Signal<BuilderContextInterface>;
   wrapperProps: Dictionary<any>;
+  includeBlockProps: boolean;
 };
 
 useMetadata({
@@ -34,7 +37,21 @@ export default function InteractiveElement(
   return (
     <props.Wrapper
       {...props.wrapperProps}
-      attributes={props.wrapperProps.attributes}
+      attributes={{
+        ...(props.includeBlockProps && {
+          ...getBlockProperties({
+            block: props.block,
+            context: props.context.value,
+          }),
+          ...getBlockActions({
+            block: props.block,
+            rootState: props.context.value.rootState,
+            rootSetState: props.context.value.rootSetState,
+            localState: props.context.value.localState,
+            context: props.context.value.context,
+          }),
+        }),
+      }}
     >
       {props.children}
     </props.Wrapper>

--- a/packages/sdks/src/components/block/components/interactive-element.lite.tsx
+++ b/packages/sdks/src/components/block/components/interactive-element.lite.tsx
@@ -37,21 +37,23 @@ export default function InteractiveElement(
   return (
     <props.Wrapper
       {...props.wrapperProps}
-      attributes={{
-        ...(props.includeBlockProps && {
-          ...getBlockProperties({
-            block: props.block,
-            context: props.context.value,
-          }),
-          ...getBlockActions({
-            block: props.block,
-            rootState: props.context.value.rootState,
-            rootSetState: props.context.value.rootSetState,
-            localState: props.context.value.localState,
-            context: props.context.value.context,
-          }),
-        }),
-      }}
+      attributes={
+        props.includeBlockProps
+          ? {
+              ...getBlockProperties({
+                block: props.block,
+                context: props.context.value,
+              }),
+              ...getBlockActions({
+                block: props.block,
+                rootState: props.context.value.rootState,
+                rootSetState: props.context.value.rootSetState,
+                localState: props.context.value.localState,
+                context: props.context.value.context,
+              }),
+            }
+          : {}
+      }
     >
       {props.children}
     </props.Wrapper>

--- a/packages/sdks/src/components/block/components/interactive-element.lite.tsx
+++ b/packages/sdks/src/components/block/components/interactive-element.lite.tsx
@@ -1,15 +1,14 @@
 import { useMetadata, type Signal } from '@builder.io/mitosis';
 import type { BuilderContextInterface } from '../../../context/types.js';
 import { getBlockActions } from '../../../functions/get-block-actions.js';
-import { getBlockProperties } from '../../../functions/get-block-properties.js';
 import type { BuilderBlock } from '../../../types/builder-block.js';
-import type { PropsWithChildren } from '../../../types/typescript.js';
+import type { Dictionary, PropsWithChildren } from '../../../types/typescript.js';
 
 export type InteractiveElementProps = {
   Wrapper: any;
   block: BuilderBlock;
   context: Signal<BuilderContextInterface>;
-  wrapperProps: object;
+  wrapperProps: Dictionary<any>;
 };
 
 useMetadata({
@@ -34,10 +33,7 @@ export default function InteractiveElement(
     <props.Wrapper
       {...props.wrapperProps}
       attributes={{
-        ...getBlockProperties({
-          block: props.block,
-          context: props.context.value,
-        }),
+        ...props.wrapperProps.attributes,
         ...getBlockActions({
           block: props.block,
           rootState: props.context.value.rootState,


### PR DESCRIPTION
## Description

With the InteractiveElements we are passing all the attributes in the block. In this PR, we are checking if we should pass the props to the block itself or to the wrapper element only. This way we are fixing duplicate attributes being sent to the child component as well.
