### PR TITLE
do not use raw url in srcset

### DIFF
--- a/packages/sdks/src/blocks/image/image.helpers.ts
+++ b/packages/sdks/src/blocks/image/image.helpers.ts
@@ -58,7 +58,7 @@ export function getSrcSet(url: string): string {
     return sizes
       .filter((size) => size !== widthInSrc)
       .map((size) => `${updateQueryParam(url, 'width', size)} ${size}w`)
-      .concat([srcUrl])
+      .concat([`${srcUrl} 9999w`])
       .join(', ');
   }
 


### PR DESCRIPTION
## Description

Sorry for the fly by PR :) I think I'm probably brigning this up more like a discussion than a proper PR. I've beein looking into image performance issues with builder content and the thing that I noticed is that you are putting raw url in the `srcset` without adding `1x` or `1w` attributes. Those images are showing up in the `Properly size images Potential savings of xxx KiB` report of lighthouse (especially on the desktop). I think the proper solution according to all the standards and docs is to use intrinsic size of the image, so let's say I have an image of 1234px then proper srcset would be `... 100w ... 200w ... 400w ... 800w ... 1200w ... 1234w` (drops 1600 and 2000), but that information is not awailable in the current Image props, so I'm proposing `... 100w ... 200w ... 400w ... 800w ... 1200w ... 1600w ... 2000w ... 9999w` which I think is the best you can do in the current circumstances. The main point is that browser will basically ignroe the src set that doesn't have that last `...w` directive, and the result is that you are sending tons of html with all those srcsets just for browser to ignore it :)
