### PR TITLE
fix: manual stringification of `userAttributes` as a major release

### DIFF
--- a/.changeset/fifty-pandas-repeat.md
+++ b/.changeset/fifty-pandas-repeat.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/sdk': major
+---
+
+Fix: Reintroduced `JSON.stringify(userAttributes)` change to standardize parsing logic and preserve strings. This is a breaking change as it doesn't require manual stringification of `userAttributes` values. Ensure that attributes are not manually stringified before passing them to avoid potential issues.

--- a/.changeset/rich-apes-move.md
+++ b/.changeset/rich-apes-move.md
@@ -28,4 +28,4 @@ userAttributes: {
 }
 ```
 
-they were actual string numbers but we failed to parse it because we were not preserving the strings and users had to perform manual stringification hacks like "'1'" to achieve correct result. With this change stringified numbers/bools etc will work out of the box as expected showing less room for randomness.
+they were actual string numbers but we failed to parse it because we were not preserving the strings and users had to perform manual stringification hacks like `"'1'"` to achieve correct result. With this change stringified numbers/bools etc will work out of the box as expected showing less room for randomness.

--- a/.changeset/rich-apes-move.md
+++ b/.changeset/rich-apes-move.md
@@ -2,7 +2,7 @@
 '@builder.io/react': major
 ---
 
-Breaking Change :firecracker:: `userAttributes` now is parsed as an object - `JSON.stringify(userAttributes)` which preserves strings. Users no longer need to manually stringify anything unless they have explicitly included it in custom targeting attributes.
+Breaking Change 🧨: `userAttributes` now is parsed as an object - `JSON.stringify(userAttributes)` which preserves strings. Users no longer need to manually stringify anything unless they have explicitly included it in custom targeting attributes.
 
 For example,
 

--- a/.changeset/rich-apes-move.md
+++ b/.changeset/rich-apes-move.md
@@ -1,0 +1,31 @@
+---
+'@builder.io/react': major
+---
+
+Breaking Change :firecracker:: `userAttributes` now is parsed as an object - `JSON.stringify(userAttributes)` which preserves strings. Users no longer need to manually stringify anything unless they have explicitly included it in custom targeting attributes.
+
+For example,
+
+```js
+userAttributes: {
+  stringWithStrs: ['a', 'c'];
+}
+```
+
+used to work as well as this,
+
+```js
+userAttributes: {
+  stringWithStrs: ["'a'", "'c'"];
+}
+```
+
+but now its not needed to manually stringify strings. This change was needed to preserve data types and strings so previously when we passed,
+
+```js
+userAttributes: {
+  stringWithNums: ['1', '2'];
+}
+```
+
+they were actual string numbers but we failed to parse it because we were not preserving the strings and users had to perform manual stringification hacks like "'1'" to achieve correct result. With this change stringified numbers/bools etc will work out of the box as expected showing less room for randomness.

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -2426,7 +2426,7 @@ export class Builder {
     }
     // TODO: merge in the attribute from query string ones
     // TODO: make this an option per component/request
-    queryParams.userAttributes = userAttributes;
+    queryParams.userAttributes = JSON.stringify(userAttributes);
 
     if (!usePastQueue && !useQueue) {
       this.priorContentQueue = queue;


### PR DESCRIPTION
## Description

Re-introduces this https://github.com/BuilderIO/builder/commit/a5b8810ae1b1886db99d1b169762dbd051b74390 as a major release (breaking change)

**Loom**
https://www.loom.com/share/c8a104f1c7de4694825599705eac442f
