### PR TITLE
docs: add info on how to install builder CLI

### DIFF
--- a/examples/react-design-system/README.md
+++ b/examples/react-design-system/README.md
@@ -28,6 +28,12 @@ cd examples/react-design-system
 npm install
 ```
 
+### Install the Builder CLI
+
+```
+npm install @builder.io/cli -g
+```
+
 ### Generate your Builder.io space
 
 <!-- TODO: link "private key" to a forum post or doc showing how to create that -->


### PR DESCRIPTION
The readme file mentions running a `builder` CLI command. However, it does not mention how to install the CLI.