### PR TITLE
fix serialization of all functions in component info

### DIFF
--- a/.changeset/yellow-camels-argue.md
+++ b/.changeset/yellow-camels-argue.md
@@ -1,0 +1,14 @@
+---
+"@builder.io/sdk": patch
+"@builder.io/react": patch
+"@builder.io/sdk-angular": patch
+"@builder.io/sdk-react-nextjs": patch
+"@builder.io/sdk-qwik": patch
+"@builder.io/sdk-react": patch
+"@builder.io/sdk-react-native": patch
+"@builder.io/sdk-solid": patch
+"@builder.io/sdk-svelte": patch
+"@builder.io/sdk-vue": patch
+---
+
+Fix: serialize all functions within registered component info.

--- a/packages/core/src/builder.class.test.ts
+++ b/packages/core/src/builder.class.test.ts
@@ -21,3 +21,149 @@ describe('Builder', () => {
     expect(Builder.isTrustedHost('example.com')).toBe(true);
   });
 });
+
+describe('serializeComponentInfo', () => {
+  test('serializes functions in inputs', () => {
+    const input = {
+      name: 'TestComponent',
+      inputs: [
+        {
+          name: 'text',
+          type: 'string',
+          onChange: function (value: string) {
+            return value.toUpperCase();
+          },
+        },
+      ],
+    };
+
+    const result = Builder['serializeComponentInfo'](input);
+
+    expect(typeof result.inputs[0].onChange).toBe('string');
+    expect(result.inputs[0].onChange).toContain('return value.toUpperCase()');
+  });
+
+  test('serializes arrow functions in inputs', () => {
+    const input = {
+      name: 'ArrowComponent',
+      inputs: [
+        {
+          name: 'number',
+          type: 'number',
+          onChange: (value: number) => value * 2,
+        },
+      ],
+    };
+
+    const result = Builder['serializeComponentInfo'](input);
+
+    expect(typeof result.inputs[0].onChange).toBe('string');
+    expect(result.inputs[0].onChange).toContain('value * 2');
+  });
+
+  test('does not modify non-function properties', () => {
+    const input = {
+      name: 'MixedComponent',
+      inputs: [
+        {
+          name: 'text',
+          type: 'string',
+          defaultValue: 'hello',
+        },
+      ],
+    };
+
+    const result = Builder['serializeComponentInfo'](input);
+
+    expect(result).toEqual(input);
+  });
+
+  test('handles multiple inputs with mixed properties', () => {
+    const input = {
+      name: 'ComplexComponent',
+      inputs: [
+        {
+          name: 'text',
+          type: 'string',
+          onChange: (value: string) => value.trim(),
+        },
+        {
+          name: 'number',
+          type: 'number',
+          defaultValue: 42,
+        },
+        {
+          name: 'options',
+          type: 'string',
+          onChange: function (value: string[]) {
+            return value.map(v => v.toLowerCase());
+          },
+        },
+      ],
+    };
+
+    const result = Builder['serializeComponentInfo'](input);
+
+    expect(typeof result.inputs[0].onChange).toBe('string');
+    expect(result.inputs[0].onChange).toContain('value.trim()');
+
+    expect(result.inputs[1]).toEqual(input.inputs[1]);
+
+    expect(typeof result.inputs[2].onChange).toBe('string');
+    expect(result.inputs[2].onChange).toContain('v.toLowerCase()');
+  });
+});
+
+describe('prepareComponentSpecToSend', () => {
+  test('removes class property and serializes functions in inputs', () => {
+    const input = {
+      name: 'TestComponent',
+      class: class TestClass {},
+      inputs: [
+        {
+          name: 'text',
+          type: 'string',
+          onChange: function (value: string) {
+            return value.toUpperCase();
+          },
+        },
+      ],
+    };
+
+    const result = Builder['prepareComponentSpecToSend'](input);
+
+    expect(result.class).toBeUndefined();
+    expect(typeof result.inputs?.[0].onChange).toBe('string');
+    expect(result.inputs?.[0].onChange).toContain('value.toUpperCase()');
+  });
+
+  test('preserves other properties', () => {
+    const input = {
+      name: 'ComplexComponent',
+      class: class ComplexClass {},
+      inputs: [
+        {
+          name: 'text',
+          type: 'string',
+          defaultValue: 'hello',
+          onChange: (value: string) => value.trim(),
+        },
+        {
+          name: 'number',
+          type: 'number',
+          defaultValue: 42,
+        },
+      ],
+    };
+
+    const result = Builder['prepareComponentSpecToSend'](input);
+
+    expect(result.class).toBeUndefined();
+    expect(result.name).toBe('ComplexComponent');
+    expect(result.inputs?.length).toBe(2);
+    expect(typeof result.inputs?.[0].onChange).toBe('string');
+    expect(result.inputs?.[0].onChange).toContain('value.trim()');
+    expect(result.inputs?.[0].defaultValue).toBe('hello');
+    expect(result.inputs?.[1]).toEqual(input.inputs[1]);
+  });
+});

--- a/packages/sdks/src/functions/__snapshots__/register-component.test.ts.snap
+++ b/packages/sdks/src/functions/__snapshots__/register-component.test.ts.snap
@@ -1,0 +1,54 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Component Registration and Serialization > serializeComponentInfo handles arrow functions 1`] = `
+{
+  "hooks": {
+    "onInit": "return ((num) => num * 2).apply(this, arguments)",
+  },
+  "inputs": [
+    {
+      "name": "testInput",
+      "type": "number",
+    },
+  ],
+  "name": "ArrowComponent",
+}
+`;
+
+exports[`Component Registration and Serialization > serializeComponentInfo handles functions correctly 1`] = `
+{
+  "hooks": {
+    "onChange": "return (function(value) {
+          return value.toUpperCase();
+        }).apply(this, arguments)",
+  },
+  "inputs": [
+    {
+      "name": "testInput",
+      "type": "string",
+    },
+  ],
+  "name": "TestComponent",
+}
+`;
+
+exports[`Component Registration and Serialization > serializeFn handles different function syntaxes 1`] = `
+{
+  "hooks": {
+    "func1": "return (function namedFunction(x) {
+          return x + 1;
+        }).apply(this, arguments)",
+    "func2": "return ((x) => x * 2).apply(this, arguments)",
+    "func3": "return (function func3(x) {
+          return x - 1;
+        }).apply(this, arguments)",
+  },
+  "inputs": [
+    {
+      "name": "testInput",
+      "type": "string",
+    },
+  ],
+  "name": "SyntaxTestComponent",
+}
+`;

--- a/packages/sdks/src/functions/register-component.test.ts
+++ b/packages/sdks/src/functions/register-component.test.ts
@@ -1,0 +1,82 @@
+import type { ComponentInfo } from '../types/components.js';
+import {
+  createRegisterComponentMessage,
+  serializeComponentInfo,
+} from './register-component.js';
+
+describe('Component Registration and Serialization', () => {
+  test('createRegisterComponentMessage creates correct message structure', () => {
+    const mockComponentInfo: ComponentInfo = {
+      name: 'TestComponent',
+      inputs: [{ name: 'testInput', type: 'string' }],
+      // Add other required fields as necessary
+    };
+
+    const result = createRegisterComponentMessage(mockComponentInfo);
+
+    expect(result).toEqual({
+      type: 'builder.registerComponent',
+      data: expect.any(Object), // We'll test the data content separately
+    });
+  });
+
+  test('serializeComponentInfo handles functions correctly', () => {
+    const mockComponentInfo: ComponentInfo = {
+      name: 'TestComponent',
+      inputs: [{ name: 'testInput', type: 'string' }],
+      hooks: {
+        // eslint-disable-next-line
+        onChange: function (value: string) {
+          return value.toUpperCase();
+        },
+      },
+      // Add other required fields as necessary
+    };
+
+    const result = serializeComponentInfo(mockComponentInfo);
+
+    expect(result).toMatchSnapshot();
+    expect(result.name).toBe('TestComponent');
+    expect(result.inputs).toEqual([{ name: 'testInput', type: 'string' }]);
+    expect(typeof result.hooks.onChange).toBe('string');
+    expect(result.hooks.onChange).toContain('return value.toUpperCase();');
+  });
+
+  test('serializeComponentInfo handles arrow functions', () => {
+    const mockComponentInfo: ComponentInfo = {
+      name: 'ArrowComponent',
+      inputs: [{ name: 'testInput', type: 'number' }],
+      hooks: {
+        onInit: (num: number) => num * 2,
+      },
+      // Add other required fields as necessary
+    };
+
+    const result = serializeComponentInfo(mockComponentInfo);
+
+    expect(result).toMatchSnapshot();
+    expect(typeof result.hooks.onInit).toBe('string');
+    expect(result.hooks.onInit).toContain('num * 2');
+  });
+
+  test('serializeFn handles different function syntaxes', () => {
+    const mockComponentInfo: ComponentInfo = {
+      name: 'SyntaxTestComponent',
+      inputs: [{ name: 'testInput', type: 'string' }],
+      hooks: {
+        func1: function namedFunction(x: number) {
+          return x + 1;
+        },
+        func2: (x: number) => x * 2,
+        func3(x: number) {
+          return x - 1;
+        },
+      },
+      // Add other required fields as necessary
+    };
+
+    const result = serializeComponentInfo(mockComponentInfo);
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/packages/sdks/src/functions/register-component.ts
+++ b/packages/sdks/src/functions/register-component.ts
@@ -1,6 +1,4 @@
 import type { ComponentInfo } from '../types/components.js';
-import type { Input } from '../types/input.js';
-import { fastClone } from './fast-clone.js';
 
 export const createRegisterComponentMessage = (info: ComponentInfo) => ({
   type: 'builder.registerComponent',
@@ -21,21 +19,13 @@ const serializeFn = (fnValue: Function) => {
   return `return (${appendFunction ? 'function ' : ''}${fnStr}).apply(this, arguments)`;
 };
 
-const serializeValue = (value: object): any =>
-  typeof value === 'function' ? serializeFn(value) : fastClone(value);
-
-export const serializeComponentInfo = ({
-  inputs,
-  ...info
-}: ComponentInfo): ComponentInfo => ({
-  ...fastClone(info),
-  inputs: inputs?.map((input) =>
-    Object.entries(input).reduce(
-      (acc, [key, value]) => ({
-        ...acc,
-        [key]: serializeValue(value),
-      }),
-      {} as Input
-    )
-  ),
-});
+export function serializeComponentInfo(info: ComponentInfo) {
+  return JSON.parse(
+    JSON.stringify(info, (key, value) => {
+      if (typeof value === 'function') {
+        return serializeFn(value);
+      }
+      return value;
+    })
+  );
+}


### PR DESCRIPTION
currently we only do some top level functions, so people, for instance, need to do onChange and showIf hooks with subFields as strings whereas top level can be functions which will no longer be needed

more context: https://builder-internal.slack.com/archives/CMBPNS6RM/p1722968511933239?thread_ts=1722964078.709639&cid=CMBPNS6RM
