### PR TITLE
fix[sdks]: ENG-5039 update default value of video in sdks

### DIFF
--- a/packages/react/src/blocks/Video.tsx
+++ b/packages/react/src/blocks/Video.tsx
@@ -198,7 +198,7 @@ export const Video = Builder.registerComponent(withChildren(VideoComponent), {
       allowedFileTypes: ['mp4'],
       bubble: true,
       defaultValue:
-        'https://firebasestorage.googleapis.com/v0/b/builder-3b0a2.appspot.com/o/assets%2FKQlEmWDxA0coC3PK6UvkrjwkIGI2%2F28cb070609f546cdbe5efa20e931aa4b?alt=media&token=912e9551-7a7c-4dfb-86b6-3da1537d1a7f',
+        'https://cdn.builder.io/o/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fd27731a526464deba0016216f5f9e570%2Fcompressed?apiKey=YJIGb4i01jvw0SRdL5Bt&token=d27731a526464deba0016216f5f9e570&alt=media&optimized=true',
       required: true,
     },
     {

--- a/packages/sdks/src/blocks/video/component-info.ts
+++ b/packages/sdks/src/blocks/video/component-info.ts
@@ -17,7 +17,7 @@ export const componentInfo: ComponentInfo = {
       allowedFileTypes: ['mp4'],
       bubble: true,
       defaultValue:
-        'https://firebasestorage.googleapis.com/v0/b/builder-3b0a2.appspot.com/o/assets%2FKQlEmWDxA0coC3PK6UvkrjwkIGI2%2F28cb070609f546cdbe5efa20e931aa4b?alt=media&token=912e9551-7a7c-4dfb-86b6-3da1537d1a7f',
+        'https://cdn.builder.io/o/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fd27731a526464deba0016216f5f9e570%2Fcompressed?apiKey=YJIGb4i01jvw0SRdL5Bt&token=d27731a526464deba0016216f5f9e570&alt=media&optimized=true',
       required: true,
     },
     {


### PR DESCRIPTION
## Description

The default value of the video is [corrupted](https://firebasestorage.googleapis.com/v0/b/builder-3b0a2.appspot.com/o/assets%2FKQlEmWDxA0coC3PK6UvkrjwkIGI2%2F28cb070609f546cdbe5efa20e931aa4b?alt=media&token=912e9551-7a7c-4dfb-86b6-3da1537d1a7f) and shows permissions denied. By debugging we found out that the video is not present in the storage.

After a discussion in slack, we've decided to use this video value. This is uploaded in the Builder space assets library named `default-builder-sdk-video.mp4`

**Jira**
https://builder-io.atlassian.net/browse/ENG-5039
