### PR TITLE
Utils: version update after release of v1.1.22

### DIFF
--- a/packages/utils/package-lock.json
+++ b/packages/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/utils",
-  "version": "1.1.21",
+  "version": "1.1.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/utils",
-      "version": "1.1.21",
+      "version": "1.1.22",
       "dependencies": {
         "@types/lodash": "^4.14.182",
         "lodash": "^4.17.21",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/utils",
-  "version": "1.1.21",
+  "version": "1.1.22",
   "description": "Utils for working with Builder.io content",
   "main": "./dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Description
Version update after release of v1.1.22. Releases a fix for translation to ignore symbol's `data.children` property when processing content for translation.