### PR TITLE
docs: fix builder-settings link

### DIFF
--- a/examples/react-design-system/README.md
+++ b/examples/react-design-system/README.md
@@ -40,7 +40,7 @@ From the `examples/react-design-system` folder
 builder create -k [private-key] -n [space-name] -d
 ```
 
-This command when done it'll print your new space's public api key, copy it and add as the value for `YOUR_KEY` in [builder-settings](./src/builder-settings.s)
+This command when done it'll print your new space's public api key, copy it and add as the value for `YOUR_KEY` in [builder-settings](./src/builder-settings.js)
 
 ```
 YOUR_KEY=...


### PR DESCRIPTION
The link was missing its `.js` extension.