### PR TITLE
feat: add `nonce` to scripts and styles in custom code block

### DIFF
--- a/packages/sdks-tests/src/e2e-tests/custom-code-nonce.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/custom-code-nonce.spec.ts
@@ -1,0 +1,53 @@
+import { expect, type Page } from '@playwright/test';
+import { test } from '../helpers/index.js';
+
+async function skipFetchingScriptContainingSrc(page: Page) {
+  await page.route('**/*', route => {
+    const request = route.request();
+
+    if (request.url().includes('something')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: '',
+      });
+    }
+    return route.continue();
+  });
+}
+
+test.describe('Nonce in Custom Code script and style tags', () => {
+  test.beforeEach(async ({ page }) => {
+    await skipFetchingScriptContainingSrc(page);
+  });
+
+  test('runnable script with code contains nonce', async ({ page, packageName }) => {
+    test.skip(packageName !== 'react', 'Test only added for React SDK');
+    await page.goto('/custom-code-nonce');
+
+    const scriptInHead = page.locator('head').locator('script').last();
+    const nonce = await scriptInHead.getAttribute('nonce');
+
+    expect(nonce).toEqual('123');
+  });
+  test('script tag with src contains nonce', async ({ page, packageName }) => {
+    test.skip(packageName !== 'react', 'Test only added for React SDK');
+    await page.goto('/custom-code-nonce');
+
+    const customCodeLocator = page.locator('.builder-custom-code');
+    const scriptTag = customCodeLocator.locator('script').last();
+    const nonce = await scriptTag.getAttribute('nonce');
+
+    expect(nonce).toEqual('123');
+  });
+  test('style tag contains nonce', async ({ page, packageName }) => {
+    test.skip(packageName !== 'react', 'Test only added for React SDK');
+    await page.goto('/custom-code-nonce');
+
+    const customCodeLocator = page.locator('.builder-custom-code');
+    const styleTag = customCodeLocator.locator('style').first();
+    const nonce = await styleTag.getAttribute('nonce');
+
+    expect(nonce).toEqual('123');
+  });
+});

--- a/packages/sdks-tests/src/specs/custom-code-nonce.ts
+++ b/packages/sdks-tests/src/specs/custom-code-nonce.ts
@@ -1,0 +1,64 @@
+export const CUSTOM_CODE_NONCE = {
+  ownerId: 'ad30f9a246614faaa6a03374f83554c9',
+  lastUpdateBy: null,
+  createdDate: 1724074628985,
+  id: '91a14f0d1cb54098806ad13772226620',
+  '@version': 4,
+  name: 'custom-code-nonce',
+  modelId: '17c6065109ef4062ba083f5741f4ee6a',
+  published: 'draft',
+  meta: {
+    kind: 'page',
+    lastPreviewUrl:
+      'http://localhost:5173/custom-code-nonce?builder.space=ad30f9a246614faaa6a03374f83554c9&builder.user.permissions=read%2Ccreate%2Cpublish%2CeditCode%2CeditDesigns%2Cadmin%2CeditLayouts%2CeditLayers&builder.user.role.name=Admin&builder.user.role.id=admin&builder.cachebust=true&builder.preview=page&builder.noCache=true&builder.allowTextEdit=true&__builder_editing__=true&builder.overrides.page=91a14f0d1cb54098806ad13772226620&builder.overrides.91a14f0d1cb54098806ad13772226620=91a14f0d1cb54098806ad13772226620&builder.overrides.page:/custom-code-nonce=91a14f0d1cb54098806ad13772226620&builder.options.locale=Default',
+    hasLinks: false,
+  },
+  priority: -606,
+  query: [
+    {
+      '@type': '@builder.io/core:Query',
+      property: 'urlPath',
+      operator: 'is',
+      value: '/custom-code-nonce',
+    },
+  ],
+  data: {
+    title: 'custom-code-nonce',
+    themeId: false,
+    inputs: [],
+    blocks: [
+      {
+        '@type': '@builder.io/sdk:Element',
+        '@version': 2,
+        id: 'builder-fc580e306ce2493b990fa354439baaef',
+        component: {
+          name: 'Custom Code',
+          options: {
+            code: "<h1>Nonce is attached</h1>\n\n<script src=\"something\"></script>\n\n<script>\n  const h1El = document.querySelector('h1');\n\n  h1El.innerText += '!';\n</script>\n\n<style>\n  h1 {\n    color: red;\n  }\n</style>\n",
+            scriptsClientOnly: false,
+          },
+        },
+        responsiveStyles: {
+          large: {
+            display: 'flex',
+            flexDirection: 'column',
+            position: 'relative',
+            flexShrink: '0',
+            boxSizing: 'border-box',
+            marginTop: '20px',
+          },
+        },
+      },
+    ],
+  },
+  metrics: {
+    clicks: 0,
+    impressions: 0,
+  },
+  variations: {},
+  lastUpdated: 1724078090425,
+  testRatio: 1,
+  createdBy: 'RuGeCLr9ryVt1xRazFYc72uWwIK2',
+  lastUpdatedBy: 'RuGeCLr9ryVt1xRazFYc72uWwIK2',
+  folders: [],
+};

--- a/packages/sdks-tests/src/specs/index.ts
+++ b/packages/sdks-tests/src/specs/index.ts
@@ -53,6 +53,7 @@ import { ACCORDION, ACCORDION_GRID, ACCORDION_ONE_AT_A_TIME } from './accordion.
 import { SYMBOL_TRACKING } from './symbol-tracking.js';
 import { COLUMNS_WITH_DIFFERENT_WIDTHS } from './columns-with-different-widths.js';
 import { CUSTOM_COMPONENTS_MODELS_RESTRICTION } from './custom-components-models.js';
+import { CUSTOM_CODE_NONCE } from './custom-code-nonce.js';
 
 function isBrowser(): boolean {
   return typeof window !== 'undefined' && typeof document !== 'undefined';
@@ -122,6 +123,7 @@ const PAGES = {
   '/columns-with-different-widths': COLUMNS_WITH_DIFFERENT_WIDTHS,
   '/custom-components-models-show': CUSTOM_COMPONENTS_MODELS_RESTRICTION,
   '/custom-components-models-not-show': CUSTOM_COMPONENTS_MODELS_RESTRICTION,
+  '/custom-code-nonce': CUSTOM_CODE_NONCE,
 } as const;
 
 const apiVersionPathToProp = {

--- a/packages/sdks/e2e/react/src/App.tsx
+++ b/packages/sdks/e2e/react/src/App.tsx
@@ -84,6 +84,7 @@ function App() {
               }),
             },
           ]}
+          nonce={window.location.pathname.includes('nonce') ? '123' : undefined}
         />
       )}
     </DataComp>

--- a/packages/sdks/src/blocks/custom-code/component-info.ts
+++ b/packages/sdks/src/blocks/custom-code/component-info.ts
@@ -4,6 +4,9 @@ export const componentInfo: ComponentInfo = {
   name: 'Custom Code',
   static: true,
 
+  shouldReceiveBuilderProps: {
+    builderContext: true,
+  },
   requiredPermissions: ['editCode'],
   inputs: [
     {

--- a/packages/sdks/src/blocks/custom-code/custom-code.lite.tsx
+++ b/packages/sdks/src/blocks/custom-code/custom-code.lite.tsx
@@ -1,5 +1,5 @@
 import { onMount, useMetadata, useRef, useStore } from '@builder.io/mitosis';
-import type { BuilderDataProps } from '../../types/builder-props';
+import type { BuilderDataProps } from '../../types/builder-props.js';
 
 useMetadata({
   rsc: {

--- a/packages/sdks/src/blocks/custom-code/custom-code.lite.tsx
+++ b/packages/sdks/src/blocks/custom-code/custom-code.lite.tsx
@@ -1,4 +1,5 @@
 import { onMount, useMetadata, useRef, useStore } from '@builder.io/mitosis';
+import type { BuilderDataProps } from '../../types/builder-props';
 
 useMetadata({
   rsc: {
@@ -9,6 +10,7 @@ useMetadata({
 export interface CustomCodeProps {
   code: string;
   replaceNodes?: boolean;
+  builderContext: BuilderDataProps['builderContext'];
 }
 
 export default function CustomCode(props: CustomCodeProps) {
@@ -36,6 +38,9 @@ export default function CustomCode(props: CustomCodeProps) {
         const newScript = document.createElement('script');
         newScript.async = true;
         newScript.src = script.src;
+        if (props.builderContext.value.nonce) {
+          newScript.setAttribute('nonce', props.builderContext.value.nonce);
+        }
         document.head.appendChild(newScript);
       } else if (
         !script.type ||
@@ -49,11 +54,22 @@ export default function CustomCode(props: CustomCodeProps) {
           continue;
         }
         try {
+          if (props.builderContext.value.nonce) {
+            script.setAttribute('nonce', props.builderContext.value.nonce);
+          }
           state.scriptsRun.push(script.innerText);
           new Function(script.innerText)();
         } catch (error) {
           console.warn('`CustomCode`: Error running script:', error);
         }
+      }
+    }
+
+    if (props.builderContext.value.nonce) {
+      const styles = elementRef.getElementsByTagName('style');
+      for (let i = 0; i < styles.length; i++) {
+        const style = styles[i];
+        style.setAttribute('nonce', props.builderContext.value.nonce);
       }
     }
   });


### PR DESCRIPTION
## Description

Adds `nonce` attribute to script or style tags attached in Custom Code block

Jira
https://builder-io.atlassian.net/browse/PLAN-58

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
