### PR TITLE
Backport: stricter trusted hosts (#2943)

### DIFF
--- a/packages/core/jest.config.ts
+++ b/packages/core/jest.config.ts
@@ -117,9 +117,7 @@ export default {
   // rootDir: undefined,
 
   // A list of paths to directories that Jest should use to search for files in
-  // roots: [
-  //   "<rootDir>"
-  // ],
+  roots: ['src'],
 
   // Allows you to use a custom runner instead of Jest's default test runner
   // runner: "jest-runner",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,6 +54,7 @@
     "rollup-plugin-typescript": "^0.8.1",
     "rollup-plugin-typescript2": "^0.13.0",
     "rollup-plugin-uglify": "^3.0.0",
+    "ts-node": "^10.9.2",
     "typedoc": "^0.22.15",
     "typedoc-plugin-markdown": "^3.12.1",
     "typescript": "^4.6.4"

--- a/packages/core/src/builder.class.test.ts
+++ b/packages/core/src/builder.class.test.ts
@@ -1,0 +1,23 @@
+import { Builder } from './builder.class';
+
+describe('Builder', () => {
+  test('trustedHosts', () => {
+    expect(Builder.isTrustedHost('localhost')).toBe(true);
+    expect(Builder.isTrustedHost('builder.io')).toBe(true);
+    expect(Builder.isTrustedHost('beta.builder.io')).toBe(true);
+    expect(Builder.isTrustedHost('qa.builder.io')).toBe(true);
+    expect(Builder.isTrustedHost('123-review-build.beta.builder.io')).toBe(true);
+  });
+
+  test('arbitrary builder.io subdomains', () => {
+    expect(Builder.isTrustedHost('cdn.builder.io')).toBe(false);
+    expect(Builder.isTrustedHost('foo.builder.io')).toBe(false);
+    expect(Builder.isTrustedHost('evildomainbeta.builder.io')).toBe(false);
+  });
+
+  test('add trusted host', () => {
+    expect(Builder.isTrustedHost('example.com')).toBe(false);
+    Builder.registerTrustedHost('example.com');
+    expect(Builder.isTrustedHost('example.com')).toBe(true);
+  });
+});

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -663,7 +663,14 @@ export class Builder {
   static throttle = throttle;
 
   static editors: any[] = [];
-  static trustedHosts: string[] = ['builder.io', 'localhost'];
+  static trustedHosts: string[] = [
+    '*.beta.builder.io',
+    'beta.builder.io',
+    'builder.io',
+    'localhost',
+    'qa.builder.io',
+  ];
+  static serverContext: any;
   static plugins: any[] = [];
 
   static actions: Action[] = [];
@@ -739,8 +746,10 @@ export class Builder {
 
   static isTrustedHost(hostname: string) {
     return (
-      this.trustedHosts.findIndex(
-        trustedHost => trustedHost === hostname || hostname.endsWith(`.${trustedHost}`)
+      this.trustedHosts.findIndex(trustedHost =>
+        trustedHost.startsWith('*.')
+          ? hostname.endsWith(trustedHost.slice(1))
+          : trustedHost === hostname
       ) > -1
     );
   }


### PR DESCRIPTION
No longer allow arbitrary subdomains of builder.io in trusted hosts.