### PR TITLE
[SUPP-451] fix form submissions for qwik sdk

### DIFF
--- a/.changeset/kind-rabbits-fry.md
+++ b/.changeset/kind-rabbits-fry.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/sdk-qwik": patch
+---
+
+Fix: qwik sdk form event submissions

--- a/packages/sdks/src/blocks/form/form/form.lite.tsx
+++ b/packages/sdks/src/blocks/form/form/form.lite.tsx
@@ -90,7 +90,7 @@ export default function FormComponent(props: FormProps) {
         }
         event.preventDefault();
 
-        const el = event.currentTarget;
+        const el = event.currentTarget || event.target;
         const headers = props.customHeaders || {};
 
         let body: any;
@@ -101,9 +101,7 @@ export default function FormComponent(props: FormProps) {
         const formPairs: {
           key: string;
           value: File | boolean | number | string | FileList;
-        }[] = Array.from(
-          event.currentTarget.querySelectorAll('input,select,textarea')
-        )
+        }[] = Array.from(el.querySelectorAll('input,select,textarea'))
           .filter((el) => !!(el as HTMLInputElement).name)
           .map((el) => {
             let value: any;
@@ -301,6 +299,12 @@ export default function FormComponent(props: FormProps) {
       method={props.method}
       name={props.name}
       onSubmit={(event) => state.onSubmit(event)}
+      {...useTarget({
+        qwik: {
+          'preventdefault:submit': true,
+        },
+        default: {},
+      })}
       {...useTarget({
         vue: filterAttrs(props.attributes, 'v-on:', false),
         svelte: filterAttrs(props.attributes, 'on:', false),


### PR DESCRIPTION
## Description

`event.currentTarget` is always null for qwik, instead we get the content from `event.target` so added a fallback for that. We also need `preventdefault:submit` so that the form content doesn't refresh

**Jira**
https://builder-io.atlassian.net/browse/SUPP-451

_Screenshot_
![Screenshot 2024-06-13 at 11 28 44 AM](https://github.com/BuilderIO/builder/assets/73601258/b4c3fc03-06b0-425c-8b17-c52c99667864)
![Screenshot 2024-06-13 at 11 29 05 AM](https://github.com/BuilderIO/builder/assets/73601258/e45fd3a3-465d-4738-aaa2-ddecbe7add6b)

