### PR TITLE
cleanup `angular-ssr` snippets and comments

### DIFF
--- a/packages/sdks-tests/src/e2e-tests/hydration.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/hydration.spec.ts
@@ -23,7 +23,7 @@ test.describe('Hydration', () => {
   });
 
   test('No mismatch on A/B test content', async ({ page, packageName }) => {
-    test.fail(packageName === 'angular-ssr');
+    test.skip(packageName === 'angular-ssr', 'Angular SSR does not support A/B tests');
     test.fail(
       packageName === 'nextjs-sdk-next-app',
       "NextJS SDK currently does not support SSR'd A/B tests. Losing variants are stripped from SSR'd Content too late."

--- a/packages/sdks/e2e/angular/src/app/app.component.ts
+++ b/packages/sdks/e2e/angular/src/app/app.component.ts
@@ -1,6 +1,4 @@
-// fails because type imports cannot be injected
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-import { ChangeDetectorRef, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import {
   _processContentResult,
   fetchOneEntry,
@@ -54,8 +52,6 @@ export class AppComponent {
     },
   ];
 
-  constructor(private cdr: ChangeDetectorRef) {}
-
   async ngOnInit() {
     const urlPath = window.location.pathname || '';
 
@@ -78,7 +74,5 @@ export class AppComponent {
     this.apiKey = builderProps.apiKey;
     this.model = builderProps.model;
     this.apiVersion = builderProps.apiVersion;
-
-    this.cdr.detectChanges();
   }
 }

--- a/packages/sdks/mitosis.config.cjs
+++ b/packages/sdks/mitosis.config.cjs
@@ -261,7 +261,7 @@ const ANGULAR_BLOCKS_WRAPPER_MERGED_INPUT_REACTIVITY_PLUGIN = () => ({
     post: (code) => {
       if (code?.includes('blocks-wrapper, BlocksWrapper')) {
         const mergedInputsCode = code.match(/this.mergedInputs_.* = \{.*\};/s);
-        code = code.replace('ngOnInit', 'ngAfterContentInit');
+        code = code.replace('ngOnInit', 'ngAfterViewInit');
         code = code.replace(
           /}\n\s*$/,
           `

--- a/packages/sdks/mitosis.config.cjs
+++ b/packages/sdks/mitosis.config.cjs
@@ -261,7 +261,7 @@ const ANGULAR_BLOCKS_WRAPPER_MERGED_INPUT_REACTIVITY_PLUGIN = () => ({
     post: (code) => {
       if (code?.includes('blocks-wrapper, BlocksWrapper')) {
         const mergedInputsCode = code.match(/this.mergedInputs_.* = \{.*\};/s);
-        code = code.replace('ngOnInit', 'ngAfterViewInit');
+        code = code.replace('ngOnInit', 'ngAfterContentInit');
         code = code.replace(
           /}\n\s*$/,
           `

--- a/packages/sdks/snippets/angular-ssr/.eslintrc.js
+++ b/packages/sdks/snippets/angular-ssr/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    '@typescript-eslint/consistent-type-imports': 'off',
+  },
+};

--- a/packages/sdks/snippets/angular-ssr/src/app/announcement-bar/announcement-bar.component.ts
+++ b/packages/sdks/snippets/angular-ssr/src/app/announcement-bar/announcement-bar.component.ts
@@ -4,22 +4,9 @@
  * src/app/announcement-bar/announcement-bar.component.ts
  */
 
-import { isPlatformServer } from '@angular/common';
-// fails because type imports cannot be injected
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-import {
-  ChangeDetectorRef,
-  Component,
-  Inject,
-  Optional,
-  PLATFORM_ID,
-} from '@angular/core';
-import {
-  fetchOneEntry,
-  getBuilderSearchParams,
-  type BuilderContent,
-} from '@builder.io/sdk-angular';
-import { REQUEST } from '@nguniversal/express-engine/tokens';
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { type BuilderContent } from '@builder.io/sdk-angular';
 
 @Component({
   selector: 'app-announcement-bar',
@@ -45,29 +32,11 @@ export class AnnouncementBarComponent {
   model = 'announcement-bar';
   content: BuilderContent | null = null;
 
-  constructor(
-    private cdr: ChangeDetectorRef,
-    @Inject(PLATFORM_ID) private platformId: any,
-    @Optional() @Inject(REQUEST) private req: any
-  ) {
-    const urlPath = isPlatformServer(this.platformId)
-      ? this.req.path || ''
-      : window.location.pathname;
-    const searchParams = isPlatformServer(this.platformId)
-      ? new URLSearchParams(this.req.url.split('?')[1])
-      : new URLSearchParams(window.location.search);
+  constructor(private activatedRoute: ActivatedRoute) {}
 
-    fetchOneEntry({
-      apiKey: this.apiKey,
-      model: this.model,
-      userAttributes: { urlPath },
-      options: getBuilderSearchParams(searchParams),
-    }).then((content) => {
-      this.content = content;
+  ngOnInit() {
+    this.activatedRoute.data.subscribe((data: any) => {
+      this.content = data.content;
     });
-  }
-
-  async ngOnInit() {
-    this.cdr.detectChanges();
   }
 }

--- a/packages/sdks/snippets/angular-ssr/src/app/announcement-bar/announcement-bar.resolver.ts
+++ b/packages/sdks/snippets/angular-ssr/src/app/announcement-bar/announcement-bar.resolver.ts
@@ -1,0 +1,18 @@
+import type { ActivatedRouteSnapshot, ResolveFn } from '@angular/router';
+import { fetchOneEntry, getBuilderSearchParams } from '@builder.io/sdk-angular';
+
+export const announcementBarResolver: ResolveFn<any> = (
+  route: ActivatedRouteSnapshot
+) => {
+  const urlPath = `/${route.url.join('/')}`;
+  const searchParams = getBuilderSearchParams(route.queryParams);
+
+  return fetchOneEntry({
+    apiKey: 'ee9f13b4981e489a9a1209887695ef2b',
+    model: 'announcement-bar',
+    userAttributes: {
+      urlPath,
+    },
+    options: searchParams,
+  });
+};

--- a/packages/sdks/snippets/angular-ssr/src/app/app.module.ts
+++ b/packages/sdks/snippets/angular-ssr/src/app/app.module.ts
@@ -8,8 +8,10 @@ import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 import { Content } from '@builder.io/sdk-angular';
 import { AnnouncementBarComponent } from './announcement-bar/announcement-bar.component';
+import { announcementBarResolver } from './announcement-bar/announcement-bar.resolver';
 import { AppComponent } from './app.component';
 import { CatchAllComponent } from './catch-all/catch-all.component';
+import { catchAllResolver } from './catch-all/catch-all.resolver';
 
 @NgModule({
   declarations: [AppComponent, AnnouncementBarComponent, CatchAllComponent],
@@ -18,8 +20,16 @@ import { CatchAllComponent } from './catch-all/catch-all.component';
     Content,
     BrowserModule,
     RouterModule.forRoot([
-      { path: 'announcements/:id', component: AnnouncementBarComponent },
-      { path: '**', component: CatchAllComponent },
+      {
+        path: 'announcements/:id',
+        component: AnnouncementBarComponent,
+        resolve: { content: announcementBarResolver },
+      },
+      {
+        path: '**',
+        component: CatchAllComponent,
+        resolve: { content: catchAllResolver },
+      },
     ]),
   ],
   providers: [],

--- a/packages/sdks/snippets/angular-ssr/src/app/catch-all/catch-all.component.ts
+++ b/packages/sdks/snippets/angular-ssr/src/app/catch-all/catch-all.component.ts
@@ -3,22 +3,9 @@
  * snippets/angular-ssr/src/app/catch-all/catch-all.component.ts
  */
 
-import { isPlatformServer } from '@angular/common';
-// fails because type imports cannot be injected
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-import {
-  ChangeDetectorRef,
-  Component,
-  Inject,
-  Optional,
-  PLATFORM_ID,
-} from '@angular/core';
-import {
-  fetchOneEntry,
-  getBuilderSearchParams,
-  type BuilderContent,
-} from '@builder.io/sdk-angular';
-import { REQUEST } from '@nguniversal/express-engine/tokens';
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { type BuilderContent } from '@builder.io/sdk-angular';
 
 @Component({
   selector: 'app-catchall',
@@ -41,29 +28,11 @@ export class CatchAllComponent {
   model = 'page';
   content: BuilderContent | null = null;
 
-  constructor(
-    private cdr: ChangeDetectorRef,
-    @Inject(PLATFORM_ID) private platformId: any,
-    @Optional() @Inject(REQUEST) private req: any
-  ) {
-    const urlPath = isPlatformServer(this.platformId)
-      ? this.req.path || ''
-      : window.location.pathname;
-    const searchParams = isPlatformServer(this.platformId)
-      ? new URLSearchParams(this.req.url.split('?')[1])
-      : new URLSearchParams(window.location.search);
+  constructor(private activatedRoute: ActivatedRoute) {}
 
-    fetchOneEntry({
-      apiKey: this.apiKey,
-      model: this.model,
-      userAttributes: { urlPath },
-      options: getBuilderSearchParams(searchParams),
-    }).then((content) => {
-      this.content = content;
+  ngOnInit() {
+    this.activatedRoute.data.subscribe((data: any) => {
+      this.content = data.content;
     });
-  }
-
-  async ngOnInit() {
-    this.cdr.detectChanges();
   }
 }

--- a/packages/sdks/snippets/angular-ssr/src/app/catch-all/catch-all.resolver.ts
+++ b/packages/sdks/snippets/angular-ssr/src/app/catch-all/catch-all.resolver.ts
@@ -1,0 +1,18 @@
+import type { ActivatedRouteSnapshot, ResolveFn } from '@angular/router';
+import { fetchOneEntry, getBuilderSearchParams } from '@builder.io/sdk-angular';
+
+export const catchAllResolver: ResolveFn<any> = (
+  route: ActivatedRouteSnapshot
+) => {
+  const urlPath = `/${route.url.join('/')}`;
+  const searchParams = getBuilderSearchParams(route.queryParams);
+
+  return fetchOneEntry({
+    apiKey: 'ee9f13b4981e489a9a1209887695ef2b',
+    model: 'page',
+    userAttributes: {
+      urlPath,
+    },
+    options: searchParams,
+  });
+};

--- a/packages/sdks/snippets/angular/src/app/announcement-bar/announcement-bar.component.ts
+++ b/packages/sdks/snippets/angular/src/app/announcement-bar/announcement-bar.component.ts
@@ -4,9 +4,7 @@
  * src/app/announcement-bar/announcement-bar.component.ts
  */
 
-// fails because type imports cannot be injected
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-import { ChangeDetectorRef, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { fetchOneEntry, type BuilderContent } from '@builder.io/sdk-angular';
 
 @Component({
@@ -33,8 +31,6 @@ export class AnnouncementBarComponent {
   model = 'announcement-bar';
   content: BuilderContent | null = null;
 
-  constructor(private cdr: ChangeDetectorRef) {}
-
   async ngOnInit() {
     const urlPath = window.location.pathname || '';
 
@@ -51,6 +47,5 @@ export class AnnouncementBarComponent {
     }
 
     this.content = content;
-    this.cdr.detectChanges();
   }
 }

--- a/packages/sdks/snippets/angular/src/app/catch-all/catch-all.component.ts
+++ b/packages/sdks/snippets/angular/src/app/catch-all/catch-all.component.ts
@@ -3,9 +3,7 @@
  * snippets/angular/src/app/catch-all/catch-all.component.ts
  */
 
-// fails because type imports cannot be injected
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-import { ChangeDetectorRef, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { fetchOneEntry, type BuilderContent } from '@builder.io/sdk-angular';
 
 @Component({
@@ -29,8 +27,6 @@ export class CatchAllComponent {
   model = 'page';
   content: BuilderContent | null = null;
 
-  constructor(private cdr: ChangeDetectorRef) {}
-
   async ngOnInit() {
     const urlPath = window.location.pathname || '';
 
@@ -47,6 +43,5 @@ export class CatchAllComponent {
     }
 
     this.content = content;
-    this.cdr.detectChanges();
   }
 }


### PR DESCRIPTION
## Description

cleanup `angular-ssr` snippets to use resolver approach and eslint disable comments to make snippets easily copy-pastable.

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
