### PR TITLE
Fix: handling stringified numbers in `userAttributes` in gen1 sdk

### DIFF
--- a/.changeset/healthy-planes-study.md
+++ b/.changeset/healthy-planes-study.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/sdk": patch
+---
+
+Fix: handle parsing of stringified numeric values in `userAttributes`

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -2426,7 +2426,7 @@ export class Builder {
     }
     // TODO: merge in the attribute from query string ones
     // TODO: make this an option per component/request
-    queryParams.userAttributes = userAttributes;
+    queryParams.userAttributes = JSON.stringify(userAttributes);
 
     if (!usePastQueue && !useQueue) {
       this.priorContentQueue = queue;


### PR DESCRIPTION
## Description

Passes `userAttributes` as an object rather than flattening out each attribute which breaks as when we encode URI we miss out if we should keep the numeric value as string or number (in the backend it gets sent as a string only but we would need to mention explicitly that it's a string -> `'1'` we can send as `'"1"'`.

Reference:
in gen2: https://github.com/BuilderIO/builder/blob/main/packages/sdks/src/functions/get-content/generate-content-url.ts#L96

**Jira**
https://builder-io.atlassian.net/browse/ENG-5988

Loom
https://www.loom.com/share/7b803d231039401188d3759d8076ceed
