### PR TITLE
revert: `userAttributes` fix in gen1 core SDK

### DIFF
--- a/.changeset/curvy-apples-study.md
+++ b/.changeset/curvy-apples-study.md
@@ -2,4 +2,4 @@
 "@builder.io/sdk": patch
 ---
 
-Fix: reverts `userAttributes` parsing logic to the old way that requires users to handle/preserve strings on their end
+Fix: reverts `v2.2.5` change to `userAttributes` parsing logic, as it caused breaking changes in certain cases.

--- a/.changeset/curvy-apples-study.md
+++ b/.changeset/curvy-apples-study.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/sdk": patch
+---
+
+Fix: reverts `userAttributes` parsing logic to the old way that requires users to handle/preserve strings on their end

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -2426,7 +2426,7 @@ export class Builder {
     }
     // TODO: merge in the attribute from query string ones
     // TODO: make this an option per component/request
-    queryParams.userAttributes = JSON.stringify(userAttributes);
+    queryParams.userAttributes = userAttributes;
 
     if (!usePastQueue && !useQueue) {
       this.priorContentQueue = queue;


### PR DESCRIPTION
## Description

This PR reverts this commit: https://github.com/BuilderIO/builder/commit/a5b8810ae1b1886db99d1b169762dbd051b74390 as this introduces breaking change for some of our customers.

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
