### PR TITLE
gen2 sdks: export builder context

### DIFF
--- a/.changeset/brave-chicken-cover.md
+++ b/.changeset/brave-chicken-cover.md
@@ -1,0 +1,11 @@
+---
+'@builder.io/sdk-react-nextjs': patch
+'@builder.io/sdk-qwik': patch
+'@builder.io/sdk-react': patch
+'@builder.io/sdk-react-native': patch
+'@builder.io/sdk-solid': patch
+'@builder.io/sdk-svelte': patch
+'@builder.io/sdk-vue': patch
+---
+
+feat: export `BuilderContext` from sdks

--- a/packages/sdks/src/context/index.ts
+++ b/packages/sdks/src/context/index.ts
@@ -1,0 +1,1 @@
+export { default as BuilderContext } from './builder.context.lite.js';

--- a/packages/sdks/src/index-helpers/blocks-exports.ts
+++ b/packages/sdks/src/index-helpers/blocks-exports.ts
@@ -8,3 +8,8 @@ export { default as Text } from '../blocks/text/index.js';
 export { default as Video } from '../blocks/video/index.js';
 export { default as Blocks } from '../components/blocks/index.js';
 export { default as Content } from '../components/content-variants/index.js';
+
+/**
+ * Builder Context
+ */
+export { BuilderContext } from '../context/index.js';

--- a/packages/sdks/src/server-index.ts
+++ b/packages/sdks/src/server-index.ts
@@ -49,8 +49,3 @@ export {
   fetchEntries,
   fetchOneEntry,
 } from './functions/get-content/index.js';
-
-/**
- * Builder Context
- */
-export { BuilderContext } from './context/index.js';

--- a/packages/sdks/src/server-index.ts
+++ b/packages/sdks/src/server-index.ts
@@ -49,3 +49,8 @@ export {
   fetchEntries,
   fetchOneEntry,
 } from './functions/get-content/index.js';
+
+/**
+ * Builder Context
+ */
+export { BuilderContext } from './context/index.js';


### PR DESCRIPTION
## Description

This PR exports `BuilderContext` as a named export in our gen2 sdks.

_Screenshot_
If relevant, add a screenshot or two of the changes you made.

**Jira**
https://builder-io.atlassian.net/browse/ENG-5614

Closes #3044