### PR TITLE
Disabled add-to-translation menuitem when there are unsaved content changes

### DIFF
--- a/plugins/smartling/package-lock.json
+++ b/plugins/smartling/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@builder.io/commerce-plugin-tools": "^0.3.0",
-        "@builder.io/utils": "^1.1.15",
+        "@builder.io/utils": "^1.1.21",
         "fast-json-stable-stringify": "^2.1.0",
         "lodash": "^4.17.21",
         "object-hash": "^3.0.0",
@@ -1540,9 +1540,9 @@
       }
     },
     "node_modules/@builder.io/utils": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/@builder.io/utils/-/utils-1.1.20.tgz",
-      "integrity": "sha512-7HzWPLc7zY8e6y6/WD2X0HgOtB4xjVlY2/GRElPgKe47pdmqDzH16VBGc6O9M47OMglDAagErlUE1QfvroLFWg==",
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/@builder.io/utils/-/utils-1.1.21.tgz",
+      "integrity": "sha512-fqDKSWsm5qMvhkRFSZr9Y4zpdn8fL4t4OOW+PWhNLCLcOZ9Qa2SYVs0dvB6NSd80tya63G4X5mh3rLzN9wT8Wg==",
       "dependencies": {
         "@types/lodash": "^4.14.182",
         "lodash": "^4.17.21",
@@ -23375,9 +23375,9 @@
       }
     },
     "@builder.io/utils": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/@builder.io/utils/-/utils-1.1.20.tgz",
-      "integrity": "sha512-7HzWPLc7zY8e6y6/WD2X0HgOtB4xjVlY2/GRElPgKe47pdmqDzH16VBGc6O9M47OMglDAagErlUE1QfvroLFWg==",
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/@builder.io/utils/-/utils-1.1.21.tgz",
+      "integrity": "sha512-fqDKSWsm5qMvhkRFSZr9Y4zpdn8fL4t4OOW+PWhNLCLcOZ9Qa2SYVs0dvB6NSd80tya63G4X5mh3rLzN9wT8Wg==",
       "requires": {
         "@types/lodash": "^4.14.182",
         "lodash": "^4.17.21",

--- a/plugins/smartling/src/plugin-helpers.ts
+++ b/plugins/smartling/src/plugin-helpers.ts
@@ -19,6 +19,8 @@ export type ContentAction = {
   label: string;
   showIf(content: any, model: any): Boolean;
   onClick(content: any): Promise<void>;
+  isDisabled?: () => boolean;
+  disabledTooltip?: string;
 };
 
 export function registerContentAction(contentAction: ContentAction) {

--- a/plugins/smartling/src/plugin.tsx
+++ b/plugins/smartling/src/plugin.tsx
@@ -280,6 +280,10 @@ registerPlugin(
         });
         showJobNotification(translationJobId);
       },
+      isDisabled() {
+        return appState.designerState.hasUnsavedChanges();
+      },
+      disabledTooltip: 'Please publish your changes to add to translation job',
     });
     registerContentAction({
       label: 'Request an updated translation',


### PR DESCRIPTION
## Description
Disabled add-to-translation menuitem when there are unsaved content changes

_Screenshot_
<img width="598" alt="image" src="https://github.com/BuilderIO/builder/assets/98028693/bca32857-4b4d-4bd6-922b-b70eb8c6c492">
