### PR TITLE
bump: gen1 angular sdk version to `3.0.2` to use latest wc sdk

### DIFF
--- a/packages/angular/package-lock.json
+++ b/packages/angular/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/angular",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/angular",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "@builder.io/sdk": "^1.3.0"

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/angular",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "main": "dist/bundles/builder.io-angular.umd.js",
   "module": "dist/fesm5/builder.io-angular.js",
   "es2015": "dist/fesm2015/builder.io-angular.js",

--- a/packages/angular/src/app/modules/builder/utils/constants.ts
+++ b/packages/angular/src/app/modules/builder/utils/constants.ts
@@ -1,3 +1,3 @@
 // TODO remove hardcoded version, maybe a release tag?
-export const ANGULAR_LATEST_VERSION = '1.3.51';
+export const ANGULAR_LATEST_VERSION = '1.3.52';
 export const SCRIPT_ID = 'builder-wc-script';


### PR DESCRIPTION
## Description
Uses latest WC SDK which uses latest gen1 React SDK.

**Jira**
https://builder-io.atlassian.net/browse/ENG-6106

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
