### PR TITLE
add link to BigCommerce readme to doc and remove duplicate info

### DIFF
--- a/plugins/bigcommerce/README.md
+++ b/plugins/bigcommerce/README.md
@@ -1,59 +1,16 @@
-# Builder.io Bigcommerce plugin
+# Builder.io BigCommerce plugin
 
-Easily connect your BigCommerce catalog to your Builder.io content!
-## Installation
+The BigCommerce plugin helps you connect your BigCommerce catalog to your Builder.io content.
 
-Go to [builder.io/account/organization](https://builder.io/account/organization) and type `@builder.io/plugin-bigcommerce` , then hit save, a prompt will ask you for your Store Hash / Access Token.
+## Setting up the plugin for use in Builder
 
-![Installation screenshot](https://cdn.builder.io/api/v1/image/assets%2F6d39f4449e2b4e6792a793bb8c1d9615%2F18a7201313914cccae7f0311a1a614ae)
+For detailed instructions, visit the official documentation, [Setting Up the BigCommerce Plugin](https://www.builder.io/c/docs/plugins-ecom-bigcommerce). 
 
-You will now see three new field types (for [model](https://builder.io/c/docs/guides/getting-started-with-models) fields, [symbol](https://builder.io/c/docs/guides/symbols) inputs, [custom components](https://builder.io/c/docs/custom-react-components) fields), and [custom targeting attributes](https://www.builder.io/c/docs/guides/targeting-and-scheduling#custom-targeting) that can be used in three different contexts:
+## Developing the plugin 
 
-### Custom targeting
+If you're already familiar with the BigCommerce plugin and want to contribute to its development, follow the instructions in this section.
 
-Custom targeting in Builder.io allow users to target content by a multitude of attributes, and in this plugin you'll be able to add specific content to Bigcommerce products, for this you'll need first to set the target attributes on the host site, either by setting the `userAttributes` if you're rendering client side:
-
-```ts
-builder.setUserAttributes({
-  product: currentProduct.id,
-});
-```
-
-Or by passing it as a query param to the [content API](https://www.builder.io/c/docs/query-api#:~:text=userAttributes) call, or in [graqhql query](https://www.builder.io/c/docs/graphql-api#:~:text=with%20targeting) for e.g in Gatsby or nextjs.
-
-- `Bigcommerce Product` when used as a custom targeting type, it'll target contexts where the field is set to the product ID, you'll need to set the product ID on the host environment, using one of the methods above. Alternatively, if you want to target by product handle (slug) use the `Bigcommerce Product Handle` type in your custom targeting attributes.
-
-### Component model fields
-
-Component models can be used to represent product or collection page templates for all or a specific set of products/collections, using one of the following fields, you'll make previewing the templates for any product or collection straight-forward:
-
-- `Bigcommerce Product Preview` is to be used as a custom field on component models, this will allow you to have templated editing url on your component model relevant to the Vtex product being previewed, for example you can set the url in your model to:
-  `https://www.mystore.com/product/${previewProduct.handle}`, add a custom field of type `Bigcommerce Product Preview` to the model, now when you create a new entry, the handle will be added dynamically to the preview url based on the preview product, it is recommended to add a default value to the `Bigcommerce Product Preview` custom field, so users will land at a specific product page when developing a template component.
-
-### Symbol Inputs
-
-Using the field types `Bigcommerce Product` and `Bigcommerce Collection` as inputs, the UIs will prompt to search for products and collections. When consumed by APIs, SDKs, or in the Builder.io UIs, the value will be resolved automatically the in the form of a Builder.io `Request` object
-
-```js
-{
-  "yourFieldName": {
-    "@type": "@builder.io/core:Request",
-    "request": {
-      "url": "..."
-    },
-    "data": {
-      // Response data from the API request, e.g.:
-      "product": {
-        /* ... */
-      }
-    }
-  }
-}
-```
-
-## How to develop?
-
-### Install
+### Installing
 
 ```bash
 git clone https://github.com/BuilderIO/builder.git
@@ -61,13 +18,13 @@ cd plugins/bigcommerce
 npm install
 ```
 
-### Run
+### Running
 
 ```bash
 npm start
 ```
 
-### Add the plugin in Builder.io
+### Adding the plugin in Builder.io
 
 Go to [builder.io/account/organization](https://builder.io/account/organization) and add the localhost URL to the plugin from the plugin settings (`http://localhost:1268/plugin.system.js?pluginId=@builder.io/plugin-bigcommerce`)
 
@@ -75,13 +32,13 @@ Go to [builder.io/account/organization](https://builder.io/account/organization)
 
 <img alt="Load unsafe script example" src="https://i.stack.imgur.com/uSaLL.png">
 
-Now as you develop you can restart Builder to see the latest version of your plugin.
+Now as you develop you can restart Builder to get the latest version of your plugin.
 
-To uninstall your plugin,remove it in the plugins UI
+To uninstall your plugin, remove it in the [Plugins section of Builder](https://builder.io/app/integrations).
 
-### Seeing the plugin in action
+### Using the plugin
 
-Try creating a custom [model](https://builder.io/c/docs/guides/getting-started-with-models), [component](https://builder.io/c/docs/custom-react-components), or [symbol](https://builder.io/c/docs/guides/symbols) using an Bigcommerce field, and edit away!
+Try creating a custom [model](https://builder.io/c/docs/guides/getting-started-with-models), [component](https://builder.io/c/docs/custom-react-components), or [symbol](https://builder.io/c/docs/guides/symbols) using a Bigcommerce field, and edit away!
 
 <img src="https://i.imgur.com/uVOLn7A.gif" alt="Seeing your plugin in the editor example gif">
 


### PR DESCRIPTION
## Description

- Removes content that's already in the [official doc for BigCommerce](https://www.builder.io/c/docs/plugins-ecom-bigcommerce)
- Adds link to doc 
- Moves some of the unique info that was in the readme to the doc. 
- Edits copy for the development instructions. (Leaving it in GitHub as the development of the plugin is appropriate here where the usage is well-suited for the docs.)