### PR TITLE
style: Sveltekit snippets now have 2 spaces instead of tabs

### DIFF
--- a/packages/sdks/snippets/sveltekit/src/routes/announcements/[...catchall]/+page.svelte
+++ b/packages/sdks/snippets/sveltekit/src/routes/announcements/[...catchall]/+page.svelte
@@ -3,25 +3,25 @@
 <!-- src/routes/announcements/[...catchall]/+page.svelte -->
 
 <script>
-    import { isPreviewing, Content } from "@builder.io/sdk-svelte";
+  import { isPreviewing, Content } from '@builder.io/sdk-svelte';
 
-    const apiKey = "ee9f13b4981e489a9a1209887695ef2b"
-    const model = "announcement-bar"
+  const apiKey = 'ee9f13b4981e489a9a1209887695ef2b';
+  const model = 'announcement-bar';
 
-    export let data;
+  export let data;
 
-    const canShowContent = data.content || isPreviewing();
+  const canShowContent = data.content || isPreviewing();
 </script>
 
 <main>
-    <h1>Welcome to SvelteKit</h1>
-    <h2>Below is your Builder Content:</h2>
-    {#if canShowContent}
-        <div>page Title: {data.content?.data?.title || "Unpublished"}</div>
-        <Content model={model} content={data.content} apiKey={apiKey} />
-    {:else}
-        <div>Announcement Bar not Found</div>
-    {/if}
-    <!-- Your content coming from your app (or also Builder) -->
-    <div>The rest of your page goes here</div>
+  <h1>Welcome to SvelteKit</h1>
+  <h2>Below is your Builder Content:</h2>
+  {#if canShowContent}
+    <div>page Title: {data.content?.data?.title || 'Unpublished'}</div>
+    <Content {model} content={data.content} {apiKey} />
+  {:else}
+    <div>Announcement Bar not Found</div>
+  {/if}
+  <!-- Your content coming from your app (or also Builder) -->
+  <div>The rest of your page goes here</div>
 </main>


### PR DESCRIPTION
## Description

SvelteKit code in the Snippets used to have formatting with tabs(until this PR), but it is now changed to 2 spaces to stay consistent with other snippets, as per the open [Jira ticket](https://builder-io.atlassian.net/browse/EDU-146) 