### PR TITLE
Fix: react SDK isolated vm initialization

### DIFF
--- a/.changeset/curly-dryers-join.md
+++ b/.changeset/curly-dryers-join.md
@@ -1,0 +1,45 @@
+---
+'@builder.io/sdk-react': patch
+---
+
+Feature: add `@builder.io/sdk-react/node/init` entry point with `initializeNodeRuntime` export that sets the IVM instance.
+
+This import should be called in a server-only location, such as:
+
+- The NextJS Pages router's `_document.tsx`:
+
+```tsx
+// _document.tsx
+import { Html, Head, Main, NextScript } from 'next/document';
+import { initializeNodeRuntime } from '@builder.io/sdk-react/node/init';
+initializeNodeRuntime();
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}
+```
+
+- Your Remix route's `loader` responsible for fetching the page content from Builder.io:
+
+```tsx
+// ($slug)._index.tsx
+import { fetchOneEntry } from '@builder.io/sdk-react';
+
+export const loader = async ({ params, request }: LoaderFunctionArgs) => {
+  // the import must be inside the loader itself.
+  const { initializeNodeRuntime } = await import('@builder.io/sdk-react/node/init');
+  await initializeNodeRuntime();
+
+  const page = await fetchOneEntry({
+    /** */
+  });
+};
+```

--- a/.changeset/rare-planes-speak.md
+++ b/.changeset/rare-planes-speak.md
@@ -1,0 +1,11 @@
+---
+'@builder.io/sdk-react': patch
+'@builder.io/sdk-react-nextjs': patch
+'@builder.io/sdk-qwik': patch
+'@builder.io/sdk-react-native': patch
+'@builder.io/sdk-solid': patch
+'@builder.io/sdk-svelte': patch
+'@builder.io/sdk-vue': patch
+---
+
+Fix: `fetchOneEntry` prop types of `fetch` and `fetchOptions`

--- a/packages/sdks/output/react/package.json
+++ b/packages/sdks/output/react/package.json
@@ -79,6 +79,11 @@
         "require": "./lib/browser/index.cjs"
       }
     },
+    "./node/init": {
+      "types": "./types/index.d.ts",
+      "import": "./lib/node/init.mjs",
+      "require": "./lib/node/init.cjs"
+    },
     "./edge": {
       "types": "./types/index.d.ts",
       "import": "./lib/edge/edge-entry.mjs",

--- a/packages/sdks/output/react/package.json
+++ b/packages/sdks/output/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@builder.io/sdk-react",
   "description": "Builder.io SDK for React",
-  "version": "1.0.19",
+  "version": "1.0.19-dev-2",
   "homepage": "https://github.com/BuilderIO/builder/tree/main/packages/sdks/output/react",
   "type": "module",
   "repository": {
@@ -80,7 +80,7 @@
       }
     },
     "./node/init": {
-      "types": "./types/index.d.ts",
+      "types": "./types/functions/evaluate/node-runtime/init.d.ts",
       "import": "./lib/node/init.mjs",
       "require": "./lib/node/init.cjs"
     },

--- a/packages/sdks/output/react/vite.config.ts
+++ b/packages/sdks/output/react/vite.config.ts
@@ -217,13 +217,20 @@ export default defineConfig({
         index: './src/index.ts',
         [SERVER_ENTRY]: './src/server-index.ts',
         [BLOCKS_EXPORTS_ENTRY]: './src/index-helpers/blocks-exports.ts',
+        init: './src/functions/evaluate/node-runtime/init.ts',
       },
       formats: ['es', 'cjs'],
       fileName: (format, entryName) =>
         `${entryName}.${format === 'es' ? 'mjs' : 'cjs'}`,
     },
     rollupOptions: {
-      external: ['react', 'react/jsx-runtime', 'react-dom', 'node:module'],
+      external: [
+        'react',
+        'react/jsx-runtime',
+        'react-dom',
+        'node:module',
+        'isolated-vm',
+      ],
       output: {
         globals: {
           react: 'react',

--- a/packages/sdks/src/functions/evaluate/node-runtime/init.ts
+++ b/packages/sdks/src/functions/evaluate/node-runtime/init.ts
@@ -22,6 +22,6 @@ import { setIvm } from './node-runtime.js';
  * - The NextJS Pages router's `_document.tsx`
  * - Your Remix route's `loader`
  */
-export const initializeNodeRuntime = async () => {
+export const initializeNodeRuntime = () => {
   setIvm(ivm);
 };

--- a/packages/sdks/src/functions/evaluate/node-runtime/init.ts
+++ b/packages/sdks/src/functions/evaluate/node-runtime/init.ts
@@ -10,6 +10,7 @@
  * The `isolated-vm` import must exist in this separate file, or it will end up
  * in the SDK's main entry point, causing errors for users.
  */
+import ivm from 'isolated-vm';
 import { setIvm } from './node-runtime.js';
 
 /**
@@ -22,7 +23,5 @@ import { setIvm } from './node-runtime.js';
  * - Your Remix route's `loader`
  */
 export const initializeNodeRuntime = async () => {
-  const ivm = await import('isolated-vm');
-
   setIvm(ivm);
 };

--- a/packages/sdks/src/functions/evaluate/node-runtime/init.ts
+++ b/packages/sdks/src/functions/evaluate/node-runtime/init.ts
@@ -10,9 +10,19 @@
  * The `isolated-vm` import must exist in this separate file, or it will end up
  * in the SDK's main entry point, causing errors for users.
  */
-import ivm from 'isolated-vm';
 import { setIvm } from './node-runtime.js';
 
-export const initializeNodeRuntime = () => {
+/**
+ * This function initializes the SDK on a Node server. It handles importing the
+ * `isolated-vm` package which is needed for dynamic bindings.
+ *
+ * NOTE: this function cannot be called on the client. You must call this function
+ * from a server-only location, such as:
+ * - The NextJS Pages router's `_document.tsx`
+ * - Your Remix route's `loader`
+ */
+export const initializeNodeRuntime = async () => {
+  const ivm = await import('isolated-vm');
+
   setIvm(ivm);
 };

--- a/packages/sdks/src/functions/evaluate/node-runtime/init.ts
+++ b/packages/sdks/src/functions/evaluate/node-runtime/init.ts
@@ -1,0 +1,18 @@
+/**
+ * This file:
+ * - imports `isolated-vm`, which can only be made from a file that never runs
+ * on the client (e.g. Next's `_document.tsx`)
+ * - stores the ivm instance in a global variable using `setIvm`
+ *
+ * This is needed for when bundlers/meta-frameworks are not able to reliably
+ * import the `isolated-vm` package using our `safeDynamicRequire` trick.
+ *
+ * The `isolated-vm` import must exist in this separate file, or it will end up
+ * in the SDK's main entry point, causing errors for users.
+ */
+import ivm from 'isolated-vm';
+import { setIvm } from './node-runtime.js';
+
+export const initializeNodeRuntime = () => {
+  setIvm(ivm);
+};

--- a/packages/sdks/src/functions/evaluate/node-runtime/node-runtime.ts
+++ b/packages/sdks/src/functions/evaluate/node-runtime/node-runtime.ts
@@ -85,7 +85,14 @@ export const setIvm = (ivm: typeof import('isolated-vm')) => {
 
 const getIvm = (): typeof import('isolated-vm') => {
   if (IVM_INSTANCE) return IVM_INSTANCE;
-  return safeDynamicRequire('isolated-vm');
+  const dynRequiredIvm = safeDynamicRequire('isolated-vm');
+
+  if (!dynRequiredIvm) {
+    // TO-DO: cleanup this error. link to docs.
+    throw new Error('isolated-vm is not available');
+  }
+
+  return dynRequiredIvm;
 };
 
 const getIsolateContext = () => {

--- a/packages/sdks/src/functions/evaluate/node-runtime/node-runtime.ts
+++ b/packages/sdks/src/functions/evaluate/node-runtime/node-runtime.ts
@@ -1,3 +1,4 @@
+import { MSG_PREFIX } from '../../../helpers/logger.js';
 import { fastClone } from '../../fast-clone.js';
 import { set } from '../../set.js';
 import type {
@@ -88,8 +89,16 @@ const getIvm = (): typeof import('isolated-vm') => {
   const dynRequiredIvm = safeDynamicRequire('isolated-vm');
 
   if (!dynRequiredIvm) {
-    // TO-DO: cleanup this error. link to docs.
-    throw new Error('isolated-vm is not available');
+    throw new Error(
+      `${MSG_PREFIX}could not import \`isolated-vm\` module for safe script execution on Node server.
+      
+      In certain Node environments, the SDK requires additional initialization steps. This can be achieved by 
+      importing and calling \`initializeNodeRuntime()\` from "@builder.io/sdk-react/node/init". This must be done in
+      a server-only execution path within your application.
+
+      Please see the documentation for more information: https://www.builder.io/c/docs/node-isolated-vm-initialization
+      `
+    );
   }
 
   return dynRequiredIvm;

--- a/packages/sdks/src/functions/evaluate/node-runtime/node-runtime.ts
+++ b/packages/sdks/src/functions/evaluate/node-runtime/node-runtime.ts
@@ -71,12 +71,25 @@ if (typeof output === 'object' && output !== null) {
 output;
 `;
 };
+
+let IVM_INSTANCE: typeof import('isolated-vm') | null = null;
+
+/**
+ * Set the `isolated-vm` instance to be used by the node runtime.
+ * This is useful for environments that are not able to rely on our
+ * `safeDynamicRequire` trick to import the `isolated-vm` package.
+ */
+export const setIvm = (ivm: typeof import('isolated-vm')) => {
+  IVM_INSTANCE = ivm;
+};
+
+const getIvm = (): typeof import('isolated-vm') => {
+  if (IVM_INSTANCE) return IVM_INSTANCE;
+  return safeDynamicRequire('isolated-vm');
+};
+
 const getIsolateContext = () => {
-  // if (Builder.serverContext) {
-  //   return Builder.serverContext;
-  // }
-  // Builder.setServerContext(isolate.createContextSync());
-  const ivm: typeof import('isolated-vm') = safeDynamicRequire('isolated-vm');
+  const ivm = getIvm();
   const isolate = new ivm.Isolate({
     memoryLimit: 128,
   });
@@ -91,7 +104,7 @@ export const runInNode = ({
   rootSetState,
   rootState,
 }: ExecutorArgs) => {
-  const ivm: typeof import('isolated-vm') = safeDynamicRequire('isolated-vm');
+  const ivm = getIvm();
 
   const state = fastClone({
     ...rootState,

--- a/packages/sdks/src/functions/get-content/types.ts
+++ b/packages/sdks/src/functions/get-content/types.ts
@@ -144,10 +144,10 @@ export interface GetContentOptions {
   /**
    * Optional override of the `fetch` function. (Defaults to global `fetch`)
    */
-  fetch?: typeof global.fetch;
+  fetch?: (input: string, init?: object) => Promise<any>;
 
   /**
-   * Optional fetch options to be passed to the `fetch` function.
+   * Optional fetch options to be passed as the second argument to the `fetch` function.
    */
-  fetchOptions?: RequestInit;
+  fetchOptions?: object;
 }

--- a/packages/sdks/src/helpers/logger.ts
+++ b/packages/sdks/src/helpers/logger.ts
@@ -1,4 +1,4 @@
-const MSG_PREFIX = '[Builder.io]: ';
+export const MSG_PREFIX = '[Builder.io]: ';
 export const logger = {
   log: (...message: any[]) => console.log(MSG_PREFIX, ...message),
   error: (...message: any[]) => console.error(MSG_PREFIX, ...message),


### PR DESCRIPTION
## Description

- add `@builder.io/sdk-react/node/init` entry point with `initializeNodeRuntime` export that sets the IVM instance