### PR TITLE
Add a content menu action to allow removing content from smartling translation job

### DIFF
--- a/plugins/smartling/README.md
+++ b/plugins/smartling/README.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-From the integrations tab, pick `smartling`
+From the plugins tab, pick `smartling`
 
 ## Translating content
 What's being translated:

--- a/plugins/smartling/src/plugin.tsx
+++ b/plugins/smartling/src/plugin.tsx
@@ -6,7 +6,11 @@ import pkg from '../package.json';
 import appState from '@builder.io/app-context';
 import uniq from 'lodash/uniq';
 import isEqual from 'lodash/isEqual';
-import { getTranslationModelTemplate, getTranslationModel } from './model-template';
+import {
+  getTranslationModelTemplate,
+  getTranslationModel,
+  translationModelName,
+} from './model-template';
 import {
   registerBulkAction,
   registerContentAction,
@@ -349,6 +353,27 @@ registerPlugin(
         // https://dashboard.smartling.com/app/projects/0e6193784/strings/jobs/schqxtpcnxix
         const smartlingFile = `https://dashboard.smartling.com/app/projects/${translationBatch.projectId}/strings/jobs/${translationBatch.translationJobUid}`;
         window.open(smartlingFile, '_blank', 'noreferrer,noopener');
+      },
+    });
+
+    registerContentAction({
+      label: 'Remove from translation job',
+      showIf(content, model) {
+        const translationModel = getTranslationModel();
+        return model.name !== translationModel.name && Boolean(content.meta.translationJobId);
+      },
+      async onClick(content) {
+        appState.globalState.showGlobalBlockingLoading();
+
+        await api.removeContentFromTranslationJob({
+          contentId: content.id,
+          contentModel: appState.designerState.editingModel.name,
+          translationJobId: content.meta.translationJobId,
+          translationModel: translationModelName,
+        });
+
+        appState.globalState.hideGlobalBlockingLoading();
+        appState.snackBar.show('Removed from translation job.');
       },
     });
 

--- a/plugins/smartling/src/plugin.tsx
+++ b/plugins/smartling/src/plugin.tsx
@@ -360,7 +360,9 @@ registerPlugin(
       label: 'Remove from translation job',
       showIf(content, model) {
         const translationModel = getTranslationModel();
-        return model.name !== translationModel.name && Boolean(content.meta.translationJobId);
+        return (
+          model.name !== translationModel.name && Boolean(content.meta.get('translationJobId'))
+        );
       },
       async onClick(content) {
         appState.globalState.showGlobalBlockingLoading();
@@ -368,7 +370,7 @@ registerPlugin(
         await api.removeContentFromTranslationJob({
           contentId: content.id,
           contentModel: appState.designerState.editingModel.name,
-          translationJobId: content.meta.translationJobId,
+          translationJobId: content.meta.get('translationJobId'),
           translationModel: translationModelName,
         });
 

--- a/plugins/smartling/src/smartling.ts
+++ b/plugins/smartling/src/smartling.ts
@@ -95,6 +95,28 @@ export class SmartlingApi {
     });
   }
 
+  removeContentFromTranslationJob({
+    contentId,
+    contentModel,
+    translationJobId,
+    translationModel,
+  }: {
+    contentId: string;
+    contentModel: string;
+    translationJobId: string;
+    translationModel: string;
+  }) {
+    return this.request('remove-content-from-job', {
+      method: 'POST',
+      body: JSON.stringify({
+        contentId,
+        contentModel,
+        translationJobId,
+        translationModel,
+      }),
+    });
+  }
+
   updateTranslationFile(options: {
     translationJobId: string;
     translationModel: string;


### PR DESCRIPTION
## Description

To remove the content entry **cleanly** from the Smartling's local translation job, added a content menu action for the content that helps in removing job details from content and also removing an entry from the local translation job.

_Screenshot_

![snapshot](https://github.com/BuilderIO/builder/assets/98028693/db97f751-2dfc-4c9c-a140-11c30f876852)
