### PR TITLE
Fix: Vue SDK CSS imports

### DIFF
--- a/.changeset/beige-laws-vanish.md
+++ b/.changeset/beige-laws-vanish.md
@@ -1,0 +1,18 @@
+---
+'@builder.io/sdk-vue': patch
+---
+
+Fix CSS imports:
+
+- add a `/nuxt` subpath export for a Nuxt module. Currently, it handles importing CSS, and is used like so:
+
+```ts
+// nuxt.config.js
+export default defineNuxtConfig({
+  modules: ['@builder.io/sdk-vue/nuxt'],
+});
+```
+
+- bring back `/css` subpath export. This is used internally by the Nuxt module, but also allows more flexibility for customers to import CSS as they see fit.
+- remove CSS imports from server bundles, as they cause errors due to invalid extensions.
+- add `sideEffects` array to package.json for webpack.

--- a/packages/sdks/output/vue/nuxt.js
+++ b/packages/sdks/output/vue/nuxt.js
@@ -1,0 +1,10 @@
+import { defineNuxtModule } from '@nuxt/kit';
+
+export default defineNuxtModule({
+  setup(options, nuxt) {
+    /**
+     * Add the compiled Builder.io CSS to the Nuxt CSS array.
+     */
+    nuxt.options.css.push('@builder.io/sdk-vue/css');
+  },
+});

--- a/packages/sdks/output/vue/package.json
+++ b/packages/sdks/output/vue/package.json
@@ -13,7 +13,7 @@
   },
   "files": [
     "lib",
-    "package.json"
+    "nuxt.js"
   ],
   "sideEffects": [
     "./lib/browser/style.css",
@@ -28,6 +28,7 @@
   ],
   "exports": {
     "./css": "./lib/browser/style.css",
+    "./nuxt": "./nuxt.js",
     ".": {
       "node": {
         "import": "./lib/node/index.js",

--- a/packages/sdks/output/vue/package.json
+++ b/packages/sdks/output/vue/package.json
@@ -15,7 +15,19 @@
     "lib",
     "package.json"
   ],
+  "sideEffects": [
+    "./lib/browser/style.css",
+    "./lib/node/style.css",
+    "./lib/edge/style.css",
+    "./lib/browser/index.js",
+    "./lib/node/index.js",
+    "./lib/edge/index.js",
+    "./lib/node/index.cjs",
+    "./lib/browser/index.cjs",
+    "./lib/edge/index.cjs"
+  ],
   "exports": {
+    "./css": "./lib/browser/style.css",
     ".": {
       "node": {
         "import": "./lib/node/index.js",

--- a/packages/sdks/output/vue/package.json
+++ b/packages/sdks/output/vue/package.json
@@ -20,11 +20,7 @@
     "./lib/node/style.css",
     "./lib/edge/style.css",
     "./lib/browser/index.js",
-    "./lib/node/index.js",
-    "./lib/edge/index.js",
-    "./lib/node/index.cjs",
-    "./lib/browser/index.cjs",
-    "./lib/edge/index.cjs"
+    "./lib/browser/index.cjs"
   ],
   "exports": {
     "./css": "./lib/browser/style.css",

--- a/packages/sdks/output/vue/vite.config.js
+++ b/packages/sdks/output/vue/vite.config.js
@@ -30,9 +30,8 @@ export default defineConfig({
         },
 
         /**
-         * We only need the CSS import in the browser.
-         * Adding it to server bundles breaks Nuxt, since `.css` is an invalid extension. It also
-         * doesn't actually do anything useful there, so it is safe to remove.
+         * Adding CSS imports to server bundles breaks Nuxt, since `.css` is an invalid extension.
+         * Instead, users should manually import the CSS file for SSR builds.
          */
         banner: getSdkEnv() === 'browser' ? 'import "./style.css";' : undefined,
       },

--- a/packages/sdks/output/vue/vite.config.js
+++ b/packages/sdks/output/vue/vite.config.js
@@ -1,4 +1,7 @@
-import { viteOutputGenerator } from '@builder.io/sdks/output-generation/index.js';
+import {
+  getSdkEnv,
+  viteOutputGenerator,
+} from '@builder.io/sdks/output-generation/index.js';
 import vue from '@vitejs/plugin-vue';
 import { resolve } from 'path';
 import { defineConfig } from 'vite';
@@ -25,7 +28,9 @@ export default defineConfig({
         globals: {
           vue: 'Vue',
         },
-        intro: 'import "./style.css";',
+
+        // we omit the banner in node because it breaks Nuxt, since `.css` is an invalid extension.
+        banner: getSdkEnv() === 'browser' ? 'import "./style.css";' : undefined,
       },
     },
   },

--- a/packages/sdks/output/vue/vite.config.js
+++ b/packages/sdks/output/vue/vite.config.js
@@ -29,7 +29,11 @@ export default defineConfig({
           vue: 'Vue',
         },
 
-        // we omit the banner in node because it breaks Nuxt, since `.css` is an invalid extension.
+        /**
+         * We only need the CSS import in the browser.
+         * Adding it to server bundles breaks Nuxt, since `.css` is an invalid extension. It also
+         * doesn't actually do anything useful there, so it is safe to remove.
+         */
         banner: getSdkEnv() === 'browser' ? 'import "./style.css";' : undefined,
       },
     },


### PR DESCRIPTION
## Description

- fixes https://github.com/BuilderIO/builder/issues/2917, https://github.com/BuilderIO/builder/issues/2925

Vue SDK:

Fix CSS imports:

- add a `/nuxt` subpath export for a Nuxt module. Currently, it handles importing CSS, and is used like so:

```ts
// nuxt.config.js
export default defineNuxtConfig({
  modules: ['@builder.io/sdk-vue/nuxt'],
});
```

- bring back `/css` subpath export. This is used internally by the Nuxt module, but also allows more flexibility for customers to import CSS as they see fit.
- remove CSS imports from server bundles, as they cause errors due to invalid extensions.
- add `sideEffects` array to package.json for webpack.