### PR TITLE
feat(react): support named slots

### DIFF
--- a/packages/core/src/url.ts
+++ b/packages/core/src/url.ts
@@ -33,7 +33,7 @@ export function parse(url: string): UrlLike {
   if (pathOnly) {
     u = new URL(url, 'http://0.0.0.0/');
     out.href = u.href;
-    out.href = out.href.slice(14); // remove 'http://0.0.0.0/'
+    out.href = out.href?.slice(14); // remove 'http://0.0.0.0/'
   } else {
     u = new URL(url);
     out.href = u.href;

--- a/packages/react/src/functions/with-children.tsx
+++ b/packages/react/src/functions/with-children.tsx
@@ -3,6 +3,10 @@ import React from 'react';
 import { BuilderElement } from '@builder.io/sdk';
 import { BuilderBlock } from '../components/builder-block.component';
 
+const isBuilderElement = (item: unknown): item is BuilderElement => {
+  return Boolean((item as any)?.['@type'] === '@builder.io/sdk:Element');
+};
+
 /**
  * Higher order component for passing Builder.io children as React children
  *
@@ -28,16 +32,29 @@ import { BuilderBlock } from '../components/builder-block.component';
 export const withChildren = <P extends object>(Component: React.ComponentType<P>) => {
   const HOC = React.forwardRef<any, React.PropsWithChildren<P> & { builderBlock?: BuilderElement }>(
     (props, ref) => {
+      const useProps = { ...props };
       const children =
         props.children ||
         (props.builderBlock &&
           props.builderBlock.children &&
           props.builderBlock.children.map(child => <BuilderBlock key={child.id} block={child} />));
 
+      const componentOptions = props.builderBlock?.component?.options;
+      if (!!componentOptions) {
+        Object.keys(componentOptions).forEach(key => {
+          const value = componentOptions[key];
+          const valueIsArrayOfBuilderElements =
+            Array.isArray(value) && value.every(isBuilderElement);
+          if (valueIsArrayOfBuilderElements) {
+            useProps[key] = value.map(child => <BuilderBlock key={child.id} block={child} />);
+          }
+        });
+      }
+
       return (
         // getting type errors due to `@types/react` version mismatches. Can safely ignore.
         // @ts-ignore
-        <Component {...props} ref={ref}>
+        <Component {...useProps} ref={ref}>
           {children}
         </Component>
       );


### PR DESCRIPTION
## Description

This is a change to support passing Builder element JSON to named slots and having it render properly as React components when using the `useChildren` helper. https://www.loom.com/share/892e31ef922d49749aee44ac349a38c1?sid=55de675f-f110-44f0-be1f-e7bcde1be413

With this change a user can wrap their custom component with `withChildren` and now it will not only support the `children` prop but any arbitrary named slot prop as well:
```jsx
<div className={styles.counter}>
  <button className={styles.btn} onClick={decrement}>
    -
  </button>
  <span className={styles.count}>{count}</span>
  <button className={styles.btn} onClick={increment}>
    +
  </button>
  {children}
  {something}
</div>
```
