### PR TITLE
Fix: SDKs edge export

### DIFF
--- a/.changeset/fluffy-falcons-clean.md
+++ b/.changeset/fluffy-falcons-clean.md
@@ -1,0 +1,7 @@
+---
+'@builder.io/sdk-react-nextjs': patch
+'@builder.io/sdk-react': patch
+'@builder.io/sdk-vue': patch
+---
+
+Fix: update "/edge" and "/node" subpath exports to only point to their corresponding bundles. This guarantees that the browser bundle is never imported by mistake.

--- a/packages/sdks/e2e/nextjs-app-dir-client/src/app/[[...slug]]/page.tsx
+++ b/packages/sdks/e2e/nextjs-app-dir-client/src/app/[[...slug]]/page.tsx
@@ -1,10 +1,15 @@
-import { RenderContent } from '@builder.io/sdk-react/edge';
+import { Content as BrowserContent } from '@builder.io/sdk-react/browser';
+import { Content as EdgeContent } from '@builder.io/sdk-react/edge';
 import {
   _processContentResult,
   getBuilderSearchParams,
   getContent,
 } from '@builder.io/sdk-react/server';
 import { getProps } from '@e2e/tests';
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined' && typeof document !== 'undefined';
+}
 
 interface PageProps {
   params: {
@@ -32,7 +37,11 @@ export default async function Page(props: PageProps) {
       </>
     );
   }
-  return <RenderContent {...builderProps} />;
+  return isBrowser() ? (
+    <BrowserContent {...builderProps} />
+  ) : (
+    <EdgeContent {...builderProps} />
+  );
 }
 
 export const revalidate = 4;

--- a/packages/sdks/output/nextjs/package.json
+++ b/packages/sdks/output/nextjs/package.json
@@ -67,104 +67,12 @@
       }
     },
     "./edge": {
-      "node": {
-        "import": "./lib/edge/index.mjs",
-        "require": "./lib/edge/index.cjs"
-      },
-      "browser": {
-        "import": "./lib/browser/index.mjs",
-        "require": "./lib/browser/index.cjs"
-      },
-      "edge-routine": {
-        "import": "./lib/edge/index.mjs",
-        "require": "./lib/edge/index.cjs"
-      },
-      "workerd": {
-        "import": "./lib/edge/index.mjs",
-        "require": "./lib/edge/index.cjs"
-      },
-      "deno": {
-        "import": "./lib/edge/index.mjs",
-        "require": "./lib/edge/index.cjs"
-      },
-      "lagon": {
-        "import": "./lib/edge/index.mjs",
-        "require": "./lib/edge/index.cjs"
-      },
-      "netlify": {
-        "import": "./lib/edge/index.mjs",
-        "require": "./lib/edge/index.cjs"
-      },
-      "edge-light": {
-        "import": "./lib/edge/index.mjs",
-        "require": "./lib/edge/index.cjs"
-      },
-      "bun": {
-        "import": "./lib/edge/index.mjs",
-        "require": "./lib/edge/index.cjs"
-      },
-      "react-native": {
-        "import": "./lib/edge/index.mjs",
-        "require": "./lib/edge/index.cjs"
-      },
-      "electron": {
-        "import": "./lib/edge/index.mjs",
-        "require": "./lib/edge/index.cjs"
-      },
-      "default": {
-        "import": "./lib/browser/index.mjs",
-        "require": "./lib/browser/index.cjs"
-      }
+      "import": "./lib/edge/index.mjs",
+      "require": "./lib/edge/index.cjs"
     },
     "./node": {
-      "node": {
-        "import": "./lib/node/index.mjs",
-        "require": "./lib/node/index.cjs"
-      },
-      "browser": {
-        "import": "./lib/browser/index.mjs",
-        "require": "./lib/browser/index.cjs"
-      },
-      "edge-routine": {
-        "import": "./lib/node/index.mjs",
-        "require": "./lib/node/index.cjs"
-      },
-      "workerd": {
-        "import": "./lib/node/index.mjs",
-        "require": "./lib/node/index.cjs"
-      },
-      "deno": {
-        "import": "./lib/node/index.mjs",
-        "require": "./lib/node/index.cjs"
-      },
-      "lagon": {
-        "import": "./lib/node/index.mjs",
-        "require": "./lib/node/index.cjs"
-      },
-      "netlify": {
-        "import": "./lib/node/index.mjs",
-        "require": "./lib/node/index.cjs"
-      },
-      "edge-light": {
-        "import": "./lib/node/index.mjs",
-        "require": "./lib/node/index.cjs"
-      },
-      "bun": {
-        "import": "./lib/node/index.mjs",
-        "require": "./lib/node/index.cjs"
-      },
-      "react-native": {
-        "import": "./lib/node/index.mjs",
-        "require": "./lib/node/index.cjs"
-      },
-      "electron": {
-        "import": "./lib/node/index.mjs",
-        "require": "./lib/node/index.cjs"
-      },
-      "default": {
-        "import": "./lib/browser/index.mjs",
-        "require": "./lib/browser/index.cjs"
-      }
+      "import": "./lib/node/index.mjs",
+      "require": "./lib/node/index.cjs"
     },
     "./browser": {
       "import": "./lib/browser/index.mjs",

--- a/packages/sdks/output/react/package.json
+++ b/packages/sdks/output/react/package.json
@@ -80,66 +80,9 @@
       }
     },
     "./edge": {
-      "node": {
-        "types": "./types/index.d.ts",
-        "import": "./lib/edge/index.mjs",
-        "require": "./lib/edge/index.cjs"
-      },
-      "browser": {
-        "types": "./types/index.d.ts",
-        "import": "./lib/browser/index.mjs",
-        "require": "./lib/browser/index.cjs"
-      },
-      "edge-routine": {
-        "types": "./types/index.d.ts",
-        "import": "./lib/edge/index.mjs",
-        "require": "./lib/edge/index.cjs"
-      },
-      "workerd": {
-        "types": "./types/index.d.ts",
-        "import": "./lib/edge/index.mjs",
-        "require": "./lib/edge/index.cjs"
-      },
-      "deno": {
-        "types": "./types/index.d.ts",
-        "import": "./lib/edge/index.mjs",
-        "require": "./lib/edge/index.cjs"
-      },
-      "lagon": {
-        "types": "./types/index.d.ts",
-        "import": "./lib/edge/index.mjs",
-        "require": "./lib/edge/index.cjs"
-      },
-      "netlify": {
-        "types": "./types/index.d.ts",
-        "import": "./lib/edge/index.mjs",
-        "require": "./lib/edge/index.cjs"
-      },
-      "edge-light": {
-        "types": "./types/index.d.ts",
-        "import": "./lib/edge/index.mjs",
-        "require": "./lib/edge/index.cjs"
-      },
-      "bun": {
-        "types": "./types/index.d.ts",
-        "import": "./lib/edge/index.mjs",
-        "require": "./lib/edge/index.cjs"
-      },
-      "react-native": {
-        "types": "./types/index.d.ts",
-        "import": "./lib/edge/index.mjs",
-        "require": "./lib/edge/index.cjs"
-      },
-      "electron": {
-        "types": "./types/index.d.ts",
-        "import": "./lib/edge/index.mjs",
-        "require": "./lib/edge/index.cjs"
-      },
-      "default": {
-        "types": "./types/index.d.ts",
-        "import": "./lib/browser/index.mjs",
-        "require": "./lib/browser/index.cjs"
-      }
+      "types": "./types/index.d.ts",
+      "import": "./lib/edge/index.mjs",
+      "require": "./lib/edge/index.cjs"
     },
     "./node": {
       "types": "./types/index.d.ts",

--- a/packages/sdks/output/vue/package.json
+++ b/packages/sdks/output/vue/package.json
@@ -26,50 +26,16 @@
     "./css": "./lib/browser/style.css",
     "./nuxt": "./nuxt.js",
     "./edge": {
-      "node": {
-        "import": "./lib/edge/index.js",
-        "require": "./lib/edge/index.cjs"
-      },
-      "browser": {
-        "import": "./lib/browser/index.js",
-        "require": "./lib/browser/index.cjs"
-      },
-      "edge-routine": {
-        "import": "./lib/edge/index.js",
-        "require": "./lib/edge/index.cjs"
-      },
-      "workerd": {
-        "import": "./lib/edge/index.js",
-        "require": "./lib/edge/index.cjs"
-      },
-      "deno": {
-        "import": "./lib/edge/index.js",
-        "require": "./lib/edge/index.cjs"
-      },
-      "lagon": {
-        "import": "./lib/edge/index.js",
-        "require": "./lib/edge/index.cjs"
-      },
-      "netlify": {
-        "import": "./lib/edge/index.js",
-        "require": "./lib/edge/index.cjs"
-      },
-      "edge-light": {
-        "import": "./lib/edge/index.js",
-        "require": "./lib/edge/index.cjs"
-      },
-      "bun": {
-        "import": "./lib/edge/index.js",
-        "require": "./lib/edge/index.cjs"
-      },
-      "electron": {
-        "import": "./lib/edge/index.js",
-        "require": "./lib/edge/index.cjs"
-      },
-      "default": {
-        "import": "./lib/browser/index.js",
-        "require": "./lib/browser/index.cjs"
-      }
+      "import": "./lib/edge/index.js",
+      "require": "./lib/edge/index.cjs"
+    },
+    "./browser": {
+      "import": "./lib/browser/index.js",
+      "require": "./lib/browser/index.cjs"
+    },
+    "./node": {
+      "import": "./lib/node/index.js",
+      "require": "./lib/node/index.cjs"
     },
     ".": {
       "node": {


### PR DESCRIPTION
## Description

SDKS (next/react/vue):

- update subpath exports to only point to 1 bundle.