### PR TITLE
SDKs: remove Vue 2 workarounds

### DIFF
--- a/packages/sdks/src/components/block/block.lite.tsx
+++ b/packages/sdks/src/components/block/block.lite.tsx
@@ -154,6 +154,7 @@ export default function Block(props: BlockProps) {
 
   return (
     <Show when={state.canShowBlock}>
+      <BlockStyles block={props.block} context={props.context.value} />
       <Show
         when={!state.blockComponent?.noWrap}
         else={
@@ -212,26 +213,13 @@ export default function Block(props: BlockProps) {
               includeBlockProps={state.componentRefProps.includeBlockProps}
               isInteractive={state.componentRefProps.isInteractive}
             />
-            {/**
-             * We need to run two separate loops for content + styles to workaround the fact that Vue 2
-             * does not support multiple root elements.
-             */}
             <For each={state.childrenWithoutParentComponent}>
               {(child) => (
                 <Block
-                  key={'block-' + child.id}
+                  key={child.id}
                   block={child}
                   context={childrenContext}
                   registeredComponents={props.registeredComponents}
-                />
-              )}
-            </For>
-            <For each={state.childrenWithoutParentComponent}>
-              {(child) => (
-                <BlockStyles
-                  key={'block-style-' + child.id}
-                  block={child}
-                  context={childrenContext.value}
                 />
               )}
             </For>

--- a/packages/sdks/src/components/block/components/component-ref/component-ref.lite.tsx
+++ b/packages/sdks/src/components/block/components/component-ref/component-ref.lite.tsx
@@ -7,7 +7,6 @@ import {
 } from '@builder.io/mitosis';
 import { wrapComponentRef } from '../../../content/wrap-component-ref.js';
 import Block from '../../block.lite.jsx';
-import BlockStyles from '../block-styles.lite.jsx';
 import InteractiveElement from '../interactive-element.lite.jsx';
 import type { ComponentProps } from './component-ref.helpers.js';
 import { getWrapperProps } from './component-ref.helpers.js';
@@ -49,26 +48,13 @@ export default function ComponentRef(props: ComponentProps) {
           contextValue: props.context.value,
         })}
       >
-        {/**
-         * We need to run two separate loops for content + styles to workaround the fact that Vue 2
-         * does not support multiple root elements.
-         */}
         <For each={props.blockChildren}>
           {(child) => (
             <Block
-              key={'block-' + child.id}
+              key={child.id}
               block={child}
               context={props.context}
               registeredComponents={props.registeredComponents}
-            />
-          )}
-        </For>
-        <For each={props.blockChildren}>
-          {(child) => (
-            <BlockStyles
-              key={'block-style-' + child.id}
-              block={child}
-              context={props.context.value}
             />
           )}
         </For>

--- a/packages/sdks/src/components/blocks/blocks.lite.tsx
+++ b/packages/sdks/src/components/blocks/blocks.lite.tsx
@@ -1,5 +1,11 @@
 import type { Signal } from '@builder.io/mitosis';
-import { For, useContext, useMetadata, useTarget } from '@builder.io/mitosis';
+import {
+  For,
+  Show,
+  useContext,
+  useMetadata,
+  useTarget,
+} from '@builder.io/mitosis';
 import BuilderContext from '../../context/builder.context.lite.js';
 import ComponentsContext from '../../context/components.context.lite.js';
 import type {
@@ -36,24 +42,26 @@ export default function Blocks(props: BlocksProps) {
       BlocksWrapper={props.context?.value?.BlocksWrapper}
       BlocksWrapperProps={props.context?.value?.BlocksWrapperProps}
     >
-      <For each={props.blocks || []}>
-        {(block) => (
-          <Block
-            key={block.id}
-            block={block}
-            context={useTarget({
-              rsc: props.context,
-              default: props.context || builderContext,
-            })}
-            registeredComponents={useTarget({
-              rsc: props.registeredComponents,
-              default:
-                props.registeredComponents ||
-                componentsContext.registeredComponents,
-            })}
-          />
-        )}
-      </For>
+      <Show when={props.blocks}>
+        <For each={props.blocks}>
+          {(block) => (
+            <Block
+              key={block.id}
+              block={block}
+              context={useTarget({
+                rsc: props.context,
+                default: props.context || builderContext,
+              })}
+              registeredComponents={useTarget({
+                rsc: props.registeredComponents,
+                default:
+                  props.registeredComponents ||
+                  componentsContext.registeredComponents,
+              })}
+            />
+          )}
+        </For>
+      </Show>
     </BlocksWrapper>
   );
 }

--- a/packages/sdks/src/components/blocks/blocks.lite.tsx
+++ b/packages/sdks/src/components/blocks/blocks.lite.tsx
@@ -1,11 +1,5 @@
 import type { Signal } from '@builder.io/mitosis';
-import {
-  For,
-  Show,
-  useContext,
-  useMetadata,
-  useTarget,
-} from '@builder.io/mitosis';
+import { For, useContext, useMetadata, useTarget } from '@builder.io/mitosis';
 import BuilderContext from '../../context/builder.context.lite.js';
 import ComponentsContext from '../../context/components.context.lite.js';
 import type {
@@ -13,7 +7,6 @@ import type {
   RegisteredComponents,
 } from '../../context/types.js';
 import Block from '../block/block.lite.jsx';
-import BlockStyles from '../block/components/block-styles.lite.jsx';
 import type { BlocksWrapperProps } from './blocks-wrapper.lite.jsx';
 import BlocksWrapper from './blocks-wrapper.lite.jsx';
 
@@ -43,44 +36,24 @@ export default function Blocks(props: BlocksProps) {
       BlocksWrapper={props.context?.value?.BlocksWrapper}
       BlocksWrapperProps={props.context?.value?.BlocksWrapperProps}
     >
-      {/**
-       * We need to run two separate loops for content + styles to workaround the fact that Vue 2
-       * does not support multiple root elements.
-       */}
-      <Show when={props.blocks}>
-        <For each={props.blocks}>
-          {(block) => (
-            <Block
-              key={'render-block-' + block.id}
-              block={block}
-              context={useTarget({
-                rsc: props.context,
-                default: props.context || builderContext,
-              })}
-              registeredComponents={useTarget({
-                rsc: props.registeredComponents,
-                default:
-                  props.registeredComponents ||
-                  componentsContext.registeredComponents,
-              })}
-            />
-          )}
-        </For>
-      </Show>
-      <Show when={props.blocks}>
-        <For each={props.blocks}>
-          {(block) => (
-            <BlockStyles
-              key={'block-style-' + block.id}
-              block={block}
-              context={useTarget({
-                rsc: props.context?.value,
-                default: props.context?.value || builderContext.value,
-              })}
-            />
-          )}
-        </For>
-      </Show>
+      <For each={props.blocks || []}>
+        {(block) => (
+          <Block
+            key={block.id}
+            block={block}
+            context={useTarget({
+              rsc: props.context,
+              default: props.context || builderContext,
+            })}
+            registeredComponents={useTarget({
+              rsc: props.registeredComponents,
+              default:
+                props.registeredComponents ||
+                componentsContext.registeredComponents,
+            })}
+          />
+        )}
+      </For>
     </BlocksWrapper>
   );
 }


### PR DESCRIPTION
## Description

Simplify the codebase by removing workarounds that were only needed to keep Vue 2 working.