### PR TITLE
chore: ignore e2e angular packages in changeset config to fix publish script

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -21,6 +21,8 @@
     "@e2e/gen1-next",
     "@e2e/gen1-remix",
     "@e2e/gen1-react",
-    "@builder.io/sdk-angular"
+    "@builder.io/sdk-angular",
+    "@e2e/angular",
+    "@e2e/angular-ssr"
   ]
 }


### PR DESCRIPTION
## Description

Ignore e2e angular packages in changeset config to fix publish script.

Ref: https://github.com/BuilderIO/builder/actions/runs/8988128196/job/24688256731

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
