### PR TITLE
[Plugin][Utils][Smartling][Phrase] ENG-5718 Skip 'children' property for symbol inputs which contaings component defs

### DIFF
--- a/packages/utils/src/__snapshots__/translation-helpers.test.ts.snap
+++ b/packages/utils/src/__snapshots__/translation-helpers.test.ts.snap
@@ -121,6 +121,103 @@ Object {
           "translated": true,
         },
       },
+      Object {
+        "@type": "@builder.io/sdk:Element",
+        "@version": 2,
+        "component": Object {
+          "name": "Symbol",
+          "options": Object {
+            "symbol": Object {
+              "data": Object {
+                "children": Array [
+                  Object {
+                    "@type": "@builder.io/sdk:Element",
+                    "@version": 2,
+                    "children": Array [
+                      Object {
+                        "@type": "@builder.io/sdk:Element",
+                        "@version": 2,
+                        "component": Object {
+                          "name": "Typography",
+                          "options": Object {
+                            "children": Object {
+                              "@type": "@builder.io/core:LocalizedValue",
+                              "Default": "2. Properly configuring your gamepad",
+                              "de": "2. german Properly configuring your gamepad",
+                              "fr": "Gardez vos fichiers privés et en sécurité grâce à Shadow Drive, notre solution de stockage dans le cloud conçue et hébergée en Europe.<br><strong> C'est désormais le drive sécurisé le moins cher du marché.",
+                              "fr-FR": "2. french Properly configuring your gamepad",
+                            },
+                            "color": "black",
+                            "component": "p",
+                            "htmlTag": "h2",
+                            "variant": "heading-h4",
+                            "variantMobile": "heading-h5",
+                            "variantTablet": "body-md",
+                          },
+                        },
+                        "id": "builder-5f0b30f48b5a47a7ababc6526b65a17e",
+                        "layerName": "Intertitre",
+                        "meta": Object {
+                          "localizedTextInputs": Array [
+                            "children",
+                          ],
+                          "previousId": "builder-5f7863a185524c40ba854534de6c5d7f",
+                          "transformed.children": "localized",
+                          "translated": true,
+                        },
+                        "responsiveStyles": Object {
+                          "large": Object {
+                            "display": "inline",
+                          },
+                        },
+                      },
+                      Object {
+                        "@type": "@builder.io/sdk:Element",
+                        "@version": 2,
+                        "component": Object {
+                          "name": "Typography",
+                          "options": Object {
+                            "children": Object {
+                              "@type": "@builder.io/core:LocalizedValue",
+                              "Default": "3. Optimizing connectivity",
+                              "de": "3. german Optimizing connectivity",
+                              "fr": "Gardez vos fichiers privés et en sécurité grâce à Shadow Drive, notre solution de stockage dans le cloud conçue et hébergée en Europe.<br><strong> C'est désormais le drive sécurisé le moins cher du marché.",
+                              "fr-FR": "3. french Optimizing connectivity",
+                            },
+                            "color": "black",
+                            "component": "p",
+                            "variant": "heading-h4",
+                            "variantMobile": "heading-h5",
+                            "variantTablet": "body-md",
+                          },
+                        },
+                        "id": "builder-5ce42f734ffa429b8c5612cb2e340bd7",
+                        "layerName": "Intertitre",
+                        "meta": Object {
+                          "localizedTextInputs": Array [
+                            "children",
+                          ],
+                          "previousId": "builder-5f0b30f48b5a47a7ababc6526b65a17e",
+                          "transformed.children": "localized",
+                          "translated": true,
+                        },
+                      },
+                    ],
+                    "id": "builder-1fae3855fc1c441683f52c18d46e2601",
+                  },
+                ],
+              },
+              "entry": "6a013dc290a548eb8e968c848ae5d5a2",
+              "model": "symbol",
+              "ownerId": "cfadfce0f3684576b7a6cca6599ce3be",
+            },
+          },
+        },
+        "id": "builder-5128283319b1740b3aa8279c09c1dc957",
+        "meta": Object {
+          "translated": true,
+        },
+      },
     ],
     "seo": Object {
       "@type": "@builder.io/core:LocalizedValue",
@@ -192,6 +289,14 @@ Object {
   "blocks.builder-068283319b1740b3aa8279c09c1dc957.symbolInput#heroContent.cta.otherLabels[1].women": Object {
     "instructions": "Visit https://builder.io/fiddle/... for more details",
     "value": "label for US women",
+  },
+  "blocks.builder-5ce42f734ffa429b8c5612cb2e340bd7#children": Object {
+    "instructions": "Visit https://builder.io/fiddle/... for more details",
+    "value": "3. Optimizing connectivity",
+  },
+  "blocks.builder-5f0b30f48b5a47a7ababc6526b65a17e#children": Object {
+    "instructions": "Visit https://builder.io/fiddle/... for more details",
+    "value": "2. Properly configuring your gamepad",
   },
   "blocks.builder-custom-component-id#heading": Object {
     "instructions": "Visit https://builder.io/fiddle/... for more details",

--- a/packages/utils/src/translation-helpers.test.ts
+++ b/packages/utils/src/translation-helpers.test.ts
@@ -131,6 +131,93 @@ test('getTranslateableFields from content to match snapshot', async () => {
             },
           },
         },
+
+        {
+          '@type': '@builder.io/sdk:Element',
+          '@version': 2,
+          id: 'builder-5128283319b1740b3aa8279c09c1dc957',
+          component: {
+            name: 'Symbol',
+            options: {
+              symbol: {
+                entry: '6a013dc290a548eb8e968c848ae5d5a2',
+                model: 'symbol',
+                ownerId: 'cfadfce0f3684576b7a6cca6599ce3be',
+                data: {
+                  children: [
+                    {
+                      '@type': '@builder.io/sdk:Element',
+                      '@version': 2,
+                      id: 'builder-1fae3855fc1c441683f52c18d46e2601',
+                      children: [
+                        {
+                          '@type': '@builder.io/sdk:Element',
+                          '@version': 2,
+                          layerName: 'Intertitre',
+                          id: 'builder-5f0b30f48b5a47a7ababc6526b65a17e',
+                          meta: {
+                            localizedTextInputs: ['children'],
+                            previousId: 'builder-5f7863a185524c40ba854534de6c5d7f',
+                            'transformed.children': 'localized',
+                          },
+                          component: {
+                            name: 'Typography',
+                            options: {
+                              component: 'p',
+                              color: 'black',
+                              variant: 'heading-h4',
+                              variantTablet: 'body-md',
+                              variantMobile: 'heading-h5',
+                              children: {
+                                '@type': '@builder.io/core:LocalizedValue',
+                                Default: '2. Properly configuring your gamepad',
+                                fr: "Gardez vos fichiers privés et en sécurité grâce à Shadow Drive, notre solution de stockage dans le cloud conçue et hébergée en Europe.<br><strong> C'est désormais le drive sécurisé le moins cher du marché.",
+                                de: 'Halte deine Dateien privat und sicher dank Shadow Drive, unserer in Europa hergestellten und gehosteten Cloud-Speicherlösung. <b>Jetzt die preiswerteste datenschutzorientierte Speicherlösung  auf dem Markt.</b>',
+                              },
+                              htmlTag: 'h2',
+                            },
+                          },
+                          responsiveStyles: {
+                            large: {
+                              display: 'inline',
+                            },
+                          },
+                        },
+                        {
+                          '@type': '@builder.io/sdk:Element',
+                          '@version': 2,
+                          layerName: 'Intertitre',
+                          id: 'builder-5ce42f734ffa429b8c5612cb2e340bd7',
+                          meta: {
+                            localizedTextInputs: ['children'],
+                            previousId: 'builder-5f0b30f48b5a47a7ababc6526b65a17e',
+                            'transformed.children': 'localized',
+                          },
+                          component: {
+                            name: 'Typography',
+                            options: {
+                              component: 'p',
+                              color: 'black',
+                              variant: 'heading-h4',
+                              variantTablet: 'body-md',
+                              variantMobile: 'heading-h5',
+                              children: {
+                                '@type': '@builder.io/core:LocalizedValue',
+                                Default: '3. Optimizing connectivity',
+                                fr: "Gardez vos fichiers privés et en sécurité grâce à Shadow Drive, notre solution de stockage dans le cloud conçue et hébergée en Europe.<br><strong> C'est désormais le drive sécurisé le moins cher du marché.",
+                                de: 'Halte deine Dateien privat und sicher dank Shadow Drive, unserer in Europa hergestellten und gehosteten Cloud-Speicherlösung. <b>Jetzt die preiswerteste datenschutzorientierte Speicherlösung  auf dem Markt.</b>',
+                              },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
       ],
     },
   };
@@ -271,6 +358,93 @@ test('applyTranslation from content to match snapshot', async () => {
             },
           },
         },
+
+        {
+          '@type': '@builder.io/sdk:Element',
+          '@version': 2,
+          id: 'builder-5128283319b1740b3aa8279c09c1dc957',
+          component: {
+            name: 'Symbol',
+            options: {
+              symbol: {
+                entry: '6a013dc290a548eb8e968c848ae5d5a2',
+                model: 'symbol',
+                ownerId: 'cfadfce0f3684576b7a6cca6599ce3be',
+                data: {
+                  children: [
+                    {
+                      '@type': '@builder.io/sdk:Element',
+                      '@version': 2,
+                      id: 'builder-1fae3855fc1c441683f52c18d46e2601',
+                      children: [
+                        {
+                          '@type': '@builder.io/sdk:Element',
+                          '@version': 2,
+                          layerName: 'Intertitre',
+                          id: 'builder-5f0b30f48b5a47a7ababc6526b65a17e',
+                          meta: {
+                            localizedTextInputs: ['children'],
+                            previousId: 'builder-5f7863a185524c40ba854534de6c5d7f',
+                            'transformed.children': 'localized',
+                          },
+                          component: {
+                            name: 'Typography',
+                            options: {
+                              component: 'p',
+                              color: 'black',
+                              variant: 'heading-h4',
+                              variantTablet: 'body-md',
+                              variantMobile: 'heading-h5',
+                              children: {
+                                '@type': '@builder.io/core:LocalizedValue',
+                                Default: '2. Properly configuring your gamepad',
+                                fr: "Gardez vos fichiers privés et en sécurité grâce à Shadow Drive, notre solution de stockage dans le cloud conçue et hébergée en Europe.<br><strong> C'est désormais le drive sécurisé le moins cher du marché.",
+                                de: 'Halte deine Dateien privat und sicher dank Shadow Drive, unserer in Europa hergestellten und gehosteten Cloud-Speicherlösung. <b>Jetzt die preiswerteste datenschutzorientierte Speicherlösung  auf dem Markt.</b>',
+                              },
+                              htmlTag: 'h2',
+                            },
+                          },
+                          responsiveStyles: {
+                            large: {
+                              display: 'inline',
+                            },
+                          },
+                        },
+                        {
+                          '@type': '@builder.io/sdk:Element',
+                          '@version': 2,
+                          layerName: 'Intertitre',
+                          id: 'builder-5ce42f734ffa429b8c5612cb2e340bd7',
+                          meta: {
+                            localizedTextInputs: ['children'],
+                            previousId: 'builder-5f0b30f48b5a47a7ababc6526b65a17e',
+                            'transformed.children': 'localized',
+                          },
+                          component: {
+                            name: 'Typography',
+                            options: {
+                              component: 'p',
+                              color: 'black',
+                              variant: 'heading-h4',
+                              variantTablet: 'body-md',
+                              variantMobile: 'heading-h5',
+                              children: {
+                                '@type': '@builder.io/core:LocalizedValue',
+                                Default: '3. Optimizing connectivity',
+                                fr: "Gardez vos fichiers privés et en sécurité grâce à Shadow Drive, notre solution de stockage dans le cloud conçue et hébergée en Europe.<br><strong> C'est désormais le drive sécurisé le moins cher du marché.",
+                                de: 'Halte deine Dateien privat und sicher dank Shadow Drive, unserer in Europa hergestellten und gehosteten Cloud-Speicherlösung. <b>Jetzt die preiswerteste datenschutzorientierte Speicherlösung  auf dem Markt.</b>',
+                              },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
       ],
     },
   };
@@ -304,6 +478,12 @@ test('applyTranslation from content to match snapshot', async () => {
       {
         value: 'french label for women',
       },
+    'blocks.builder-5ce42f734ffa429b8c5612cb2e340bd7#children': {
+      value: '3. french Optimizing connectivity',
+    },
+    'blocks.builder-5f0b30f48b5a47a7ababc6526b65a17e#children': {
+      value: '2. french Properly configuring your gamepad',
+    },
   };
   const germanTranslations = {
     'metadata.title': { value: 'hallo' },
@@ -334,6 +514,12 @@ test('applyTranslation from content to match snapshot', async () => {
       {
         value: 'german label for women',
       },
+    'blocks.builder-5ce42f734ffa429b8c5612cb2e340bd7#children': {
+      value: '3. german Optimizing connectivity',
+    },
+    'blocks.builder-5f0b30f48b5a47a7ababc6526b65a17e#children': {
+      value: '2. german Properly configuring your gamepad',
+    },
   };
 
   let result = applyTranslation(content, frenchTranslations, 'fr-FR');

--- a/packages/utils/src/translation-helpers.ts
+++ b/packages/utils/src/translation-helpers.ts
@@ -199,6 +199,10 @@ export function getTranslateableFields(
               symbolInputName: string,
               symbolInputValue: any
             ]) => {
+              if (symbolInputName === 'children') {
+                return;
+              }
+
               recordValue({
                 results,
                 value: symbolInputValue,


### PR DESCRIPTION
## Description
Skip `data.children` in symbol, when resolving complex symbol inputs which may contain component defs (that may come to render when 'useChildren' symbol prop is set) in 'data.children'. This is to skip double translations and avoid unpredictable results.

For the translations required in component defs of `data.children`, let the regular `traverse` cycle handle it.

_Screenshot_
<img width="577" alt="image" src="https://github.com/BuilderIO/builder/assets/98028693/0ec7f23b-ba1f-4427-9981-d332e3846012">

<img width="602" alt="image" src="https://github.com/BuilderIO/builder/assets/98028693/0e07416f-9890-4ede-931a-dc284f12385a">

