### PR TITLE
[fix] default styles to be present only once (not inside nested render)

### DIFF
--- a/.changeset/gorgeous-ants-enjoy.md
+++ b/.changeset/gorgeous-ants-enjoy.md
@@ -1,0 +1,11 @@
+---
+'@builder.io/sdk-react-nextjs': patch
+'@builder.io/sdk-qwik': patch
+'@builder.io/sdk-react': patch
+'@builder.io/sdk-react-native': patch
+'@builder.io/sdk-solid': patch
+'@builder.io/sdk-svelte': patch
+'@builder.io/sdk-vue': patch
+---
+
+fix: default styles only when content is not a nested render

--- a/.changeset/gorgeous-ants-enjoy.md
+++ b/.changeset/gorgeous-ants-enjoy.md
@@ -8,4 +8,4 @@
 '@builder.io/sdk-vue': patch
 ---
 
-fix: default styles only when content is not a nested render
+Fix: Symbol styles overriding subsequent content styles.

--- a/packages/sdks-tests/src/specs/default-styles.ts
+++ b/packages/sdks-tests/src/specs/default-styles.ts
@@ -1,0 +1,160 @@
+export const DEFAULT_STYLES = {
+  ownerId: 'ad30f9a246614faaa6a03374f83554c9',
+  lastUpdateBy: null,
+  createdDate: 1710745607133,
+  id: '66c4a568f6674c8d950d700f0ae39a75',
+  '@version': 4,
+  name: 'nuxt-test',
+  modelId: '17c6065109ef4062ba083f5741f4ee6a',
+  published: 'published',
+  meta: {
+    hasLinks: false,
+    lastPreviewUrl:
+      'http://localhost:5173/nuxt-test?builder.space=ad30f9a246614faaa6a03374f83554c9&builder.cachebust=true&builder.preview=page&builder.noCache=true&builder.allowTextEdit=true&__builder_editing__=true&builder.overrides.page=66c4a568f6674c8d950d700f0ae39a75&builder.overrides.66c4a568f6674c8d950d700f0ae39a75=66c4a568f6674c8d950d700f0ae39a75&builder.overrides.page:/nuxt-test=66c4a568f6674c8d950d700f0ae39a75',
+    kind: 'page',
+    symbolsUsed: {
+      '5229f8cc4ff94ab59ecfca7a1ea50eb2': true,
+    },
+  },
+  priority: -306,
+  query: [
+    {
+      '@type': '@builder.io/core:Query',
+      property: 'urlPath',
+      operator: 'is',
+      value: '/nuxt-test',
+    },
+  ],
+  data: {
+    themeId: false,
+    title: 'nuxt-test',
+    blocks: [
+      {
+        '@type': '@builder.io/sdk:Element',
+        '@version': 2,
+        id: 'builder-d102907d176b4dfea5dbe7c0e0887681',
+        component: {
+          name: 'Core:Button',
+          options: {
+            text: 'Click me!',
+            openLinkInNewTab: false,
+          },
+        },
+        responsiveStyles: {
+          large: {
+            display: 'flex',
+            flexDirection: 'column',
+            position: 'relative',
+            flexShrink: '0',
+            boxSizing: 'border-box',
+            marginTop: '20px',
+            appearance: 'none',
+            paddingTop: '15px',
+            paddingBottom: '15px',
+            paddingLeft: '25px',
+            paddingRight: '25px',
+            backgroundColor: 'black',
+            color: 'white',
+            borderRadius: '4px',
+            textAlign: 'center',
+            cursor: 'pointer',
+          },
+        },
+      },
+      {
+        '@type': '@builder.io/sdk:Element',
+        '@version': 2,
+        id: 'builder-df66a2cfc233453c9ae84f4fb394b1ea',
+        component: {
+          name: 'Symbol',
+          options: {
+            symbol: {
+              data: {},
+              model: 'symbol',
+              entry: '5229f8cc4ff94ab59ecfca7a1ea50eb2',
+              ownerId: 'ad30f9a246614faaa6a03374f83554c9',
+              content: {
+                ownerId: 'ad30f9a246614faaa6a03374f83554c9',
+                lastUpdateBy: null,
+                createdDate: 1710424607776,
+                id: '5229f8cc4ff94ab59ecfca7a1ea50eb2',
+                '@version': 4,
+                name: 'dsjg',
+                modelId: '5e1209efea0045f58d9b871d81b652fa',
+                published: 'published',
+                meta: {
+                  kind: 'component',
+                  lastPreviewUrl:
+                    'https://preview.builder.codes?model=symbol&previewing=true&apiKey=ad30f9a246614faaa6a03374f83554c9&builder.space=ad30f9a246614faaa6a03374f83554c9&builder.cachebust=true&builder.preview=symbol&builder.noCache=true&builder.allowTextEdit=true&__builder_editing__=true&builder.overrides.symbol=5229f8cc4ff94ab59ecfca7a1ea50eb2&builder.overrides.5229f8cc4ff94ab59ecfca7a1ea50eb2=5229f8cc4ff94ab59ecfca7a1ea50eb2',
+                  hasLinks: false,
+                },
+                priority: -301,
+                query: [],
+                data: {
+                  blocks: [
+                    {
+                      '@type': '@builder.io/sdk:Element',
+                      '@version': 2,
+                      id: 'builder-24b138e51268417d994c0cef1fe0e718',
+                      meta: {
+                        previousId: 'builder-4e17a0ece3f84bb7b9134190be4c837a',
+                      },
+                      component: {
+                        name: 'Text',
+                        options: {
+                          text: 'Enter some text...',
+                        },
+                      },
+                      responsiveStyles: {
+                        large: {
+                          display: 'flex',
+                          flexDirection: 'column',
+                          position: 'relative',
+                          flexShrink: '0',
+                          boxSizing: 'border-box',
+                          marginTop: '20px',
+                          lineHeight: 'normal',
+                          height: 'auto',
+                        },
+                      },
+                    },
+                  ],
+                },
+                metrics: {
+                  clicks: 0,
+                  impressions: 0,
+                },
+                variations: {},
+                testRatio: 1,
+                screenshot: '',
+                createdBy: 'RuGeCLr9ryVt1xRazFYc72uWwIK2',
+                lastUpdatedBy: 'RuGeCLr9ryVt1xRazFYc72uWwIK2',
+                folders: [],
+              },
+            },
+          },
+        },
+        responsiveStyles: {
+          large: {
+            display: 'flex',
+            flexDirection: 'column',
+            position: 'relative',
+            flexShrink: '0',
+            boxSizing: 'border-box',
+          },
+        },
+      },
+    ],
+  },
+  metrics: {
+    clicks: 0,
+    impressions: 0,
+  },
+  variations: {},
+  lastUpdated: 1710754517606,
+  firstPublished: 1710745869807,
+  testRatio: 1,
+  createdBy: 'RuGeCLr9ryVt1xRazFYc72uWwIK2',
+  lastUpdatedBy: 'RuGeCLr9ryVt1xRazFYc72uWwIK2',
+  folders: [],
+};

--- a/packages/sdks-tests/src/specs/index.ts
+++ b/packages/sdks-tests/src/specs/index.ts
@@ -166,13 +166,13 @@ export const getProps = async (args: {
   const extraProps =
     pathname === '/can-track-false'
       ? {
-          canTrack: false,
-        }
+        canTrack: false,
+      }
       : pathname.includes('no-trusted-hosts')
-      ? {
+        ? {
           trustedHosts: [],
         }
-      : {};
+        : {};
 
   const extraApiVersionProp =
     apiVersionPathToProp[pathname as keyof typeof apiVersionPathToProp] ?? {};

--- a/packages/sdks-tests/src/specs/index.ts
+++ b/packages/sdks-tests/src/specs/index.ts
@@ -92,7 +92,7 @@ const PAGES = {
   '/animations': ANIMATIONS,
   '/data-preview': DATA_PREVIEW,
   '/form': FORM,
-  '/default-styles': DEFAULT_STYLES
+  '/default-styles': DEFAULT_STYLES,
 } as const;
 
 const apiVersionPathToProp = {

--- a/packages/sdks-tests/src/specs/index.ts
+++ b/packages/sdks-tests/src/specs/index.ts
@@ -166,13 +166,13 @@ export const getProps = async (args: {
   const extraProps =
     pathname === '/can-track-false'
       ? {
-        canTrack: false,
-      }
+          canTrack: false,
+        }
       : pathname.includes('no-trusted-hosts')
-        ? {
+      ? {
           trustedHosts: [],
         }
-        : {};
+      : {};
 
   const extraApiVersionProp =
     apiVersionPathToProp[pathname as keyof typeof apiVersionPathToProp] ?? {};

--- a/packages/sdks-tests/src/specs/index.ts
+++ b/packages/sdks-tests/src/specs/index.ts
@@ -11,6 +11,7 @@ import {
 import { CONTENT as dataBindingStyles } from './data-binding-styles.js';
 import { CONTENT as dataBindings } from './data-bindings.js';
 import { DATA_PREVIEW } from './data-preview.js';
+import { DEFAULT_STYLES } from './default-styles.js';
 import { DUPLICATE_ATTRIBUTES } from './duplicate-attributes.js';
 import { EDITING_STYLES } from './editing-styles.js';
 import { CONTENT as elementEvents } from './element-events.js';
@@ -91,6 +92,7 @@ const PAGES = {
   '/animations': ANIMATIONS,
   '/data-preview': DATA_PREVIEW,
   '/form': FORM,
+  '/default-styles': DEFAULT_STYLES
 } as const;
 
 const apiVersionPathToProp = {

--- a/packages/sdks-tests/src/tests/default-styles.spec.ts
+++ b/packages/sdks-tests/src/tests/default-styles.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { test } from './helpers.js';
+import { EXCLUDE_GEN_1, test } from './helpers.js';
 
 // is a subset - if this selector is there then others would've also been added
 const DEFAULT_STYLES = `.builder-button {
@@ -10,7 +10,11 @@ const DEFAULT_STYLES = `.builder-button {
 test.describe('Default styles', () => {
   test('default styles should be present only once and not inside nested content', async ({
     page,
+    packageName,
   }) => {
+    // dont have .builder-button class
+    test.skip(EXCLUDE_GEN_1);
+    test.fail(packageName === 'react-native');
     await page.goto('/default-styles');
 
     const allStyleTags = await page.evaluate(() => {
@@ -29,7 +33,9 @@ test.describe('Default styles', () => {
     expect(count).toBe(1);
   });
 
-  test('button should have default styles', async ({ page }) => {
+  test('button should have default styles', async ({ page, packageName }) => {
+    test.fail(packageName === 'react-native');
+
     await page.goto('/default-styles');
     const button = page.locator('text=Click me!');
 

--- a/packages/sdks-tests/src/tests/default-styles.spec.ts
+++ b/packages/sdks-tests/src/tests/default-styles.spec.ts
@@ -1,0 +1,54 @@
+import { expect } from '@playwright/test';
+import { test } from './helpers.js';
+
+// is a subset - if this selector is there then others would've also been added
+const DEFAULT_STYLES = `.builder-button {
+  all: unset;
+}
+`;
+
+test.describe('Default styles', () => {
+  test('default styles should be present only once and not inside nested content', async ({
+    page,
+  }) => {
+    await page.goto('/default-styles');
+
+    const allStyleTags = await page.evaluate(() => {
+      const styleElements = Array.from(document.querySelectorAll('style'));
+      return styleElements.map(style => style.textContent);
+    });
+
+    let count = 0;
+
+    for (const style of allStyleTags) {
+      if (style?.includes(DEFAULT_STYLES)) {
+        count++;
+      }
+    }
+
+    expect(count).toBe(1);
+  });
+
+  test('button should have default styles', async ({ page }) => {
+    await page.goto('/default-styles');
+    const button = page.locator('text=Click me!');
+
+    const buttonPaddingTop = await button?.evaluate(
+      element => getComputedStyle(element).paddingTop
+    );
+    const buttonPaddingRight = await button?.evaluate(
+      element => getComputedStyle(element).paddingRight
+    );
+    const buttonPaddingBottom = await button?.evaluate(
+      element => getComputedStyle(element).paddingBottom
+    );
+    const buttonPaddingLeft = await button?.evaluate(
+      element => getComputedStyle(element).paddingLeft
+    );
+
+    expect(buttonPaddingTop).toBe('15px');
+    expect(buttonPaddingRight).toBe('25px');
+    expect(buttonPaddingBottom).toBe('15px');
+    expect(buttonPaddingLeft).toBe('25px');
+  });
+});

--- a/packages/sdks/src/blocks/symbol/symbol.lite.tsx
+++ b/packages/sdks/src/blocks/symbol/symbol.lite.tsx
@@ -100,7 +100,7 @@ export default function Symbol(props: SymbolProps) {
       })}
     >
       <ContentVariants
-        __isNestedRender
+        isNestedRender
         apiVersion={props.builderContext.value.apiVersion}
         apiKey={props.builderContext.value.apiKey!}
         context={{

--- a/packages/sdks/src/components/content-variants/content-variants.lite.tsx
+++ b/packages/sdks/src/components/content-variants/content-variants.lite.tsx
@@ -100,6 +100,7 @@ export default function ContentVariants(props: VariantsProviderProps) {
         <For each={getVariants(props.content)}>
           {(variant) => (
             <ContentComponent
+              __isNestedRender={props.__isNestedRender}
               key={variant.testVariationId}
               content={variant}
               showContent={false}
@@ -124,6 +125,7 @@ export default function ContentVariants(props: VariantsProviderProps) {
         </For>
       </Show>
       <ContentComponent
+        __isNestedRender={props.__isNestedRender}
         {...useTarget({
           vue: { key: state.shouldRenderVariants.toString() },
           default: {},

--- a/packages/sdks/src/components/content-variants/content-variants.lite.tsx
+++ b/packages/sdks/src/components/content-variants/content-variants.lite.tsx
@@ -33,7 +33,7 @@ type VariantsProviderProps = ContentVariantsPrps & {
   /**
    * For internal use only. Do not provide this prop.
    */
-  __isNestedRender?: boolean;
+  isNestedRender?: boolean;
 };
 
 export default function ContentVariants(props: VariantsProviderProps) {
@@ -86,7 +86,7 @@ export default function ContentVariants(props: VariantsProviderProps) {
 
   return (
     <>
-      <Show when={!props.__isNestedRender && TARGET !== 'reactNative'}>
+      <Show when={!props.isNestedRender && TARGET !== 'reactNative'}>
         <InlinedScript scriptStr={getScriptString()} />
       </Show>
       <Show when={state.shouldRenderVariants}>
@@ -100,7 +100,7 @@ export default function ContentVariants(props: VariantsProviderProps) {
         <For each={getVariants(props.content)}>
           {(variant) => (
             <ContentComponent
-              __isNestedRender={props.__isNestedRender}
+              isNestedRender={props.isNestedRender}
               key={variant.testVariationId}
               content={variant}
               showContent={false}
@@ -125,7 +125,7 @@ export default function ContentVariants(props: VariantsProviderProps) {
         </For>
       </Show>
       <ContentComponent
-        __isNestedRender={props.__isNestedRender}
+        isNestedRender={props.isNestedRender}
         {...useTarget({
           vue: { key: state.shouldRenderVariants.toString() },
           default: {},

--- a/packages/sdks/src/components/content/components/enable-editor.lite.tsx
+++ b/packages/sdks/src/components/content/components/enable-editor.lite.tsx
@@ -54,6 +54,7 @@ type BuilderEditorProps = Omit<
   | 'isSsrAbTest'
   | 'blocksWrapper'
   | 'blocksWrapperProps'
+  | '__isNestedRender'
 > & {
   builderContextSignal: Signal<BuilderContextInterface>;
   setBuilderContextSignal?: (signal: any) => any;

--- a/packages/sdks/src/components/content/components/enable-editor.lite.tsx
+++ b/packages/sdks/src/components/content/components/enable-editor.lite.tsx
@@ -54,7 +54,7 @@ type BuilderEditorProps = Omit<
   | 'isSsrAbTest'
   | 'blocksWrapper'
   | 'blocksWrapperProps'
-  | '__isNestedRender'
+  | 'isNestedRender'
 > & {
   builderContextSignal: Signal<BuilderContextInterface>;
   setBuilderContextSignal?: (signal: any) => any;

--- a/packages/sdks/src/components/content/components/styles.helpers.ts
+++ b/packages/sdks/src/components/content/components/styles.helpers.ts
@@ -77,3 +77,26 @@ export const getCss = ({
   // TODO: handle if '&' is within a string like `content: "&"`
   return cssCode?.replace(/&/g, `div[builder-content-id="${contentId}"]`) || '';
 };
+
+const DEFAULT_STYLES = `
+.builder-button {
+  all: unset;
+}
+
+.builder-text > p:first-of-type, .builder-text > .builder-paragraph:first-of-type {
+  margin: 0;
+}
+.builder-text > p, .builder-text > .builder-paragraph {
+  color: inherit;
+  line-height: inherit;
+  letter-spacing: inherit;
+  font-weight: inherit;
+  font-size: inherit;
+  text-align: inherit;
+  font-family: inherit;
+}
+`;
+
+export const getDefaultStyles = (isNested: boolean | undefined) => {
+  return !isNested ? DEFAULT_STYLES : '';
+}

--- a/packages/sdks/src/components/content/components/styles.helpers.ts
+++ b/packages/sdks/src/components/content/components/styles.helpers.ts
@@ -99,4 +99,4 @@ const DEFAULT_STYLES = `
 
 export const getDefaultStyles = (isNested: boolean | undefined) => {
   return !isNested ? DEFAULT_STYLES : '';
-}
+};

--- a/packages/sdks/src/components/content/components/styles.lite.tsx
+++ b/packages/sdks/src/components/content/components/styles.lite.tsx
@@ -3,12 +3,12 @@ import InlinedStyles from '../../inlined-styles.lite.jsx';
 import type { CustomFont } from './styles.helpers.js';
 import { getCss, getDefaultStyles, getFontCss } from './styles.helpers.js';
 
-type Props = {
+interface Props {
   cssCode?: string;
   customFonts?: CustomFont[];
   contentId?: string;
   __isNestedRender?: boolean;
-};
+}
 
 useMetadata({
   rsc: {

--- a/packages/sdks/src/components/content/components/styles.lite.tsx
+++ b/packages/sdks/src/components/content/components/styles.lite.tsx
@@ -1,13 +1,14 @@
 import { useMetadata, useStore } from '@builder.io/mitosis';
 import InlinedStyles from '../../inlined-styles.lite.jsx';
 import type { CustomFont } from './styles.helpers.js';
-import { getCss, getFontCss } from './styles.helpers.js';
+import { getCss, getDefaultStyles, getFontCss } from './styles.helpers.js';
 
-interface Props {
+type Props = {
   cssCode?: string;
   customFonts?: CustomFont[];
   contentId?: string;
-}
+  __isNestedRender?: boolean;
+};
 
 useMetadata({
   rsc: {
@@ -20,23 +21,7 @@ export default function ContentStyles(props: Props) {
     injectedStyles: `
 ${getCss({ cssCode: props.cssCode, contentId: props.contentId })}
 ${getFontCss({ customFonts: props.customFonts })}
-
-.builder-button {
-  all: unset;
-}
-
-.builder-text > p:first-of-type, .builder-text > .builder-paragraph:first-of-type {
-  margin: 0;
-}
-.builder-text > p, .builder-text > .builder-paragraph {
-  color: inherit;
-  line-height: inherit;
-  letter-spacing: inherit;
-  font-weight: inherit;
-  font-size: inherit;
-  text-align: inherit;
-  font-family: inherit;
-}
+${getDefaultStyles(props.__isNestedRender)}
 `.trim(),
   });
 

--- a/packages/sdks/src/components/content/components/styles.lite.tsx
+++ b/packages/sdks/src/components/content/components/styles.lite.tsx
@@ -7,7 +7,7 @@ interface Props {
   cssCode?: string;
   customFonts?: CustomFont[];
   contentId?: string;
-  __isNestedRender?: boolean;
+  isNestedRender?: boolean;
 }
 
 useMetadata({
@@ -21,7 +21,7 @@ export default function ContentStyles(props: Props) {
     injectedStyles: `
 ${getCss({ cssCode: props.cssCode, contentId: props.contentId })}
 ${getFontCss({ customFonts: props.customFonts })}
-${getDefaultStyles(props.__isNestedRender)}
+${getDefaultStyles(props.isNestedRender)}
 `.trim(),
   });
 

--- a/packages/sdks/src/components/content/content.lite.tsx
+++ b/packages/sdks/src/components/content/content.lite.tsx
@@ -152,7 +152,7 @@ export default function ContentComponent(props: ContentProps) {
       </Show>
       <Show when={TARGET !== 'reactNative'}>
         <ContentStyles
-          __isNestedRender={props.__isNestedRender}
+          isNestedRender={props.isNestedRender}
           contentId={builderContextSignal.value.content?.id}
           cssCode={builderContextSignal.value.content?.data?.cssCode}
           customFonts={builderContextSignal.value.content?.data?.customFonts}

--- a/packages/sdks/src/components/content/content.lite.tsx
+++ b/packages/sdks/src/components/content/content.lite.tsx
@@ -152,6 +152,7 @@ export default function ContentComponent(props: ContentProps) {
       </Show>
       <Show when={TARGET !== 'reactNative'}>
         <ContentStyles
+          __isNestedRender={props.__isNestedRender}
           contentId={builderContextSignal.value.content?.id}
           cssCode={builderContextSignal.value.content?.data?.cssCode}
           customFonts={builderContextSignal.value.content?.data?.customFonts}

--- a/packages/sdks/src/components/content/contentProps.types.ts
+++ b/packages/sdks/src/components/content/contentProps.types.ts
@@ -15,5 +15,5 @@ export type ContentProps = InternalRenderProps &
     /**
      * For internal use only. Do not provide this prop.
      */
-    __isNestedRender?: boolean;
+    isNestedRender?: boolean;
   };

--- a/packages/sdks/src/components/content/contentProps.types.ts
+++ b/packages/sdks/src/components/content/contentProps.types.ts
@@ -11,4 +11,9 @@ interface InternalRenderProps {
  * where prop types cannot be wrapped by generics like `EnforcePartials`).
  */
 export type ContentProps = InternalRenderProps &
-  EnforcePartials<ContentVariantsPrps>;
+  EnforcePartials<ContentVariantsPrps> & {
+    /**
+     * For internal use only. Do not provide this prop.
+     */
+    __isNestedRender?: boolean;
+  };


### PR DESCRIPTION
## Description

When we add a symbol it adds another content div with style tag which contains the `.builder-button` class with `unset:all;` this gets higher priority as it comes below the button styles in the html.

**Jira**
https://builder-io.atlassian.net/browse/ENG-5281

**Loom(Issue)**
https://www.loom.com/share/d7240f0ee97b4632b42348c6fb12f39a
