### PR TITLE
[Fix][Environments][Algolia Plugin] SUPP-298 Added safety check so that sync-to-algolia does not appear in an env's model

### DIFF
--- a/plugins/algolia/README.md
+++ b/plugins/algolia/README.md
@@ -22,7 +22,7 @@ Now that you have the plugin set up, you can start syncing your model content. F
 
 Click the More Options button above the model fields, then you'll see a button at the bottom of the Show More Options section, click this button and your existing content will automatically be sent to Algolia with the index name `builder-modelName`.
 
-![Builder Model Sync to Algolia](https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F84665735c1c3430696f3d382f23bec40)
+![Builder Model Sync to Algolia](https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F84665735c1c3430696f3d382f23bec40)
 
 ## Adding Algolia Search Inputs via Builder
 

--- a/plugins/algolia/package.json
+++ b/plugins/algolia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-algolia",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "",
   "keywords": [],
   "main": "dist/plugin.system.js",

--- a/plugins/algolia/package.json
+++ b/plugins/algolia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-algolia",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "",
   "keywords": [],
   "main": "dist/plugin.system.js",

--- a/plugins/algolia/src/plugin.tsx
+++ b/plugins/algolia/src/plugin.tsx
@@ -53,7 +53,7 @@ Builder.register('app.onLoad', async ({ triggerSettingsDialog }: AppActions) => 
 Builder.register('model.action', {
   name: 'Sync to Algolia',
   showIf() {
-    return appState.user.can('admin');
+    return appState.user.can('admin') && !appState.user.organization.value.isEnvironment;
   },
   async onClick(model: any) {
     if (


### PR DESCRIPTION

Added safety check so that sync-to-algolia button does not appear, in an env's model so that changes of mixup dont arise.