### PR TITLE
Allow Phrase plugin users to set if their account is in US data center

### DIFF
--- a/plugins/phrase-conector/src/plugin.tsx
+++ b/plugins/phrase-conector/src/plugin.tsx
@@ -160,7 +160,7 @@ registerPlugin(
             settings.get('callbackHost')
           );
           appState.globalState.hideGlobalBlockingLoading();
-          showJobNotification(project.uid);
+          showJobNotification(project.uid, settings.get('isUSDataCenterAccount'));
         }
       },
     });

--- a/plugins/phrase-conector/src/plugin.tsx
+++ b/plugins/phrase-conector/src/plugin.tsx
@@ -30,6 +30,10 @@ registerPlugin(
         type: 'password',
         required: true,
       },
+      {
+        name: 'isUSDataCenterAccount',
+        type: 'boolean',
+      },
       // allow developer to override callback host , e.g ngrok for local development
       ...(appState.user.isBuilderAdmin
         ? [

--- a/plugins/phrase-conector/src/snackbar-utils.tsx
+++ b/plugins/phrase-conector/src/snackbar-utils.tsx
@@ -15,7 +15,7 @@ import {
   Radio,
 } from '@material-ui/core';
 
-export function showJobNotification(projectUid: string) {
+export function showJobNotification(projectUid: string, isUSDataCenterAccount?: boolean) {
   appState.snackBar.show(
     <div css={{ display: 'flex', alignItems: 'center' }}>Done!</div>,
     2000,
@@ -32,7 +32,9 @@ export function showJobNotification(projectUid: string) {
       }}
       variant="contained"
       onClick={async () => {
-        const link = `https://cloud.memsource.com/web/project2/show/${projectUid}`;
+        const link = `${
+          isUSDataCenterAccount ? 'https://us.cloud.memsource.com' : 'https://cloud.memsource.com'
+        }/web/project2/show/${projectUid}`;
         window.open(link, '_blank');
         appState.snackBar.open = false;
       }}


### PR DESCRIPTION
## Description
Phrase allows users to create accounts in US data center as well and their apis are non-interoperable.

Thus adding a setting for users to choose if their account is in US data center. If false, its assumed it is in European data center (default).

