### PR TITLE
remove iframely api key

### DIFF
--- a/.changeset/yellow-drinks-knock.md
+++ b/.changeset/yellow-drinks-knock.md
@@ -1,0 +1,13 @@
+---
+"@builder.io/sdk-react-nextjs" patch
+"@builder.io/sdk-react" patch
+"@builder.io/react" patch
+"@builder.io/sdk-angular" patch
+"@builder.io/sdk-qwik" patch
+"@builder.io/sdk-react-native" patch
+"@builder.io/sdk-solid" patch
+"@builder.io/sdk-svelte" patch
+"@builder.io/sdk-vue" patch
+---
+
+Fix: Remove `iframely` API key from Embed block logic.

--- a/packages/react/src/blocks/Embed.tsx
+++ b/packages/react/src/blocks/Embed.tsx
@@ -3,6 +3,9 @@ import React from 'react';
 import { Builder } from '@builder.io/sdk';
 import { withBuilder } from '../functions/with-builder';
 
+// Provided by the web app as a local variable in onChange functions
+declare const _iframelyApiKey: string;
+
 class EmbedComponent extends React.Component<any> {
   elementRef: HTMLElement | null = null;
 
@@ -84,7 +87,7 @@ export const Embed = withBuilder(EmbedComponent, {
         if (url) {
           options.set('content', 'Loading...');
           // TODO: get this out of here!
-          const apiKey = 'ae0e60e78201a3f2b0de4b';
+          const apiKey = _iframelyApiKey;
           return fetch(`https://iframe.ly/api/iframely?url=${url}&api_key=${apiKey}`)
             .then(res => res.json())
             .then(data => {

--- a/packages/sdks/src/blocks/embed/component-info.ts
+++ b/packages/sdks/src/blocks/embed/component-info.ts
@@ -1,5 +1,8 @@
 import type { ComponentInfo } from '../../types/components.js';
 
+// Provided by the web app as a local variable in onChange functions
+declare const _iframelyApiKey: string;
+
 export const componentInfo: ComponentInfo = {
   name: 'Embed',
   static: true,
@@ -15,8 +18,8 @@ export const componentInfo: ComponentInfo = {
         const url = options.get('url');
         if (url) {
           options.set('content', 'Loading...');
-          // TODO: get this out of here!
-          const apiKey = 'ae0e60e78201a3f2b0de4b';
+          
+          const apiKey = _iframelyApiKey;
           return fetch(
             `https://iframe.ly/api/iframely?url=${url}&api_key=${apiKey}`
           )

--- a/packages/sdks/src/blocks/embed/component-info.ts
+++ b/packages/sdks/src/blocks/embed/component-info.ts
@@ -18,7 +18,7 @@ export const componentInfo: ComponentInfo = {
         const url = options.get('url');
         if (url) {
           options.set('content', 'Loading...');
-          
+
           const apiKey = _iframelyApiKey;
           return fetch(
             `https://iframe.ly/api/iframely?url=${url}&api_key=${apiKey}`


### PR DESCRIPTION
the key already has restrictions on what domains it can be called from (us), but better hygeine to remove entirely as it has shown up in a bounty program of a customer

relates to: https://github.com/BuilderIO/builder-internal/pull/6505