### PR TITLE
remove srcset for svg images

### DIFF
--- a/.changeset/polite-pets-smell.md
+++ b/.changeset/polite-pets-smell.md
@@ -1,0 +1,6 @@
+---
+"@builder.io/packages": patch
+"@builder.io/sdks": patch
+---
+
+remove srcset for svg images

--- a/.changeset/polite-pets-smell.md
+++ b/.changeset/polite-pets-smell.md
@@ -10,4 +10,4 @@
 '@builder.io/sdk-vue': patch
 ---
 
-Fix: remove srcset for svg images
+Fix: Image block: remove redundant `srcset` for SVG images

--- a/.changeset/polite-pets-smell.md
+++ b/.changeset/polite-pets-smell.md
@@ -1,4 +1,5 @@
 ---
+'@builder.io/react': patch
 '@builder.io/sdk-angular': patch
 '@builder.io/sdk-react-nextjs': patch
 '@builder.io/sdk-qwik': patch

--- a/.changeset/polite-pets-smell.md
+++ b/.changeset/polite-pets-smell.md
@@ -1,6 +1,12 @@
 ---
-"@builder.io/packages": patch
-"@builder.io/sdks": patch
+'@builder.io/sdk-angular': patch
+'@builder.io/sdk-react-nextjs': patch
+'@builder.io/sdk-qwik': patch
+'@builder.io/sdk-react': patch
+'@builder.io/sdk-react-native': patch
+'@builder.io/sdk-solid': patch
+'@builder.io/sdk-svelte': patch
+'@builder.io/sdk-vue': patch
 ---
 
-remove srcset for svg images
+Fix: remove srcset for svg images

--- a/packages/react/src/blocks/Image.tsx
+++ b/packages/react/src/blocks/Image.tsx
@@ -266,6 +266,10 @@ class ImageComponent extends React.Component<any, { imageLoaded: boolean; load: 
       return;
     }
 
+    if (this.props.noWebp) {
+      return;
+    }
+
     // We can auto add srcset for cdn.builder.io and shopify
     // images, otherwise you can supply this prop manually
     if (!(url.match(/builder\.io/) || url.match(/cdn\.shopify\.com/))) {

--- a/packages/sdks-tests/src/mocks/sample-svg.svg
+++ b/packages/sdks-tests/src/mocks/sample-svg.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 12H17M8 8.5C8 8.5 9 9 10 9C11.5 9 12.5 8 14 8C15 8 16 8.5 16 8.5M8 15.5C8 15.5 9 16 10 16C11.5 16 12.5 15 14 15C15 15 16 15.5 16 15.5M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/sdks-tests/src/specs/image.ts
+++ b/packages/sdks-tests/src/specs/image.ts
@@ -401,3 +401,80 @@ export const CONTENT_2 = {
   published: 'published',
   rev: 'n1iwryhh5oh',
 };
+
+export const CONTENT_3 = {
+  ownerId: 'ad30f9a246614faaa6a03374f83554c9',
+  lastUpdateBy: null,
+  createdDate: 1722330740468,
+  id: '45455accd3fd46a3b0fb0183c885cf65',
+  '@version': 4,
+  name: 'svg',
+  modelId: '17c6065109ef4062ba083f5741f4ee6a',
+  published: 'draft',
+  meta: {
+    kind: 'page',
+    hasLinks: false,
+    lastPreviewUrl:
+      'http://localhost:5173/svg?builder.space=ad30f9a246614faaa6a03374f83554c9&builder.user.permissions=read%2Ccreate%2Cpublish%2CeditCode%2CeditDesigns%2Cadmin%2CeditLayouts%2CeditLayers&builder.user.role.name=Admin&builder.user.role.id=admin&builder.cachebust=true&builder.preview=page&builder.noCache=true&builder.allowTextEdit=true&__builder_editing__=true&builder.overrides.page=45455accd3fd46a3b0fb0183c885cf65&builder.overrides.45455accd3fd46a3b0fb0183c885cf65=45455accd3fd46a3b0fb0183c885cf65&builder.overrides.page:/svg=45455accd3fd46a3b0fb0183c885cf65&builder.options.locale=Default',
+  },
+  priority: -586,
+  query: [
+    {
+      '@type': '@builder.io/core:Query',
+      property: 'urlPath',
+      operator: 'is',
+      value: '/svg',
+    },
+  ],
+  data: {
+    themeId: false,
+    title: 'svg',
+    blocks: [
+      {
+        '@type': '@builder.io/sdk:Element',
+        '@version': 2,
+        id: 'builder-bc55bbdd71ca4214af445b26bebc489f',
+        component: {
+          name: 'Image',
+          options: {
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+            lazy: false,
+            fitContent: true,
+            aspectRatio: 1,
+            lockAspectRatio: false,
+            height: 800,
+            width: 800,
+            image:
+              'https://cdn.builder.io/api/v1/image/assets%2Fad30f9a246614faaa6a03374f83554c9%2Fac77a1342acb4a8f9ed907379339ba68',
+            noWebp: true,
+          },
+        },
+        responsiveStyles: {
+          large: {
+            display: 'flex',
+            flexDirection: 'column',
+            position: 'relative',
+            flexShrink: '0',
+            boxSizing: 'border-box',
+            marginTop: '20px',
+            width: '100%',
+            minHeight: '20px',
+            minWidth: '20px',
+            overflow: 'hidden',
+          },
+        },
+      },
+    ],
+  },
+  metrics: {
+    clicks: 0,
+    impressions: 0,
+  },
+  variations: {},
+  lastUpdated: 1722331044384,
+  testRatio: 1,
+  createdBy: 'RuGeCLr9ryVt1xRazFYc72uWwIK2',
+  lastUpdatedBy: 'RuGeCLr9ryVt1xRazFYc72uWwIK2',
+  folders: [],
+};

--- a/packages/sdks-tests/src/specs/index.ts
+++ b/packages/sdks-tests/src/specs/index.ts
@@ -21,7 +21,11 @@ import { FORM } from './form.js';
 import { CONTENT as homepage } from './homepage.js';
 import { HOVER_ANIMATION } from './hover-animation.js';
 import { HTTP_REQUESTS } from './http-requests.js';
-import { CONTENT as image, CONTENT_2 as imageHighPriority } from './image.js';
+import {
+  CONTENT as image,
+  CONTENT_2 as imageHighPriority,
+  CONTENT_3 as imageNoWebp,
+} from './image.js';
 import { INPUT_DEFAULT_VALUE } from './input-default-value.js';
 import { JS_CODE_CONTENT } from './js-code.js';
 import { JS_CONTENT_IS_BROWSER } from './js-content-is-browser.js';
@@ -73,6 +77,7 @@ const PAGES = {
   '/content-bindings': contentBindings,
   '/image': image,
   '/image-high-priority': imageHighPriority,
+  '/image-no-webp': imageNoWebp,
   '/data-bindings': dataBindings,
   '/data-binding-styles': dataBindingStyles,
   '/ab-test': abTest,

--- a/packages/sdks/src/blocks/image/image.lite.tsx
+++ b/packages/sdks/src/blocks/image/image.lite.tsx
@@ -23,6 +23,10 @@ export default function Image(props: ImageProps) {
         return props.srcset;
       }
 
+      if (props.noWebp) {
+        return undefined; // no need to add srcset to svg images
+      }
+
       if (props.srcset && props.image?.includes('builder.io/api/v1/image')) {
         if (!props.srcset.includes(props.image.split('?')[0])) {
           console.debug('Removed given srcset');


### PR DESCRIPTION
## Description

It sounds like we are wasting a lot of time trying to add src set for svg images even though they are not going to use them :) I wonder if this simple change can help out in that case

before|after
-|-
<img width="961" alt="image" src="https://github.com/user-attachments/assets/30e8baa4-ed22-4eb9-9a44-ef1309e91c01">|<img width="1060" alt="image" src="https://github.com/user-attachments/assets/63855ea7-ec7f-485b-a2fa-3a32ae719efe">

