### PR TITLE
fix: inner layout "columns" crashing

### DIFF
--- a/.changeset/real-experts-heal.md
+++ b/.changeset/real-experts-heal.md
@@ -1,0 +1,11 @@
+---
+'@builder.io/sdk-angular': patch
+'@builder.io/sdk-qwik': patch
+'@builder.io/sdk-react': patch
+'@builder.io/sdk-react-native': patch
+'@builder.io/sdk-solid': patch
+'@builder.io/sdk-svelte': patch
+'@builder.io/sdk-vue': patch
+---
+
+Fix: scoped `isInteractive` prop for RSC SDK only so that it fixes Inner Layout > "Columns" option during visual editing

--- a/packages/sdks-tests/src/e2e-tests/editing.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/editing.spec.ts
@@ -99,10 +99,13 @@ test.describe('Visual Editing', () => {
     }
 
     await sendContentUpdateMessage({ page, newContent: MODIFIED_EDITING_COLUMNS, model: 'page' });
+    // had to hack this so that we can wait for the content update to actually show up (was failing in Qwik)
+    await page.frameLocator('iframe').getByText('third').waitFor();
 
-    await expect(firstText).toBeVisible();
+    const updatedFirstText = page.frameLocator('iframe').getByText('third');
+    await expect(updatedFirstText).toBeVisible();
     await expect(secondText).toBeVisible();
-    const updatedFirstBox = await firstText.boundingBox();
+    const updatedFirstBox = await updatedFirstText.boundingBox();
     const updatedSecondBox = await secondText.boundingBox();
     if (updatedFirstBox && updatedSecondBox) {
       expect(updatedFirstBox.x).toBeLessThan(updatedSecondBox.x);

--- a/packages/sdks-tests/src/e2e-tests/editing.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/editing.spec.ts
@@ -3,15 +3,14 @@ import { MODIFIED_COLUMNS } from '../specs/columns.js';
 import { MODIFIED_EDITING_STYLES } from '../specs/editing-styles.js';
 import { NEW_TEXT } from '../specs/helpers.js';
 import { MODIFIED_HOMEPAGE } from '../specs/homepage.js';
-import { test } from '../helpers/index.js';
+import { checkIsRN, test } from '../helpers/index.js';
 import { launchEmbedderAndWaitForSdk, sendContentUpdateMessage } from '../helpers/visual-editor.js';
 import { MODIFIED_EDITING_COLUMNS } from '../specs/editing-columns-inner-layout.js';
 
 const editorTests = ({ noTrustedHosts }: { noTrustedHosts: boolean }) => {
   test('correctly updates Text block', async ({ page, basePort, packageName }) => {
     test.skip(
-      packageName === 'react-native' ||
-        packageName === 'nextjs-sdk-next-app' ||
+      packageName === 'nextjs-sdk-next-app' ||
         packageName === 'gen1-next' ||
         packageName === 'gen1-react' ||
         packageName === 'gen1-remix'
@@ -28,8 +27,7 @@ const editorTests = ({ noTrustedHosts }: { noTrustedHosts: boolean }) => {
 
   test('correctly updates Text block styles', async ({ page, packageName, basePort }) => {
     test.skip(
-      packageName === 'react-native' ||
-        packageName === 'nextjs-sdk-next-app' ||
+      packageName === 'nextjs-sdk-next-app' ||
         packageName === 'gen1-next' ||
         packageName === 'gen1-react' ||
         packageName === 'gen1-remix'
@@ -57,8 +55,7 @@ test.describe('Visual Editing', () => {
     packageName,
   }) => {
     test.skip(
-      packageName === 'react-native' ||
-        packageName === 'nextjs-sdk-next-app' ||
+      packageName === 'nextjs-sdk-next-app' ||
         packageName === 'gen1-next' ||
         packageName === 'gen1-react' ||
         packageName === 'gen1-remix'
@@ -73,10 +70,10 @@ test.describe('Visual Editing', () => {
     page,
     packageName,
     basePort,
+    sdk,
   }) => {
     test.skip(
-      packageName === 'react-native' ||
-        packageName === 'nextjs-sdk-next-app' ||
+      packageName === 'nextjs-sdk-next-app' ||
         packageName === 'gen1-next' ||
         packageName === 'gen1-react' ||
         packageName === 'gen1-remix'
@@ -108,8 +105,14 @@ test.describe('Visual Editing', () => {
     const updatedFirstBox = await updatedFirstText.boundingBox();
     const updatedSecondBox = await secondText.boundingBox();
     if (updatedFirstBox && updatedSecondBox) {
-      expect(updatedFirstBox.x).toBeLessThan(updatedSecondBox.x);
-      expect(updatedFirstBox.y).toBe(updatedSecondBox.y);
+      if (checkIsRN(sdk)) {
+        // stack layout incase of RN SDK
+        expect(updatedFirstBox.x).toBe(updatedSecondBox.x);
+        expect(updatedFirstBox.y).toBeLessThan(updatedSecondBox.y);
+      } else {
+        expect(updatedFirstBox.x).toBeLessThan(updatedSecondBox.x);
+        expect(updatedFirstBox.y).toBe(updatedSecondBox.y);
+      }
     }
   });
 

--- a/packages/sdks-tests/src/specs/editing-columns-inner-layout.ts
+++ b/packages/sdks-tests/src/specs/editing-columns-inner-layout.ts
@@ -130,7 +130,7 @@ export const MODIFIED_EDITING_COLUMNS = {
                     component: {
                       name: 'Text',
                       options: {
-                        text: 'first',
+                        text: 'third',
                       },
                     },
                     responsiveStyles: {

--- a/packages/sdks-tests/src/specs/editing-columns-inner-layout.ts
+++ b/packages/sdks-tests/src/specs/editing-columns-inner-layout.ts
@@ -1,0 +1,198 @@
+export const EDITING_BOX_TO_COLUMN_INNER_LAYOUT = {
+  ownerId: 'ad30f9a246614faaa6a03374f83554c9',
+  lastUpdateBy: null,
+  createdDate: 1724132675778,
+  id: 'fd46ebf82e0c481681deb9e0823faeca',
+  '@version': 4,
+  name: 'asfxgxgv',
+  modelId: '17c6065109ef4062ba083f5741f4ee6a',
+  published: 'draft',
+  meta: {
+    hasLinks: false,
+    kind: 'page',
+    lastPreviewUrl:
+      'http://localhost:5173/asfxgxgv?builder.space=ad30f9a246614faaa6a03374f83554c9&builder.user.permissions=read%2Ccreate%2Cpublish%2CeditCode%2CeditDesigns%2Cadmin%2CeditLayouts%2CeditLayers&builder.user.role.name=Admin&builder.user.role.id=admin&builder.cachebust=true&builder.preview=page&builder.noCache=true&builder.allowTextEdit=true&__builder_editing__=true&builder.overrides.page=fd46ebf82e0c481681deb9e0823faeca&builder.overrides.fd46ebf82e0c481681deb9e0823faeca=fd46ebf82e0c481681deb9e0823faeca&builder.overrides.page:/asfxgxgv=fd46ebf82e0c481681deb9e0823faeca&builder.options.locale=Default',
+  },
+  priority: -611,
+  query: [
+    {
+      '@type': '@builder.io/core:Query',
+      property: 'urlPath',
+      operator: 'is',
+      value: '/asfxgxgv',
+    },
+  ],
+  data: {
+    themeId: false,
+    title: 'asfxgxgv',
+    inputs: [],
+    blocks: [
+      {
+        '@type': '@builder.io/sdk:Element',
+        '@version': 2,
+        id: 'builder-caf4d18da3d0439281f29eb144874e2e',
+        children: [
+          {
+            '@type': '@builder.io/sdk:Element',
+            '@version': 2,
+            id: 'builder-6a7ca44506bf459abaff59e2e76fdaaf',
+            component: {
+              name: 'Text',
+              options: {
+                text: 'first',
+              },
+            },
+            responsiveStyles: {
+              large: {
+                display: 'flex',
+                flexDirection: 'column',
+                position: 'relative',
+                flexShrink: '0',
+                boxSizing: 'border-box',
+                marginTop: '20px',
+                lineHeight: 'normal',
+                height: 'auto',
+              },
+            },
+          },
+          {
+            '@type': '@builder.io/sdk:Element',
+            '@version': 2,
+            id: 'builder-f102f51c56b84727be3f222c1d34b3ea',
+            component: {
+              name: 'Text',
+              options: {
+                text: 'second',
+              },
+            },
+            responsiveStyles: {
+              large: {
+                display: 'flex',
+                flexDirection: 'column',
+                position: 'relative',
+                flexShrink: '0',
+                boxSizing: 'border-box',
+                marginTop: '20px',
+                lineHeight: 'normal',
+                height: 'auto',
+              },
+            },
+          },
+        ],
+        responsiveStyles: {
+          large: {
+            display: 'flex',
+            flexDirection: 'column',
+            position: 'relative',
+            flexShrink: '0',
+            boxSizing: 'border-box',
+            marginTop: '20px',
+            height: 'auto',
+            paddingBottom: '30px',
+          },
+        },
+      },
+    ],
+  },
+  metrics: {
+    clicks: 0,
+    impressions: 0,
+  },
+  variations: {},
+  lastUpdated: 1724165281228,
+  testRatio: 1,
+  createdBy: 'RuGeCLr9ryVt1xRazFYc72uWwIK2',
+  lastUpdatedBy: 'RuGeCLr9ryVt1xRazFYc72uWwIK2',
+  folders: [],
+};
+
+export const MODIFIED_EDITING_COLUMNS = {
+  id: 'fd46ebf82e0c481681deb9e0823faeca',
+  data: {
+    themeId: false,
+    title: 'asfxgxgv',
+    inputs: [],
+    blocks: [
+      {
+        '@type': '@builder.io/sdk:Element',
+        '@version': 2,
+        id: 'builder-a5309f6a1d2c43068e51557edcc0a85d',
+        component: {
+          name: 'Columns',
+          options: {
+            columns: [
+              {
+                blocks: [
+                  {
+                    '@type': '@builder.io/sdk:Element',
+                    '@version': 2,
+                    id: 'builder-2f8d079276024173a80801d6fe0117f7',
+                    component: {
+                      name: 'Text',
+                      options: {
+                        text: 'first',
+                      },
+                    },
+                    responsiveStyles: {
+                      large: {
+                        display: 'flex',
+                        flexDirection: 'column',
+                        position: 'relative',
+                        flexShrink: '0',
+                        boxSizing: 'border-box',
+                        marginTop: '20px',
+                        lineHeight: 'normal',
+                        height: 'auto',
+                      },
+                    },
+                  },
+                ],
+              },
+              {
+                blocks: [
+                  {
+                    '@type': '@builder.io/sdk:Element',
+                    '@version': 2,
+                    id: 'builder-b6c8d6beff5b4049b6374827c59743fa',
+                    component: {
+                      name: 'Text',
+                      options: {
+                        text: 'second',
+                      },
+                    },
+                    responsiveStyles: {
+                      large: {
+                        display: 'flex',
+                        flexDirection: 'column',
+                        position: 'relative',
+                        flexShrink: '0',
+                        boxSizing: 'border-box',
+                        marginTop: '20px',
+                        lineHeight: 'normal',
+                        height: 'auto',
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+            space: 20,
+            stackColumnsAt: 'tablet',
+          },
+        },
+        responsiveStyles: {
+          large: {
+            position: 'relative',
+            flexShrink: '0',
+            boxSizing: 'border-box',
+            marginTop: '20px',
+            paddingBottom: '30px',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'stretch',
+          },
+        },
+      },
+    ],
+  },
+};

--- a/packages/sdks-tests/src/specs/index.ts
+++ b/packages/sdks-tests/src/specs/index.ts
@@ -53,6 +53,7 @@ import { ACCORDION, ACCORDION_GRID, ACCORDION_ONE_AT_A_TIME } from './accordion.
 import { SYMBOL_TRACKING } from './symbol-tracking.js';
 import { COLUMNS_WITH_DIFFERENT_WIDTHS } from './columns-with-different-widths.js';
 import { CUSTOM_COMPONENTS_MODELS_RESTRICTION } from './custom-components-models.js';
+import { EDITING_BOX_TO_COLUMN_INNER_LAYOUT } from './editing-columns-inner-layout.js';
 
 function isBrowser(): boolean {
   return typeof window !== 'undefined' && typeof document !== 'undefined';
@@ -122,6 +123,7 @@ const PAGES = {
   '/columns-with-different-widths': COLUMNS_WITH_DIFFERENT_WIDTHS,
   '/custom-components-models-show': CUSTOM_COMPONENTS_MODELS_RESTRICTION,
   '/custom-components-models-not-show': CUSTOM_COMPONENTS_MODELS_RESTRICTION,
+  '/editing-box-columns-inner-layout': EDITING_BOX_TO_COLUMN_INNER_LAYOUT,
 } as const;
 
 const apiVersionPathToProp = {

--- a/packages/sdks/e2e/react/src/App.tsx
+++ b/packages/sdks/e2e/react/src/App.tsx
@@ -36,12 +36,7 @@ function App() {
   const [props, setProps] = useState<any>(undefined);
 
   useEffect(() => {
-    getProps({
-      _processContentResult,
-      fetchOneEntry,
-      data: 'real',
-      apiKey: 'ad30f9a246614faaa6a03374f83554c9',
-    }).then(setProps);
+    getProps({ _processContentResult, fetchOneEntry }).then(setProps);
 
     if (window.location.pathname === '/data-preview') {
       const unsubscribe = subscribeToEditor('coffee', (content) =>

--- a/packages/sdks/src/components/block/block.lite.tsx
+++ b/packages/sdks/src/components/block/block.lite.tsx
@@ -7,6 +7,7 @@ import {
   useStore,
   useTarget,
 } from '@builder.io/mitosis';
+import { TARGET } from '../../constants/target.js';
 import type {
   BuilderContextInterface,
   RegisteredComponents,
@@ -166,7 +167,7 @@ export default function Block(props: BlockProps) {
         registeredComponents: props.registeredComponents,
         builderBlock: state.processedBlock,
         includeBlockProps: state.blockComponent?.noWrap === true,
-        isInteractive: !state.blockComponent?.isRSC,
+        isInteractive: !(state.blockComponent?.isRSC && TARGET === 'rsc'),
       };
     },
   });


### PR DESCRIPTION
## Description
`isRSC = true` makes Columns block a non-reactive element (`isInteractive = false`), this then is not able to get `interactiveElementProps` which contains `Wrapper` information. Updated it such that the `isInteractive` check is scoped to RSC SDK only.

Links:

[where `isInteractive` is false](https://github.com/sidmohanty11/builder/blob/fix/inner-layouts-columns-crash/packages/sdks/src/components/block/components/component-ref/component-ref.lite.tsx/#L48)

[`isInteractive = false` so we don't have access to Wrapper](https://github.com/sidmohanty11/builder/blob/fix/inner-layouts-columns-crash/packages/sdks/src/components/block/components/component-ref/component-ref.helpers.ts/#L57-L65)

**Jira**
https://builder-io.atlassian.net/browse/PLAN-76

**Loom**
https://www.loom.com/share/e7cbae3ca62b493e98b5179712754e62
