### PR TITLE
Fix: SDKs types & Edge exports

### DIFF
--- a/.changeset/popular-foxes-complain.md
+++ b/.changeset/popular-foxes-complain.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/sdk-vue': patch
+---
+
+Add './edge' subpath export to work around isolated-vm issues in serverless environments.

--- a/.changeset/proud-ducks-pretend.md
+++ b/.changeset/proud-ducks-pretend.md
@@ -1,0 +1,11 @@
+---
+'@builder.io/sdk-react-nextjs': patch
+'@builder.io/sdk-react': patch
+'@builder.io/sdk-vue': patch
+'@builder.io/sdk-qwik': patch
+'@builder.io/sdk-react-native': patch
+'@builder.io/sdk-solid': patch
+'@builder.io/sdk-svelte': patch
+---
+
+Fix: use correct export for ContentProps

--- a/.changeset/real-donuts-move.md
+++ b/.changeset/real-donuts-move.md
@@ -1,0 +1,6 @@
+---
+'@builder.io/sdk-react-nextjs': patch
+'@builder.io/sdk-react': patch
+---
+
+Improve "./edge" subpath export to automatically use the browser bundle for browser environments. This allows the usage of that subpath export without also manually toggling with the "./browser" bundle.

--- a/.changeset/tricky-ears-film.md
+++ b/.changeset/tricky-ears-film.md
@@ -1,0 +1,11 @@
+---
+'@builder.io/sdk-react-nextjs': patch
+'@builder.io/sdk-react': patch
+'@builder.io/sdk-vue': patch
+'@builder.io/sdk-qwik': patch
+'@builder.io/sdk-react-native': patch
+'@builder.io/sdk-solid': patch
+'@builder.io/sdk-svelte': patch
+---
+
+Export prop types of all exported components in main index file.

--- a/.changeset/weak-baboons-deliver.md
+++ b/.changeset/weak-baboons-deliver.md
@@ -8,4 +8,4 @@
 '@builder.io/sdk-svelte': patch
 ---
 
-Improve documentation of ContentProps types.
+Improve documentation of `ContentProps` types.

--- a/.changeset/weak-baboons-deliver.md
+++ b/.changeset/weak-baboons-deliver.md
@@ -1,0 +1,11 @@
+---
+'@builder.io/sdk-react-nextjs': patch
+'@builder.io/sdk-react': patch
+'@builder.io/sdk-vue': patch
+'@builder.io/sdk-qwik': patch
+'@builder.io/sdk-react-native': patch
+'@builder.io/sdk-solid': patch
+'@builder.io/sdk-svelte': patch
+---
+
+Improve documentation of ContentProps types.

--- a/packages/sdks-tests/playwright.config.ts
+++ b/packages/sdks-tests/playwright.config.ts
@@ -19,13 +19,7 @@ const WEB_SERVERS: Record<Exclude<Sdk, 'all' | 'allNew'>, PackageName[]> = {
   reactNative: ['react-native'],
   solid: ['solid', 'solid-start'],
   qwik: ['qwik-city'],
-  react: [
-    'next-pages-dir',
-    'react',
-    // TO-DO: Fix this when https://github.com/vercel/next.js/issues/60491 is
-    // fixed.
-    // 'next-app-dir-client'
-  ],
+  react: ['next-pages-dir', 'react', 'next-app-dir-client'],
   vue: ['vue', 'nuxt'],
   svelte: ['svelte', 'sveltekit'],
   rsc: ['next-app-dir'],

--- a/packages/sdks/e2e/nextjs-app-dir-client/src/app/[[...slug]]/page.tsx
+++ b/packages/sdks/e2e/nextjs-app-dir-client/src/app/[[...slug]]/page.tsx
@@ -1,11 +1,10 @@
+import { RenderContent } from '@builder.io/sdk-react/edge';
 import {
   _processContentResult,
   getBuilderSearchParams,
   getContent,
 } from '@builder.io/sdk-react/server';
 import { getProps } from '@e2e/tests';
-
-import { RenderContent } from '@builder.io/sdk-react';
 
 interface PageProps {
   params: {

--- a/packages/sdks/output/nextjs/package.json
+++ b/packages/sdks/output/nextjs/package.json
@@ -67,12 +67,104 @@
       }
     },
     "./edge": {
-      "import": "./lib/edge/index.mjs",
-      "require": "./lib/edge/index.cjs"
+      "node": {
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs"
+      },
+      "browser": {
+        "import": "./lib/browser/index.mjs",
+        "require": "./lib/browser/index.cjs"
+      },
+      "edge-routine": {
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs"
+      },
+      "workerd": {
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs"
+      },
+      "deno": {
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs"
+      },
+      "lagon": {
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs"
+      },
+      "netlify": {
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs"
+      },
+      "edge-light": {
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs"
+      },
+      "bun": {
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs"
+      },
+      "react-native": {
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs"
+      },
+      "electron": {
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs"
+      },
+      "default": {
+        "import": "./lib/browser/index.mjs",
+        "require": "./lib/browser/index.cjs"
+      }
     },
     "./node": {
-      "import": "./lib/node/index.mjs",
-      "require": "./lib/node/index.cjs"
+      "node": {
+        "import": "./lib/node/index.mjs",
+        "require": "./lib/node/index.cjs"
+      },
+      "browser": {
+        "import": "./lib/browser/index.mjs",
+        "require": "./lib/browser/index.cjs"
+      },
+      "edge-routine": {
+        "import": "./lib/node/index.mjs",
+        "require": "./lib/node/index.cjs"
+      },
+      "workerd": {
+        "import": "./lib/node/index.mjs",
+        "require": "./lib/node/index.cjs"
+      },
+      "deno": {
+        "import": "./lib/node/index.mjs",
+        "require": "./lib/node/index.cjs"
+      },
+      "lagon": {
+        "import": "./lib/node/index.mjs",
+        "require": "./lib/node/index.cjs"
+      },
+      "netlify": {
+        "import": "./lib/node/index.mjs",
+        "require": "./lib/node/index.cjs"
+      },
+      "edge-light": {
+        "import": "./lib/node/index.mjs",
+        "require": "./lib/node/index.cjs"
+      },
+      "bun": {
+        "import": "./lib/node/index.mjs",
+        "require": "./lib/node/index.cjs"
+      },
+      "react-native": {
+        "import": "./lib/node/index.mjs",
+        "require": "./lib/node/index.cjs"
+      },
+      "electron": {
+        "import": "./lib/node/index.mjs",
+        "require": "./lib/node/index.cjs"
+      },
+      "default": {
+        "import": "./lib/browser/index.mjs",
+        "require": "./lib/browser/index.cjs"
+      }
     },
     "./browser": {
       "import": "./lib/browser/index.mjs",

--- a/packages/sdks/output/react/package.json
+++ b/packages/sdks/output/react/package.json
@@ -80,9 +80,66 @@
       }
     },
     "./edge": {
-      "types": "./types/index.d.ts",
-      "import": "./lib/edge/index.mjs",
-      "require": "./lib/edge/index.cjs"
+      "node": {
+        "types": "./types/index.d.ts",
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs"
+      },
+      "browser": {
+        "types": "./types/index.d.ts",
+        "import": "./lib/browser/index.mjs",
+        "require": "./lib/browser/index.cjs"
+      },
+      "edge-routine": {
+        "types": "./types/index.d.ts",
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs"
+      },
+      "workerd": {
+        "types": "./types/index.d.ts",
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs"
+      },
+      "deno": {
+        "types": "./types/index.d.ts",
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs"
+      },
+      "lagon": {
+        "types": "./types/index.d.ts",
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs"
+      },
+      "netlify": {
+        "types": "./types/index.d.ts",
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs"
+      },
+      "edge-light": {
+        "types": "./types/index.d.ts",
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs"
+      },
+      "bun": {
+        "types": "./types/index.d.ts",
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs"
+      },
+      "react-native": {
+        "types": "./types/index.d.ts",
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs"
+      },
+      "electron": {
+        "types": "./types/index.d.ts",
+        "import": "./lib/edge/index.mjs",
+        "require": "./lib/edge/index.cjs"
+      },
+      "default": {
+        "types": "./types/index.d.ts",
+        "import": "./lib/browser/index.mjs",
+        "require": "./lib/browser/index.cjs"
+      }
     },
     "./node": {
       "types": "./types/index.d.ts",

--- a/packages/sdks/output/vue/package.json
+++ b/packages/sdks/output/vue/package.json
@@ -25,6 +25,52 @@
   "exports": {
     "./css": "./lib/browser/style.css",
     "./nuxt": "./nuxt.js",
+    "./edge": {
+      "node": {
+        "import": "./lib/edge/index.js",
+        "require": "./lib/edge/index.cjs"
+      },
+      "browser": {
+        "import": "./lib/browser/index.js",
+        "require": "./lib/browser/index.cjs"
+      },
+      "edge-routine": {
+        "import": "./lib/edge/index.js",
+        "require": "./lib/edge/index.cjs"
+      },
+      "workerd": {
+        "import": "./lib/edge/index.js",
+        "require": "./lib/edge/index.cjs"
+      },
+      "deno": {
+        "import": "./lib/edge/index.js",
+        "require": "./lib/edge/index.cjs"
+      },
+      "lagon": {
+        "import": "./lib/edge/index.js",
+        "require": "./lib/edge/index.cjs"
+      },
+      "netlify": {
+        "import": "./lib/edge/index.js",
+        "require": "./lib/edge/index.cjs"
+      },
+      "edge-light": {
+        "import": "./lib/edge/index.js",
+        "require": "./lib/edge/index.cjs"
+      },
+      "bun": {
+        "import": "./lib/edge/index.js",
+        "require": "./lib/edge/index.cjs"
+      },
+      "electron": {
+        "import": "./lib/edge/index.js",
+        "require": "./lib/edge/index.cjs"
+      },
+      "default": {
+        "import": "./lib/browser/index.js",
+        "require": "./lib/browser/index.cjs"
+      }
+    },
     ".": {
       "node": {
         "import": "./lib/node/index.js",

--- a/packages/sdks/package.json
+++ b/packages/sdks/package.json
@@ -45,7 +45,7 @@
     "e2e:build:react-native": "nx run-many -t build -p @e2e/react-native",
     "e2e:build:solid": "nx run-many -t build -p @e2e/solid @e2e/solid-start",
     "e2e:build:qwik": "nx run-many -t build -p @e2e/qwik-city",
-    "e2e:build:react": "nx run-many -t build -p @e2e/react @e2e/next-pages-dir --exclude @e2e/next-app-dir-client",
+    "e2e:build:react": "nx run-many -t build -p @e2e/react @e2e/next-pages-dir",
     "e2e:build:nextjs": "nx run-many -t build -p @e2e/next-app-dir",
     "e2e:build:vue": "nx run-many -t build -p @e2e/vue @e2e/nuxt",
     "e2e:run": "nx test @e2e/tests",

--- a/packages/sdks/package.json
+++ b/packages/sdks/package.json
@@ -45,7 +45,7 @@
     "e2e:build:react-native": "nx run-many -t build -p @e2e/react-native",
     "e2e:build:solid": "nx run-many -t build -p @e2e/solid @e2e/solid-start",
     "e2e:build:qwik": "nx run-many -t build -p @e2e/qwik-city",
-    "e2e:build:react": "nx run-many -t build -p @e2e/react @e2e/next-pages-dir",
+    "e2e:build:react": "nx run-many -t build -p @e2e/react @e2e/next-pages-dir @e2e/next-app-dir-client",
     "e2e:build:nextjs": "nx run-many -t build -p @e2e/next-app-dir",
     "e2e:build:vue": "nx run-many -t build -p @e2e/vue @e2e/nuxt",
     "e2e:run": "nx test @e2e/tests",

--- a/packages/sdks/src/blocks/button/button.lite.tsx
+++ b/packages/sdks/src/blocks/button/button.lite.tsx
@@ -5,19 +5,13 @@ import { filterAttrs } from '../helpers.js';
  */
 
 import { setAttrs } from '../helpers.js';
+import type { ButtonProps } from './button.types.js';
 
 useMetadata({
   rsc: {
     componentType: 'client',
   },
 });
-
-export interface ButtonProps {
-  attributes?: any;
-  text?: string;
-  link?: string;
-  openLinkInNewTab?: boolean;
-}
 
 export default function Button(props: ButtonProps) {
   return (

--- a/packages/sdks/src/blocks/button/button.types.ts
+++ b/packages/sdks/src/blocks/button/button.types.ts
@@ -1,0 +1,6 @@
+export interface ButtonProps {
+  attributes?: any;
+  text?: string;
+  link?: string;
+  openLinkInNewTab?: boolean;
+}

--- a/packages/sdks/src/blocks/columns/columns.lite.tsx
+++ b/packages/sdks/src/blocks/columns/columns.lite.tsx
@@ -11,21 +11,11 @@ import type { SizeName } from '../../constants/device-sizes.js';
 import { getSizesForBreakpoints } from '../../constants/device-sizes.js';
 import { TARGET } from '../../constants/target.js';
 import { deoptSignal } from '../../functions/deopt.js';
-import type { BuilderBlock } from '../../types/builder-block.js';
-import type {
-  BuilderComponentsProp,
-  PropsWithBuilderData,
-} from '../../types/builder-props.js';
+import type { PropsWithBuilderData } from '../../types/builder-props.js';
 import type { Dictionary } from '../../types/typescript.js';
-
-type Column = {
-  blocks: BuilderBlock[];
-  width?: number;
-};
+import type { ColumnProps } from './columns.types.js';
 
 type CSSVal = string | number;
-
-type StackColumnsAt = 'tablet' | 'mobile' | 'never';
 
 useMetadata({
   rsc: {
@@ -35,14 +25,6 @@ useMetadata({
     setUseStoreFirst: true,
   },
 });
-
-export interface ColumnProps extends BuilderComponentsProp {
-  columns?: Column[];
-  builderBlock: BuilderBlock;
-  space?: number;
-  stackColumnsAt?: StackColumnsAt;
-  reverseColumnsWhenStacked?: boolean;
-}
 
 export default function Columns(props: PropsWithBuilderData<ColumnProps>) {
   const state = useStore({

--- a/packages/sdks/src/blocks/columns/columns.types.ts
+++ b/packages/sdks/src/blocks/columns/columns.types.ts
@@ -1,0 +1,17 @@
+import type { BuilderBlock } from '../../types/builder-block.js';
+import type { BuilderComponentsProp } from '../../types/builder-props.js';
+
+type Column = {
+  blocks: BuilderBlock[];
+  width?: number;
+};
+
+type StackColumnsAt = 'tablet' | 'mobile' | 'never';
+
+export interface ColumnProps extends BuilderComponentsProp {
+  columns?: Column[];
+  builderBlock: BuilderBlock;
+  space?: number;
+  stackColumnsAt?: StackColumnsAt;
+  reverseColumnsWhenStacked?: boolean;
+}

--- a/packages/sdks/src/blocks/fragment/fragment.lite.tsx
+++ b/packages/sdks/src/blocks/fragment/fragment.lite.tsx
@@ -1,15 +1,11 @@
 import { useMetadata } from '@builder.io/mitosis';
+import type { FragmentProps } from './fragment.types';
 
 useMetadata({
   rsc: {
     componentType: 'client',
   },
 });
-export interface FragmentProps {
-  maxWidth?: number;
-  attributes?: any;
-  children?: any;
-}
 
 export default function FragmentComponent(props: FragmentProps) {
   // TODO: flag for if target supports fragments / doesn't need root/host elements

--- a/packages/sdks/src/blocks/fragment/fragment.lite.tsx
+++ b/packages/sdks/src/blocks/fragment/fragment.lite.tsx
@@ -1,5 +1,5 @@
 import { useMetadata } from '@builder.io/mitosis';
-import type { FragmentProps } from './fragment.types';
+import type { FragmentProps } from './fragment.types.js';
 
 useMetadata({
   rsc: {

--- a/packages/sdks/src/blocks/fragment/fragment.types.ts
+++ b/packages/sdks/src/blocks/fragment/fragment.types.ts
@@ -1,0 +1,5 @@
+export interface FragmentProps {
+  maxWidth?: number;
+  attributes?: any;
+  children?: any;
+}

--- a/packages/sdks/src/blocks/image/image.lite.tsx
+++ b/packages/sdks/src/blocks/image/image.lite.tsx
@@ -1,32 +1,13 @@
 import { Show, useMetadata, useStore } from '@builder.io/mitosis';
 import type { JSX } from '@builder.io/mitosis/jsx-runtime';
-import type { BuilderBlock } from '../../types/builder-block.js';
 import { getSrcSet } from './image.helpers.js';
+import type { ImageProps } from './image.types.js';
 
 useMetadata({
   rsc: {
     componentType: 'client',
   },
 });
-
-export interface ImageProps {
-  className?: string;
-  image: string;
-  sizes?: string;
-  lazy?: boolean;
-  height?: number;
-  width?: number;
-  altText?: string;
-  backgroundSize?: 'cover' | 'contain';
-  backgroundPosition?: string;
-  srcset?: string;
-  aspectRatio?: number;
-  children?: any;
-  fitContent?: boolean;
-  builderBlock?: BuilderBlock;
-  noWebp?: boolean;
-  src?: string;
-}
 
 export default function Image(props: ImageProps) {
   const state = useStore({

--- a/packages/sdks/src/blocks/image/image.types.ts
+++ b/packages/sdks/src/blocks/image/image.types.ts
@@ -1,0 +1,20 @@
+import type { BuilderBlock } from '../../types/builder-block';
+
+export interface ImageProps {
+  className?: string;
+  image: string;
+  sizes?: string;
+  lazy?: boolean;
+  height?: number;
+  width?: number;
+  altText?: string;
+  backgroundSize?: 'cover' | 'contain';
+  backgroundPosition?: string;
+  srcset?: string;
+  aspectRatio?: number;
+  children?: any;
+  fitContent?: boolean;
+  builderBlock?: BuilderBlock;
+  noWebp?: boolean;
+  src?: string;
+}

--- a/packages/sdks/src/blocks/image/image.types.ts
+++ b/packages/sdks/src/blocks/image/image.types.ts
@@ -1,4 +1,4 @@
-import type { BuilderBlock } from '../../types/builder-block';
+import type { BuilderBlock } from '../../types/builder-block.js';
 
 export interface ImageProps {
   className?: string;

--- a/packages/sdks/src/blocks/section/section.lite.tsx
+++ b/packages/sdks/src/blocks/section/section.lite.tsx
@@ -1,9 +1,9 @@
 import { useMetadata, useTarget } from '@builder.io/mitosis';
 import { filterAttrs } from '../helpers.js';
+import type { SectionProps } from './section.types.js';
 /**
  * This import is used by the Svelte SDK. Do not remove.
  */
-
 import { setAttrs } from '../helpers.js';
 
 useMetadata({
@@ -11,13 +11,6 @@ useMetadata({
     componentType: 'client',
   },
 });
-
-export interface SectionProps {
-  maxWidth?: number;
-  attributes?: any;
-  children?: any;
-  builderBlock?: any;
-}
 
 export default function SectionComponent(props: SectionProps) {
   return (

--- a/packages/sdks/src/blocks/section/section.types.ts
+++ b/packages/sdks/src/blocks/section/section.types.ts
@@ -1,0 +1,6 @@
+export interface SectionProps {
+  maxWidth?: number;
+  attributes?: any;
+  children?: any;
+  builderBlock?: any;
+}

--- a/packages/sdks/src/blocks/symbol/symbol.lite.tsx
+++ b/packages/sdks/src/blocks/symbol/symbol.lite.tsx
@@ -7,10 +7,7 @@ import {
 } from '@builder.io/mitosis';
 import ContentVariants from '../../components/content-variants/content-variants.lite.jsx';
 import type { BuilderContent } from '../../types/builder-content.js';
-import type {
-  BuilderComponentsProp,
-  PropsWithBuilderData,
-} from '../../types/builder-props.js';
+import type { PropsWithBuilderData } from '../../types/builder-props.js';
 import { filterAttrs } from '../helpers.js';
 /**
  * This import is used by the Svelte SDK. Do not remove.
@@ -19,29 +16,13 @@ import { filterAttrs } from '../helpers.js';
 import type { Nullable } from '../../types/typescript.js';
 import { setAttrs } from '../helpers.js';
 import { fetchSymbolContent } from './symbol.helpers.js';
+import type { SymbolProps } from './symbol.types.js';
 
 useMetadata({
   rsc: {
     componentType: 'server',
   },
 });
-
-export interface SymbolInfo {
-  model?: string;
-  entry?: string;
-  data?: any;
-  content?: BuilderContent;
-  inline?: boolean;
-  dynamic?: boolean;
-}
-
-export interface SymbolProps extends BuilderComponentsProp {
-  symbol?: SymbolInfo;
-  dataOnly?: boolean;
-  dynamic?: boolean;
-  attributes?: any;
-  inheritState?: boolean;
-}
 
 export default function Symbol(props: PropsWithBuilderData<SymbolProps>) {
   const state = useStore({

--- a/packages/sdks/src/blocks/symbol/symbol.types.ts
+++ b/packages/sdks/src/blocks/symbol/symbol.types.ts
@@ -1,0 +1,19 @@
+import type { BuilderContent } from '../../types/builder-content';
+import type { BuilderComponentsProp } from '../../types/builder-props';
+
+interface SymbolInfo {
+  model?: string;
+  entry?: string;
+  data?: any;
+  content?: BuilderContent;
+  inline?: boolean;
+  dynamic?: boolean;
+}
+
+export interface SymbolProps extends BuilderComponentsProp {
+  symbol?: SymbolInfo;
+  dataOnly?: boolean;
+  dynamic?: boolean;
+  attributes?: any;
+  inheritState?: boolean;
+}

--- a/packages/sdks/src/blocks/symbol/symbol.types.ts
+++ b/packages/sdks/src/blocks/symbol/symbol.types.ts
@@ -1,5 +1,5 @@
-import type { BuilderContent } from '../../types/builder-content';
-import type { BuilderComponentsProp } from '../../types/builder-props';
+import type { BuilderContent } from '../../types/builder-content.js';
+import type { BuilderComponentsProp } from '../../types/builder-props.js';
 
 interface SymbolInfo {
   model?: string;

--- a/packages/sdks/src/blocks/text/text.lite.tsx
+++ b/packages/sdks/src/blocks/text/text.lite.tsx
@@ -1,6 +1,4 @@
-export type TextProps = {
-  text?: string;
-};
+import type { TextProps } from './text.types';
 
 export default function Text(props: TextProps) {
   return (

--- a/packages/sdks/src/blocks/text/text.lite.tsx
+++ b/packages/sdks/src/blocks/text/text.lite.tsx
@@ -1,4 +1,8 @@
-export default function Text(props: { text?: string }) {
+export type TextProps = {
+  text?: string;
+};
+
+export default function Text(props: TextProps) {
   return (
     <div
       class={

--- a/packages/sdks/src/blocks/text/text.lite.tsx
+++ b/packages/sdks/src/blocks/text/text.lite.tsx
@@ -1,4 +1,4 @@
-import type { TextProps } from './text.types';
+import type { TextProps } from './text.types.js';
 
 export default function Text(props: TextProps) {
   return (

--- a/packages/sdks/src/blocks/text/text.types.ts
+++ b/packages/sdks/src/blocks/text/text.types.ts
@@ -1,0 +1,3 @@
+export type TextProps = {
+  text?: string;
+};

--- a/packages/sdks/src/blocks/video/video.lite.tsx
+++ b/packages/sdks/src/blocks/video/video.lite.tsx
@@ -1,41 +1,10 @@
 import { Show, useMetadata, useStore } from '@builder.io/mitosis';
-import type { BuilderBlock } from '../../types/builder-block.js';
 
 useMetadata({
   rsc: {
     componentType: 'client',
   },
 });
-
-export interface VideoProps {
-  attributes?: any;
-  video?: string;
-  autoPlay?: boolean;
-  controls?: boolean;
-  muted?: boolean;
-  loop?: boolean;
-  playsInline?: boolean;
-  aspectRatio?: number;
-  width?: number;
-  height?: number;
-  fit?: 'contain' | 'cover' | 'fill';
-  preload?: 'auto' | 'metadata' | 'none';
-  position?:
-    | 'center'
-    | 'top'
-    | 'left'
-    | 'right'
-    | 'bottom'
-    | 'top left'
-    | 'top right'
-    | 'bottom left'
-    | 'bottom right';
-  posterImage?: string;
-  lazyLoad?: boolean;
-  children?: any;
-  fitContent?: boolean;
-  builderBlock?: BuilderBlock;
-}
 
 export default function Video(props: VideoProps) {
   const state = useStore({

--- a/packages/sdks/src/blocks/video/video.lite.tsx
+++ b/packages/sdks/src/blocks/video/video.lite.tsx
@@ -1,4 +1,5 @@
 import { Show, useMetadata, useStore } from '@builder.io/mitosis';
+import type { VideoProps } from './video.types';
 
 useMetadata({
   rsc: {

--- a/packages/sdks/src/blocks/video/video.lite.tsx
+++ b/packages/sdks/src/blocks/video/video.lite.tsx
@@ -1,5 +1,5 @@
 import { Show, useMetadata, useStore } from '@builder.io/mitosis';
-import type { VideoProps } from './video.types';
+import type { VideoProps } from './video.types.js';
 
 useMetadata({
   rsc: {

--- a/packages/sdks/src/blocks/video/video.types.ts
+++ b/packages/sdks/src/blocks/video/video.types.ts
@@ -1,4 +1,4 @@
-import type { BuilderBlock } from '../../types/builder-block';
+import type { BuilderBlock } from '../../types/builder-block.js';
 
 export interface VideoProps {
   attributes?: any;

--- a/packages/sdks/src/blocks/video/video.types.ts
+++ b/packages/sdks/src/blocks/video/video.types.ts
@@ -1,0 +1,31 @@
+import type { BuilderBlock } from '../../types/builder-block';
+
+export interface VideoProps {
+  attributes?: any;
+  video?: string;
+  autoPlay?: boolean;
+  controls?: boolean;
+  muted?: boolean;
+  loop?: boolean;
+  playsInline?: boolean;
+  aspectRatio?: number;
+  width?: number;
+  height?: number;
+  fit?: 'contain' | 'cover' | 'fill';
+  preload?: 'auto' | 'metadata' | 'none';
+  position?:
+    | 'center'
+    | 'top'
+    | 'left'
+    | 'right'
+    | 'bottom'
+    | 'top left'
+    | 'top right'
+    | 'bottom left'
+    | 'bottom right';
+  posterImage?: string;
+  lazyLoad?: boolean;
+  children?: any;
+  fitContent?: boolean;
+  builderBlock?: BuilderBlock;
+}

--- a/packages/sdks/src/components/blocks/blocks.lite.tsx
+++ b/packages/sdks/src/components/blocks/blocks.lite.tsx
@@ -1,4 +1,3 @@
-import type { Signal } from '@builder.io/mitosis';
 import {
   For,
   Show,
@@ -8,20 +7,9 @@ import {
 } from '@builder.io/mitosis';
 import BuilderContext from '../../context/builder.context.lite.js';
 import ComponentsContext from '../../context/components.context.lite.js';
-import type {
-  BuilderContextInterface,
-  RegisteredComponents,
-} from '../../context/types.js';
 import Block from '../block/block.lite.jsx';
-import type { BlocksWrapperProps } from './blocks-wrapper.lite.jsx';
 import BlocksWrapper from './blocks-wrapper.lite.jsx';
-
-export type BlocksProps = Partial<
-  Omit<BlocksWrapperProps, 'BlocksWrapper' | 'BlocksWrapperProps'>
-> & {
-  context?: Signal<BuilderContextInterface>;
-  registeredComponents?: RegisteredComponents;
-};
+import type { BlocksProps } from './blocks.types.js';
 
 useMetadata({
   rsc: {

--- a/packages/sdks/src/components/blocks/blocks.types.ts
+++ b/packages/sdks/src/components/blocks/blocks.types.ts
@@ -2,7 +2,7 @@ import type { Signal } from '@builder.io/mitosis';
 import type {
   BuilderContextInterface,
   RegisteredComponents,
-} from '../../context/types';
+} from '../../context/types.js';
 import type { BlocksWrapperProps } from './blocks-wrapper.lite';
 
 export type BlocksProps = Partial<

--- a/packages/sdks/src/components/blocks/blocks.types.ts
+++ b/packages/sdks/src/components/blocks/blocks.types.ts
@@ -1,0 +1,13 @@
+import type { Signal } from '@builder.io/mitosis';
+import type {
+  BuilderContextInterface,
+  RegisteredComponents,
+} from '../../context/types';
+import type { BlocksWrapperProps } from './blocks-wrapper.lite';
+
+export type BlocksProps = Partial<
+  Omit<BlocksWrapperProps, 'BlocksWrapper' | 'BlocksWrapperProps'>
+> & {
+  context?: Signal<BuilderContextInterface>;
+  registeredComponents?: RegisteredComponents;
+};

--- a/packages/sdks/src/components/content-variants/content-variants.types.ts
+++ b/packages/sdks/src/components/content-variants/content-variants.types.ts
@@ -11,18 +11,22 @@ export interface ContentVariantsPrps {
    * The Builder content JSON to render (required).
    */
   content?: Nullable<BuilderContent>;
+
   /**
-   * The Builder content model to render (required).
+   * The Builder content `model` to render (required).
    */
   model?: string;
+
   /**
    * Additional data to inject into your Builder content (optional).
    */
   data?: { [key: string]: any };
+
   /**
    *
    */
   context?: BuilderRenderContext;
+
   /**
    * Your API Key: needed to dynamically fetch symbols (required).
    */
@@ -41,15 +45,17 @@ export interface ContentVariantsPrps {
   canTrack?: boolean;
 
   /**
-   * A string to set the locale (optional).
+   * If provided, the API will auto-resolve localized objects to the value of this `locale` key (optional).
    */
   locale?: string;
 
-  /** @deprecated use `enrich` instead **/
+  /** @deprecated use `enrich` instead */
   includeRefs?: boolean;
 
   /**
-   * A boolean to enable or disable enriching API content (optional). Defaults to `false`.
+   * A boolean to enable or disable enriching API content (optional).
+   *
+   * Enriching will Include multilevel references in the response. Defaults to `false`.
    */
   enrich?: boolean;
 

--- a/packages/sdks/src/components/content-variants/content-variants.types.ts
+++ b/packages/sdks/src/components/content-variants/content-variants.types.ts
@@ -7,30 +7,67 @@ import type { BuilderContent } from '../../types/builder-content.js';
 import type { Nullable } from '../../types/typescript.js';
 
 export interface ContentVariantsPrps {
+  /**
+   * The Builder content JSON to render (required).
+   */
   content?: Nullable<BuilderContent>;
+  /**
+   * The Builder content model to render (required).
+   */
   model?: string;
+  /**
+   * Additional data to inject into your Builder content (optional).
+   */
   data?: { [key: string]: any };
+  /**
+   *
+   */
   context?: BuilderRenderContext;
+  /**
+   * Your API Key: needed to dynamically fetch symbols (required).
+   */
   apiKey: string;
+
   apiVersion?: ApiVersion;
+
+  /**
+   * An array of custom components to register (optional).
+   */
   customComponents?: RegisteredComponent[];
+
+  /**
+   * A boolean to enable or disable tracking (optional). Defaults to `true`.
+   */
   canTrack?: boolean;
+
+  /**
+   * A string to set the locale (optional).
+   */
   locale?: string;
+
   /** @deprecated use `enrich` instead **/
   includeRefs?: boolean;
+
+  /**
+   * A boolean to enable or disable enriching API content (optional). Defaults to `false`.
+   */
   enrich?: boolean;
+
   /**
    * The element that wraps your content. Defaults to `div` ('ScrollView' in React Native).
    */
   contentWrapper?: any;
+
   /**
    * Additonal props to pass to `contentWrapper`. Defaults to `{}`.
    */
   contentWrapperProps?: any;
+
   /**
    * The element that wraps your blocks. Defaults to `div` ('ScrollView' in React Native).
    */
   blocksWrapper?: any;
+
   /**
    * Additonal props to pass to `blocksWrapper`. Defaults to `{}`.
    */

--- a/packages/sdks/src/functions/get-content/index.ts
+++ b/packages/sdks/src/functions/get-content/index.ts
@@ -14,7 +14,7 @@ const checkContentHasResults = (
 ): content is ContentResults => 'results' in content;
 
 /**
- * Returns a the first entry that matches the given options.
+ * Returns the first content entry that matches the given options.
  */
 export async function fetchOneEntry(
   options: GetContentOptions

--- a/packages/sdks/src/functions/get-content/types.ts
+++ b/packages/sdks/src/functions/get-content/types.ts
@@ -1,8 +1,8 @@
 export interface GetContentOptions {
-  /** The model to get content for */
+  /** The model to get content for (required) */
   model: string;
 
-  /** Your public API key */
+  /** Your public API key (required) */
   apiKey: string;
 
   /** Number of items to fetch. Default is 1 */

--- a/packages/sdks/src/index-helpers/blocks-exports.ts
+++ b/packages/sdks/src/index-helpers/blocks-exports.ts
@@ -1,16 +1,34 @@
-export { default as Button } from '../blocks/button/button.lite.jsx';
-export { default as Columns } from '../blocks/columns/columns.lite.jsx';
-export { default as Fragment } from '../blocks/fragment/fragment.lite.jsx';
-export { default as Image } from '../blocks/image/image.lite.jsx';
-export { default as Section } from '../blocks/section/section.lite.jsx';
-export { default as Symbol } from '../blocks/symbol/symbol.lite.jsx';
-export { default as Text } from '../blocks/text/text.lite.jsx';
-export { default as Video } from '../blocks/video/video.lite.jsx';
+export {
+  default as Button,
+  ButtonProps,
+} from '../blocks/button/button.lite.jsx';
+export {
+  ColumnProps,
+  default as Columns,
+} from '../blocks/columns/columns.lite.jsx';
+export {
+  default as Fragment,
+  FragmentProps,
+} from '../blocks/fragment/fragment.lite.jsx';
+export { default as Image, ImageProps } from '../blocks/image/image.lite.jsx';
+export {
+  default as Section,
+  SectionProps,
+} from '../blocks/section/section.lite.jsx';
+export {
+  default as Symbol,
+  SymbolProps,
+} from '../blocks/symbol/symbol.lite.jsx';
+export { default as Text, TextProps } from '../blocks/text/text.lite.jsx';
+export { default as Video, VideoProps } from '../blocks/video/video.lite.jsx';
 
-import { default as Blocks } from '../components/blocks/blocks.lite.jsx';
+import {
+  default as Blocks,
+  BlocksProps,
+} from '../components/blocks/blocks.lite.jsx';
 import { default as Content } from '../components/content-variants/content-variants.lite.jsx';
 
-export { Blocks, Content };
+export { Blocks, BlocksProps, Content };
 
 /**
  * @deprecated Renamed to `Blocks`.

--- a/packages/sdks/src/index-helpers/blocks-exports.ts
+++ b/packages/sdks/src/index-helpers/blocks-exports.ts
@@ -1,34 +1,16 @@
-export {
-  default as Button,
-  ButtonProps,
-} from '../blocks/button/button.lite.jsx';
-export {
-  ColumnProps,
-  default as Columns,
-} from '../blocks/columns/columns.lite.jsx';
-export {
-  default as Fragment,
-  FragmentProps,
-} from '../blocks/fragment/fragment.lite.jsx';
-export { default as Image, ImageProps } from '../blocks/image/image.lite.jsx';
-export {
-  default as Section,
-  SectionProps,
-} from '../blocks/section/section.lite.jsx';
-export {
-  default as Symbol,
-  SymbolProps,
-} from '../blocks/symbol/symbol.lite.jsx';
-export { default as Text, TextProps } from '../blocks/text/text.lite.jsx';
-export { default as Video, VideoProps } from '../blocks/video/video.lite.jsx';
+export { default as Button } from '../blocks/button/button.lite.jsx';
+export { default as Columns } from '../blocks/columns/columns.lite.jsx';
+export { default as Fragment } from '../blocks/fragment/fragment.lite.jsx';
+export { default as Image } from '../blocks/image/image.lite.jsx';
+export { default as Section } from '../blocks/section/section.lite.jsx';
+export { default as Symbol } from '../blocks/symbol/symbol.lite.jsx';
+export { default as Text } from '../blocks/text/text.lite.jsx';
+export { default as Video } from '../blocks/video/video.lite.jsx';
 
-import {
-  default as Blocks,
-  BlocksProps,
-} from '../components/blocks/blocks.lite.jsx';
+import { default as Blocks } from '../components/blocks/blocks.lite.jsx';
 import { default as Content } from '../components/content-variants/content-variants.lite.jsx';
 
-export { Blocks, BlocksProps, Content };
+export { Blocks, Content };
 
 /**
  * @deprecated Renamed to `Blocks`.

--- a/packages/sdks/src/server-index.ts
+++ b/packages/sdks/src/server-index.ts
@@ -1,15 +1,15 @@
 export * from './index-helpers/top-of-file.js';
 
-export { ButtonProps } from './blocks/button/button.types.js';
-export { ColumnProps } from './blocks/columns/columns.types.js';
-export { FragmentProps } from './blocks/fragment/fragment.types.js';
-export { ImageProps } from './blocks/image/image.types.js';
-export { SectionProps } from './blocks/section/section.types.js';
-export { SymbolProps } from './blocks/symbol/symbol.types.js';
-export { TextProps } from './blocks/text/text.types.js';
-export { VideoProps } from './blocks/video/video.types.js';
-export { BlocksProps } from './components/blocks/blocks.types.js';
-export { ContentVariantsPrps as ContentProps } from './components/content-variants/content-variants.types.js';
+export type { ButtonProps } from './blocks/button/button.types.js';
+export type { ColumnProps } from './blocks/columns/columns.types.js';
+export type { FragmentProps } from './blocks/fragment/fragment.types.js';
+export type { ImageProps } from './blocks/image/image.types.js';
+export type { SectionProps } from './blocks/section/section.types.js';
+export type { SymbolProps } from './blocks/symbol/symbol.types.js';
+export type { TextProps } from './blocks/text/text.types.js';
+export type { VideoProps } from './blocks/video/video.types.js';
+export type { BlocksProps } from './components/blocks/blocks.types.js';
+export type { ContentVariantsPrps as ContentProps } from './components/content-variants/content-variants.types.js';
 
 export { isEditing } from './functions/is-editing.js';
 export { isPreviewing } from './functions/is-previewing.js';

--- a/packages/sdks/src/server-index.ts
+++ b/packages/sdks/src/server-index.ts
@@ -1,5 +1,16 @@
 export * from './index-helpers/top-of-file.js';
 
+export { ButtonProps } from './blocks/button/button.types.js';
+export { ColumnProps } from './blocks/columns/columns.types.js';
+export { FragmentProps } from './blocks/fragment/fragment.types.js';
+export { ImageProps } from './blocks/image/image.types.js';
+export { SectionProps } from './blocks/section/section.types.js';
+export { SymbolProps } from './blocks/symbol/symbol.types.js';
+export { TextProps } from './blocks/text/text.types.js';
+export { VideoProps } from './blocks/video/video.types.js';
+export { BlocksProps } from './components/blocks/blocks.types.js';
+export { ContentVariantsPrps as ContentProps } from './components/content-variants/content-variants.types.js';
+
 export { isEditing } from './functions/is-editing.js';
 export { isPreviewing } from './functions/is-previewing.js';
 export { createRegisterComponentMessage } from './functions/register-component.js';
@@ -22,7 +33,6 @@ export { getBuilderSearchParams } from './functions/get-builder-search-params/in
 
 export { track } from './functions/track/index.js';
 
-export { ContentVariantsPrps as ContentProps } from './components/content-variants/content-variants.types.js';
 export type { RegisteredComponent } from './context/types.js';
 export type { ComponentInfo } from './types/components.js';
 

--- a/packages/sdks/src/server-index.ts
+++ b/packages/sdks/src/server-index.ts
@@ -22,7 +22,7 @@ export { getBuilderSearchParams } from './functions/get-builder-search-params/in
 
 export { track } from './functions/track/index.js';
 
-export type { ContentProps } from './components/content/content.types.js';
+export { ContentVariantsPrps as ContentProps } from './components/content-variants/content-variants.types.js';
 export type { RegisteredComponent } from './context/types.js';
 export type { ComponentInfo } from './types/components.js';
 


### PR DESCRIPTION
## Description

SDKs:

- Fix: use correct export for `ContentProps`.
- Export prop types of all exported components in main index file.
- Improve documentation of `ContentProps` types.
- Vue SDK: Add './edge' subpath export to work around isolated-vm issues in serverless environments. Closes #2933 
- React SDK & NextJS SDK: Improve "./edge" subpath export to automatically use the browser bundle for browser environments. This allows the usage of that subpath export without also manually toggling with the "./browser" bundle.
- React SDK: Bring back Nextjs app dir test using "./edge" subpath export.