### PR TITLE
Check `this.useLazyLoading` property to determine loading behavior for Image component

### DIFF
--- a/packages/react/src/blocks/Image.tsx
+++ b/packages/react/src/blocks/Image.tsx
@@ -342,7 +342,7 @@ class ImageComponent extends React.Component<any, { imageLoaded: boolean; load: 
                   },
                 }),
               }}
-              loading={isPixel ? 'eager' : 'lazy'}
+              loading={isPixel || !this.useLazyLoading ? 'eager' : 'lazy'}
               className={'builder-image' + (this.props.className ? ' ' + this.props.className : '')}
               src={this.image}
               {...(!amp && {


### PR DESCRIPTION
## Description

Right now, the built in `Image` component for builder will _always_ set `loading=lazy` for any image that is not the tracking pixel. But there is a prop `lazy` that is meant to configure the loading behavior, which in turn gets checked in `useLazyLoading`. It's counterintuitive that setting `lazy=false` will still result in an image that has the property `loading=lazy` set. 

This change would allow configuring the prop `lazy={false}` on the `Image` component to allow changing the loading behavior from `lazy` to `eager`. 
