### PR TITLE
fix: repeat items angular sdk and some other fixes

### DIFF
--- a/packages/sdks/mitosis.config.cjs
+++ b/packages/sdks/mitosis.config.cjs
@@ -576,13 +576,17 @@ const ANGULAR_WRAP_SYMBOLS_FETCH_AROUND_CHANGES_DEPS = () => ({
 });
 
 const ANGULAR_FIX_REPEAT_ITEMS_PLUGIN = () => ({
-  code: {
-    post: (code) => {
-      if (code.includes('repeated-block, RepeatedBlock')) {
-        code = code.replace('store = this.repeatContext;', '');
-        code = code.replace('[context]="store"', '[context]="repeatContext"');
+  json: {
+    pre: (json) => {
+      if (json.name === 'RepeatedBlock') {
+        const ctxCode = json.state['store'].code;
+        if (json.children[0].name === 'Block') {
+          json.children[0].bindings['context'].code = ctxCode;
+          delete json.state['store'];
+        } else {
+          throw new Error('RepeatedBlock should have a Block child');
+        }
       }
-      return code;
     },
   },
 });

--- a/packages/sdks/mitosis.config.cjs
+++ b/packages/sdks/mitosis.config.cjs
@@ -575,6 +575,18 @@ const ANGULAR_WRAP_SYMBOLS_FETCH_AROUND_CHANGES_DEPS = () => ({
   },
 });
 
+const ANGULAR_FIX_REPEAT_ITEMS_PLUGIN = () => ({
+  code: {
+    post: (code) => {
+      if (code.includes('repeated-block, RepeatedBlock')) {
+        code = code.replace('store = this.repeatContext;', '');
+        code = code.replace('[context]="store"', '[context]="repeatContext"');
+      }
+      return code;
+    },
+  },
+});
+
 /**
  * @type {MitosisConfig}
  */
@@ -601,6 +613,7 @@ module.exports = {
         ANGULAR_BLOCKS_WRAPPER_MERGED_INPUT_REACTIVITY_PLUGIN,
         ANGULAR_FIX_AB_TESTS_INITIALIZATION,
         ANGULAR_WRAP_SYMBOLS_FETCH_AROUND_CHANGES_DEPS,
+        ANGULAR_FIX_REPEAT_ITEMS_PLUGIN,
       ],
     },
     solid: {

--- a/packages/sdks/src/blocks/columns/columns.lite.tsx
+++ b/packages/sdks/src/blocks/columns/columns.lite.tsx
@@ -1,5 +1,6 @@
 import {
   For,
+  onInit,
   Show,
   useMetadata,
   useStore,
@@ -204,6 +205,23 @@ export default function Columns(props: ColumnProps) {
         style: mapStyleObjToStrIfNeeded(state.columnCssVars(index)),
       };
     },
+  });
+
+  onInit(() => {
+    useTarget({
+      angular: () => {
+        state.flexDir =
+          props.stackColumnsAt === 'never'
+            ? 'row'
+            : props.reverseColumnsWhenStacked
+              ? 'column-reverse'
+              : 'column';
+        state.gutterSize =
+          typeof props.space === 'number' ? props.space || 0 : 20;
+        state.cols = props.columns || [];
+        state.stackAt = props.stackColumnsAt || 'tablet';
+      },
+    });
   });
 
   return (

--- a/packages/sdks/src/blocks/symbol/symbol.lite.tsx
+++ b/packages/sdks/src/blocks/symbol/symbol.lite.tsx
@@ -1,4 +1,5 @@
 import {
+  onInit,
   onMount,
   onUpdate,
   useMetadata,
@@ -88,15 +89,20 @@ export default function Symbol(props: SymbolProps) {
     state.setContent();
   }, [props.symbol]);
 
+  onInit(() => {
+    useTarget({
+      angular: () => {
+        state.contentToUse = props.symbol?.content;
+      },
+    });
+  });
+
   onMount(() => {
     useTarget({
       react: () => {},
       reactNative: () => {},
       solid: () => {},
-      angular: () => {
-        state.contentToUse = props.symbol?.content;
-      },
-
+      angular: () => {},
       default: () => {
         state.setContent();
       },


### PR DESCRIPTION
## Description

Fixes repeat items in angular SDK and columns state initialization

the generated content in `RepeatBlock` had this computed state which came out `undefined` always. We are now binding the `repeatContext` directly to make it reactive

```
store = this.repeatContext;
```

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
