### PR TITLE
SDKs: optional `initializeNodeRuntime` argument

### DIFF
--- a/.changeset/lovely-snails-own.md
+++ b/.changeset/lovely-snails-own.md
@@ -1,0 +1,11 @@
+---
+'@builder.io/sdk-react-nextjs': patch
+'@builder.io/sdk-qwik': patch
+'@builder.io/sdk-react': patch
+'@builder.io/sdk-react-native': patch
+'@builder.io/sdk-solid': patch
+'@builder.io/sdk-svelte': patch
+'@builder.io/sdk-vue': patch
+---
+
+Fix: make `initializeNodeRuntime` argument optional

--- a/packages/sdks/src/functions/evaluate/node-runtime/init.ts
+++ b/packages/sdks/src/functions/evaluate/node-runtime/init.ts
@@ -24,10 +24,9 @@ import type { IsolateOptions } from 'isolated-vm';
  * - The NextJS Pages router's `_document.tsx`
  * - Your Remix route's `loader`
  */
-export const initializeNodeRuntime = ({
-  ivmIsolateOptions,
-}: {
+export const initializeNodeRuntime = (args?: {
   ivmIsolateOptions?: IsolateOptions;
 }) => {
+  const { ivmIsolateOptions } = args || {};
   setIvm(ivm, ivmIsolateOptions);
 };


### PR DESCRIPTION
## Description

- make `initializeNodeRuntime` argument optional