### PR TITLE
fix: check `e.origin` of the message to be a URL first

### DIFF
--- a/.changeset/friendly-grapes-build.md
+++ b/.changeset/friendly-grapes-build.md
@@ -1,0 +1,12 @@
+---
+"@builder.io/sdk-angular": patch
+"@builder.io/sdk-react-nextjs": patch
+"@builder.io/sdk-qwik": patch
+"@builder.io/sdk-react": patch
+"@builder.io/sdk-react-native": patch
+"@builder.io/sdk-solid": patch
+"@builder.io/sdk-svelte": patch
+"@builder.io/sdk-vue": patch
+---
+
+Fix: check `e.origin` of the message to be a URL first

--- a/packages/sdks/src/functions/is-from-trusted-host.test.ts
+++ b/packages/sdks/src/functions/is-from-trusted-host.test.ts
@@ -43,4 +43,8 @@ describe('isFromTrustedHost', () => {
       isFromTrustedHost(['example.com'], { origin: 'https://example.com' })
     ).toBe(true);
   });
+
+  test('when origin is not a URL', () => {
+    expect(isFromTrustedHost(undefined, { origin: 'foo' })).toBe(false);
+  });
 });

--- a/packages/sdks/src/functions/is-from-trusted-host.ts
+++ b/packages/sdks/src/functions/is-from-trusted-host.ts
@@ -10,7 +10,7 @@ export function isFromTrustedHost(
   trustedHosts: string[] | undefined,
   e: { origin: string }
 ): boolean {
-  if (!e.origin.includes('http') && !e.origin.includes('https')) {
+  if (!e.origin.startsWith('http') && !e.origin.startsWith('https')) {
     return false;
   }
   const url = new URL(e.origin),

--- a/packages/sdks/src/functions/is-from-trusted-host.ts
+++ b/packages/sdks/src/functions/is-from-trusted-host.ts
@@ -10,7 +10,7 @@ export function isFromTrustedHost(
   trustedHosts: string[] | undefined,
   e: { origin: string }
 ): boolean {
-  if (!e.origin.includes('http') || !e.origin.includes('https')) {
+  if (!e.origin.includes('http') && !e.origin.includes('https')) {
     return false;
   }
   const url = new URL(e.origin),

--- a/packages/sdks/src/functions/is-from-trusted-host.ts
+++ b/packages/sdks/src/functions/is-from-trusted-host.ts
@@ -10,6 +10,9 @@ export function isFromTrustedHost(
   trustedHosts: string[] | undefined,
   e: { origin: string }
 ): boolean {
+  if (!e.origin.includes('http') || !e.origin.includes('https')) {
+    return false;
+  }
   const url = new URL(e.origin),
     hostname = url.hostname;
 


### PR DESCRIPTION
## Description

URL cannot parse `e.origin` with any values other than the URL protocol so it breaks and gives error in the console. This happened with one of our customers on "Windows" machine -- isn't reproducible in macOS

_Screenshot_
![IMG20240701184837](https://github.com/BuilderIO/builder/assets/73601258/771bed74-f7d6-4cc4-9cc8-63bc9dff12a1)
![builder io](https://github.com/BuilderIO/builder/assets/73601258/d85476f2-e0da-483a-ab70-27774ffeb456)

