### PR TITLE
ENG-6057 Add 'translationBy' field in content meta to track the plugin generating the translation

### DIFF
--- a/plugins/smartling/src/plugin.tsx
+++ b/plugins/smartling/src/plugin.tsx
@@ -318,6 +318,7 @@ registerPlugin(
             ...fastClone(content.meta),
             translationStatus: 'local',
             translationJobId,
+            translationBy: pkg.name,
           },
         });
         showJobNotification(translationJobId);


### PR DESCRIPTION
## Description

Added 'translationBy' field in content meta to track the plugin generating the translation

_Screenshot_
<img width="644" alt="image" src="https://github.com/BuilderIO/builder/assets/98028693/b76a19dc-2311-44d0-a6cb-f7b176a3c9af">

