### PR TITLE
Support for translation of Symbol's content inputs

### DIFF
--- a/packages/utils/src/translation-helpers.ts
+++ b/packages/utils/src/translation-helpers.ts
@@ -135,7 +135,6 @@ export function applyTranslation(
 
   if (blocks) {
     traverse(blocks).forEach(function (el) {
-      // if (el && el.id && el.component?.name === 'Symbol' && translation[`blocks.${el.id}#text`]) {
       if (el && el.id && el.component?.name === 'Symbol') {
         const symbolInputs = Object.entries(el.component?.options?.symbol?.data) || [];
         if (symbolInputs.length) {

--- a/packages/utils/src/translation-helpers.ts
+++ b/packages/utils/src/translation-helpers.ts
@@ -86,6 +86,26 @@ export function getTranslateableFields(
           instructions: el.meta?.instructions || defaultInstructions,
         };
       }
+
+      if (el && el.id && el.component?.name === 'Symbol') {
+        const symbolInputs = Object.entries(el.component?.options?.symbol?.data) || [];
+        if (symbolInputs.length) {
+          symbolInputs.forEach(
+            ([symbolInputName, symbolInputValue]: [
+              symbolInputName: string,
+              symbolInputValue: any
+            ]) => {
+              results[`blocks.${el.id}.symbolInput#${symbolInputName}`] = {
+                value:
+                  typeof symbolInputValue === 'string'
+                    ? symbolInputValue
+                    : symbolInputValue?.[sourceLocaleId] || symbolInputValue?.Default,
+                instructions: el.meta?.instructions || defaultInstructions,
+              };
+            }
+          );
+        }
+      }
     });
   }
 
@@ -115,6 +135,61 @@ export function applyTranslation(
 
   if (blocks) {
     traverse(blocks).forEach(function (el) {
+      // if (el && el.id && el.component?.name === 'Symbol' && translation[`blocks.${el.id}#text`]) {
+      if (el && el.id && el.component?.name === 'Symbol') {
+        const symbolInputs = Object.entries(el.component?.options?.symbol?.data) || [];
+        if (symbolInputs.length) {
+          symbolInputs.forEach(
+            ([symbolInputName, symbolInputValue]: [
+              symbolInputName: string,
+              symbolInputValue: any
+            ]) => {
+              const translatedSymbolInput =
+                translation[`blocks.${el.id}.symbolInput#${symbolInputName}`];
+
+              if (!translatedSymbolInput?.value) {
+                return;
+              }
+
+              const localizedValues =
+                typeof symbolInputValue === 'string'
+                  ? {
+                      Default: symbolInputValue,
+                    }
+                  : symbolInputValue;
+
+              this.update({
+                ...el,
+                meta: {
+                  ...el.meta,
+                  translated: true,
+                  // this tells the editor that this is a forced localized input similar to clicking the globe icon
+                  [`transformed.symbol.data.${symbolInputName}`]: 'localized',
+                },
+                component: {
+                  ...el.component,
+                  options: {
+                    ...(el.component.options || {}),
+                    symbol: {
+                      ...(el.component.options.symbol || {}),
+                      data: {
+                        ...(el.component.options.symbol?.data || {}),
+
+                        [symbolInputName]: {
+                          '@type': localizedType,
+                          ...localizedValues,
+                          [locale]: unescapeStringOrObject(translatedSymbolInput.value),
+                        },
+                      },
+                    },
+                  },
+                },
+              });
+            }
+          );
+        }
+      }
+
       if (
         el &&
         el.id &&

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -6,7 +6,8 @@
     "target": "es6",
     "esModuleInterop": true,
     "strict": true,
-    "declaration": true
+    "declaration": true,
+    "skipLibCheck": true
   },
   "include": ["./src"],
   "exclude": ["node_modules", "**/*.test.ts"]

--- a/plugins/phrase-conector/README.md
+++ b/plugins/phrase-conector/README.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-From the integrations tab, pick `Phrase`, it'll ask you for your phrase user name and password, make sure the user has a `Project Manager` role.
+From the plugins tab, pick `Phrase`, it'll ask you for your phrase user name and password, make sure the user has a `Project Manager` role.
 ![Phrase connector configuration screen](https://cdn.builder.io/api/v1/image/assets%2F1f098a44b17d4df688d2afdc8a10ac7d%2F92e44f756ac848bca5bdc6d9459d2bfc)
 
 ## Translating content

--- a/plugins/phrase-conector/src/snackbar-utils.tsx
+++ b/plugins/phrase-conector/src/snackbar-utils.tsx
@@ -44,7 +44,7 @@ export function showJobNotification(projectUid: string) {
 
 export function showOutdatedNotifications(callback: () => void) {
   appState.snackBar.show(
-    <div css={{ display: 'flex', alignItems: 'center' }}>Contant has new strings!</div>,
+    <div css={{ display: 'flex', alignItems: 'center' }}>Content has new strings!</div>,
     6000,
     <Button
       color="primary"


### PR DESCRIPTION
## Description

Now symbol's content inputs spec'd in `el.component.options.symbol.data` will also be sent for translations to Phrase and also shall be applied to content when requested.
