### PR TITLE
Revert "Use latest v3 content api with enrich flag to work with symbols text translations (#3024)"

### DIFF
--- a/plugins/phrase-conector/src/plugin.tsx
+++ b/plugins/phrase-conector/src/plugin.tsx
@@ -74,7 +74,7 @@ registerPlugin(
           const sourceLocale = content.meta?.translationSourceLang;
           if (isPending && sourceLocale && content.published === 'published') {
             const lastPublishedContent = await fetch(
-              `https://cdn.builder.io/api/v3/content/${appState.designerState.editingModel.name}/${content.id}?apiKey=${appState.user.apiKey}&cachebust=true&enrich=true`
+              `https://cdn.builder.io/api/v3/content/${appState.designerState.editingModel.name}/${content.id}?apiKey=${appState.user.apiKey}&cachebust=true`
             ).then(res => res.json());
             const translatableFields = getTranslateableFields(
               lastPublishedContent,


### PR DESCRIPTION
This reverts commit d17ef6140dc69dde3a84f223251a0e017e97b80f.

## Description
Reverting this so as to apply a better fix for handling of symbols and localized text.
