### PR TITLE
Added config for disabling Smartling plugin auto-authorization

### DIFF
--- a/plugins/smartling/src/plugin.tsx
+++ b/plugins/smartling/src/plugin.tsx
@@ -109,8 +109,7 @@ registerPlugin(
             return;
           }
 
-          const translationModel = getTranslationModel();
-          updatePublishCTA(appState.designerState.editingContentModel, translationModel);
+          updatePublishCTA(appState.designerState.editingContentModel, getTranslationModel());
 
           const translationStatus = appState.designerState.editingContentModel.meta.get(
             'translationStatus'
@@ -151,7 +150,7 @@ registerPlugin(
                 appState.globalState.showGlobalBlockingLoading('Contacting Smartling ....');
                 await api.updateTranslationFile({
                   translationJobId: lastPublishedContent.meta.translationJobId,
-                  translationModel: translationModel.name,
+                  translationModel: translationModelName,
                   contentId: lastPublishedContent.id,
                   contentModel: appState.designerState.editingModel.name,
                   preview: lastPublishedContent.meta.lastPreviewUrl,

--- a/plugins/smartling/src/plugin.tsx
+++ b/plugins/smartling/src/plugin.tsx
@@ -50,6 +50,14 @@ registerPlugin(
         type: 'string',
         required: true,
       },
+      {
+        name: 'enableJobAutoAuthorization',
+        friendlyName: 'Authorize Smartling Jobs through Builder',
+        type: 'boolean',
+        defaultValue: true,
+        helperText: 'Allows users to authorize Smartling jobs directly from Builder',
+        requiredPermissions: ['admin'],
+      },
     ],
     onSave: async actions => {
       const pluginPrivateKey = await appState.globalState.getPluginPrivateKey(pkg.name);
@@ -73,10 +81,12 @@ registerPlugin(
           if (!shoudlCheck) {
             return;
           }
-          const translationStatus =
-            appState.designerState.editingContentModel.meta.get('translationStatus');
-          const translationRequested =
-            appState.designerState.editingContentModel.meta.get('translationRequested');
+          const translationStatus = appState.designerState.editingContentModel.meta.get(
+            'translationStatus'
+          );
+          const translationRequested = appState.designerState.editingContentModel.meta.get(
+            'translationRequested'
+          );
 
           // check if there's pending translation
           const isFresh =


### PR DESCRIPTION
## Description
Added config (for admins only) - "Authorize Smartling Jobs through Builder" - to disable auto-authorization of Smartling translation jobs. Its enabled by default.

_Screenshot_
<img width="972" alt="image" src="https://github.com/BuilderIO/builder/assets/98028693/3da5aa21-e0d2-4bd0-994a-7c0b7e42a4eb">
