### PR TITLE
fix[gen1][react]: SUPP-299 `deviceSize` state not getting assigned properly

### DIFF
--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -1384,10 +1384,10 @@ export class BuilderComponent extends React.Component<
         state: Object.assign(this.rootState, {
           ...this.state.state,
           location: this.locationState,
-          deviceSize: this.deviceSizeState,
           device: this.device,
           ...data.state,
           ...this.externalState,
+          deviceSize: this.deviceSizeState,
         }),
       };
       if (this.mounted) {


### PR DESCRIPTION
## Description

On content load, `data.state` has default deviceSize of `large`. Even if we are getting the correct value from `this.deviceSizeState` getter we are unable to set it correctly as this is getting overridden by the default value from `data.state` . This PR puts the deviceSize state after `...data.state` so that correct values get passed.

**Jira**:
https://builder-io.atlassian.net/browse/SUPP-299

**Loom**:
https://www.loom.com/share/48bd067109be4395954d418806c19483
