### PR TITLE
SDKs: add registerComponent and linkComponent for RSC blocks

### DIFF
--- a/.changeset/thick-birds-raise.md
+++ b/.changeset/thick-birds-raise.md
@@ -1,0 +1,12 @@
+---
+'@builder.io/react': patch
+'@builder.io/sdk-react-nextjs': patch
+'@builder.io/sdk-qwik': patch
+'@builder.io/sdk-react': patch
+'@builder.io/sdk-react-native': patch
+'@builder.io/sdk-solid': patch
+'@builder.io/sdk-svelte': patch
+'@builder.io/sdk-vue': patch
+---
+
+Feature: added `builderLinkComponent` and `builderComponents` props to RSC blocks.

--- a/.changeset/thick-birds-raise.md
+++ b/.changeset/thick-birds-raise.md
@@ -1,12 +1,5 @@
 ---
-'@builder.io/react': patch
 '@builder.io/sdk-react-nextjs': patch
-'@builder.io/sdk-qwik': patch
-'@builder.io/sdk-react': patch
-'@builder.io/sdk-react-native': patch
-'@builder.io/sdk-solid': patch
-'@builder.io/sdk-svelte': patch
-'@builder.io/sdk-vue': patch
 ---
 
 Feature: added `builderLinkComponent` and `builderComponents` props to RSC blocks.

--- a/packages/sdks/src/components/block/block.helpers.ts
+++ b/packages/sdks/src/components/block/block.helpers.ts
@@ -116,7 +116,9 @@ export const shouldPassLinkComponent = (
   return (
     block &&
     (block.isRSC ||
-      ['Symbol', 'Columns', 'Form:Form', 'Builder: Tabs'].includes(block.name))
+    ['Core:Button', 'Symbol', 'Columns', 'Form:Form', 'Builder: Tabs'].includes(
+      block.name
+    )
   );
 };
 

--- a/packages/sdks/src/components/block/block.helpers.ts
+++ b/packages/sdks/src/components/block/block.helpers.ts
@@ -116,9 +116,13 @@ export const shouldPassLinkComponent = (
   return (
     block &&
     (block.isRSC ||
-    ['Core:Button', 'Symbol', 'Columns', 'Form:Form', 'Builder: Tabs'].includes(
-      block.name
-    )
+      [
+        'Core:Button',
+        'Symbol',
+        'Columns',
+        'Form:Form',
+        'Builder: Tabs',
+      ].includes(block.name))
   );
 };
 

--- a/packages/sdks/src/components/block/block.helpers.ts
+++ b/packages/sdks/src/components/block/block.helpers.ts
@@ -1,5 +1,6 @@
 import type {
   BuilderContextInterface,
+  RegisteredComponent,
   RegisteredComponents,
 } from '../../context/types.js';
 import { evaluate } from '../../functions/evaluate/index.js';
@@ -109,20 +110,22 @@ export const getInheritedStyles = ({
   return extractTextStyles(style);
 };
 
-export const shouldPassLinkComponent = (blockName: string | undefined) => {
+export const shouldPassLinkComponent = (
+  block: RegisteredComponent | null | undefined
+) => {
   return (
-    blockName &&
-    ['Core:Button', 'Symbol', 'Columns', 'Form:Form', 'Builder: Tabs'].includes(
-      blockName
-    )
+    block &&
+    (block.isRSC ||
+      ['Symbol', 'Columns', 'Form:Form', 'Builder: Tabs'].includes(block.name))
   );
 };
 
 export const shouldPassRegisteredComponents = (
-  blockName: string | undefined
+  block: RegisteredComponent | null | undefined
 ) => {
   return (
-    blockName &&
-    ['Symbol', 'Columns', 'Form:Form', 'Builder: Tabs'].includes(blockName)
+    block &&
+    (block.isRSC ||
+      ['Symbol', 'Columns', 'Form:Form', 'Builder: Tabs'].includes(block.name))
   );
 };

--- a/packages/sdks/src/components/block/block.lite.tsx
+++ b/packages/sdks/src/components/block/block.lite.tsx
@@ -143,10 +143,10 @@ export default function Block(props: BlockProps) {
         componentOptions: {
           ...getBlockComponentOptions(state.processedBlock),
           builderContext: props.context,
-          ...(shouldPassLinkComponent(state.blockComponent?.name)
+          ...(shouldPassLinkComponent(state.blockComponent)
             ? { builderLinkComponent: props.linkComponent }
             : {}),
-          ...(shouldPassRegisteredComponents(state.blockComponent?.name)
+          ...(shouldPassRegisteredComponents(state.blockComponent)
             ? { builderComponents: props.registeredComponents }
             : {}),
         },


### PR DESCRIPTION
## Description

RSC components does not have the ability to retrieve the `builderLinkComponent` and the `builderComponents`. So they are not able to render children.

```tsx
async function MyCustomRSComponent(props) {
  return (
        <Blocks
          blocks={props.blocks}
          path={`component.options.enabled`}
          registeredComponents={props.builderComponents} // <- Not available
          parent={props.builderBlock.id}
          context={props.builderContext}
          linkComponent={props.builderLinkComponent} // <- Not available
        />
  );
}
```

This pull request adds `builderComponents` and `builderLinkComponent` to the `Block` `componentRef.componentOptions`.