### PR TITLE
Feat: React Native SDK: Strict Style Mode

### DIFF
--- a/.changeset/real-mails-unite.md
+++ b/.changeset/real-mails-unite.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/sdk-react-native": patch
+---
+
+Feature: add `isStrictStyleMode` opt-in prop that will validate and ignore any style that does not work on React Native.

--- a/.changeset/real-mails-unite.md
+++ b/.changeset/real-mails-unite.md
@@ -1,5 +1,5 @@
 ---
-"@builder.io/sdk-react-native": patch
+'@builder.io/sdk-react-native': patch
 ---
 
-Feature: add `isStrictStyleMode` opt-in prop that will validate and ignore any style that does not work on React Native.
+Feature: add optional `isStrictStyleMode` prop to `<Content>` that will validate and ignore any style that does not work on React Native. The validation logic is identical to the one in the Visual Editor's "Strict React Native Styling" advanced setting.

--- a/.changeset/shy-spiders-travel.md
+++ b/.changeset/shy-spiders-travel.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/sdk-react-native': patch
+---
+
+Fix: gracefully handle css sanitization errors.

--- a/packages/sdks-tests/src/e2e-tests/react-native-styles.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/react-native-styles.spec.ts
@@ -1,0 +1,32 @@
+import { expect } from '@playwright/test';
+import { test } from '../helpers/index.js';
+
+test.describe.only('React Native Styles', () => {
+  test('Strict Style Mode ignores styles', async ({ page, sdk }) => {
+    test.skip(sdk !== 'reactNative', 'This is an RN SDK specific test');
+    await page.goto('/react-native-strict-style-mode');
+
+    const textHtmlElRoot = page.locator('[data-testid="html"]');
+    const textWrapper = page.locator('div').filter({ has: textHtmlElRoot });
+
+    // non-ignored style
+    await expect(textWrapper).toHaveCSS('borderColor', 'rgba(80, 227, 194, 1)');
+
+    // ignored style
+    await expect(textWrapper).toHaveCSS('borderRadius', '0px');
+  });
+
+  test('Strict Style Mode ignores styles', async ({ page, sdk }) => {
+    test.skip(sdk !== 'reactNative', 'This is an RN SDK specific test');
+    await page.goto('/react-native-strict-style-mode-disabled');
+
+    const textHtmlElRoot = page.locator('[data-testid="html"]');
+    const textWrapper = page.locator('div').filter({ has: textHtmlElRoot });
+
+    // non-ignored style
+    await expect(textWrapper).toHaveCSS('borderColor', 'rgba(80, 227, 194, 1)');
+
+    // style that would be ignored by `isStrictStyleMode` prop
+    await expect(textWrapper).toHaveCSS('borderRadius', '50%');
+  });
+});

--- a/packages/sdks-tests/src/e2e-tests/react-native-styles.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/react-native-styles.spec.ts
@@ -1,32 +1,30 @@
 import { expect } from '@playwright/test';
 import { test } from '../helpers/index.js';
 
-test.describe.only('React Native Styles', () => {
-  test('Strict Style Mode ignores styles', async ({ page, sdk }) => {
+test.describe('React Native - Strict Styles', () => {
+  test('enabled', async ({ page, sdk }) => {
     test.skip(sdk !== 'reactNative', 'This is an RN SDK specific test');
     await page.goto('/react-native-strict-style-mode');
 
-    const textHtmlElRoot = page.locator('[data-testid="html"]');
-    const textWrapper = page.locator('div').filter({ has: textHtmlElRoot });
+    const textWrapper = page.locator('div [data-testid="html"]').locator('..');
 
     // non-ignored style
-    await expect(textWrapper).toHaveCSS('borderColor', 'rgba(80, 227, 194, 1)');
+    await expect(textWrapper).toHaveCSS('border-color', 'rgb(80, 227, 194)');
 
     // ignored style
-    await expect(textWrapper).toHaveCSS('borderRadius', '0px');
+    await expect(textWrapper).toHaveCSS('border-radius', '0px');
   });
 
-  test('Strict Style Mode ignores styles', async ({ page, sdk }) => {
+  test('disabled', async ({ page, sdk }) => {
     test.skip(sdk !== 'reactNative', 'This is an RN SDK specific test');
     await page.goto('/react-native-strict-style-mode-disabled');
 
-    const textHtmlElRoot = page.locator('[data-testid="html"]');
-    const textWrapper = page.locator('div').filter({ has: textHtmlElRoot });
+    const textWrapper = page.locator('div [data-testid="html"]').locator('..');
 
     // non-ignored style
-    await expect(textWrapper).toHaveCSS('borderColor', 'rgba(80, 227, 194, 1)');
+    await expect(textWrapper).toHaveCSS('border-color', 'rgb(80, 227, 194)');
 
     // style that would be ignored by `isStrictStyleMode` prop
-    await expect(textWrapper).toHaveCSS('borderRadius', '50%');
+    await expect(textWrapper).toHaveCSS('border-radius', '50%');
   });
 });

--- a/packages/sdks-tests/src/specs/index.ts
+++ b/packages/sdks-tests/src/specs/index.ts
@@ -53,6 +53,7 @@ import { ACCORDION, ACCORDION_GRID, ACCORDION_ONE_AT_A_TIME } from './accordion.
 import { SYMBOL_TRACKING } from './symbol-tracking.js';
 import { COLUMNS_WITH_DIFFERENT_WIDTHS } from './columns-with-different-widths.js';
 import { CUSTOM_COMPONENTS_MODELS_RESTRICTION } from './custom-components-models.js';
+import { REACT_NATIVE_STRICT_STYLE_MODE_CONTENT } from './react-native-strict-style-mode.js';
 
 function isBrowser(): boolean {
   return typeof window !== 'undefined' && typeof document !== 'undefined';
@@ -81,6 +82,8 @@ const PAGES = {
   '/image-no-webp': imageNoWebp,
   '/data-bindings': dataBindings,
   '/data-binding-styles': dataBindingStyles,
+  '/react-native-strict-style-mode': REACT_NATIVE_STRICT_STYLE_MODE_CONTENT,
+  '/react-native-strict-style-mode-disabled': REACT_NATIVE_STRICT_STYLE_MODE_CONTENT,
   '/ab-test': abTest,
   '/ab-test-interactive': AB_TEST_INTERACTIVE,
   '/http-requests': HTTP_REQUESTS,
@@ -212,6 +215,11 @@ export const getProps = async (args: {
       // overrides page model below
       extraProps = {
         model: 'test-model',
+      };
+      break;
+    case '/react-native-strict-style-mode':
+      extraProps = {
+        isStrictStyleMode: true,
       };
       break;
     default:

--- a/packages/sdks-tests/src/specs/react-native-strict-style-mode.ts
+++ b/packages/sdks-tests/src/specs/react-native-strict-style-mode.ts
@@ -1,57 +1,19 @@
 export const REACT_NATIVE_STRICT_STYLE_MODE_CONTENT = {
   data: {
     themeId: false,
-    title: 'data-binding-styles',
+    title: 'test-rn-style',
+    newField3: 'testing',
     blocks: [
       {
         '@type': '@builder.io/sdk:Element',
         '@version': 2,
-        id: 'builder-53b3b3d1ab0e49e6b9645f0edb5cfa2c',
-        children: [
-          {
-            '@type': '@builder.io/sdk:Element',
-            '@version': 2,
-            bindings: { 'style.color': 'state.myTextColor' },
-            code: {
-              bindings: {
-                'style.color':
-                  '/**\n * Global objects available in custom action code:\n *\n * state - builder state object - learn about state https://www.builder.io/c/docs/guides/state-and-actions\n * context - builder context object - learn about context https://github.com/BuilderIO/builder/tree/main/packages/react#passing-data-and-functions-down\n * event - HTML Event - https://developer.mozilla.org/en-US/docs/Web/API/Event\n *\n * Learn more: https://www.builder.io/c/docs/guides/custom-code\n *\n */\nstate.myTextColor;\n',
-              },
-            },
-            id: 'builder-05cadf76ae1e4359aeb76b2b5e4febc4',
-            meta: {
-              bindingActions: {
-                style: {
-                  color: [
-                    {
-                      '@type': '@builder.io/core:Action',
-                      action: '@builder.io:customCode',
-                      options: {
-                        code: '/**\n * Global objects available in custom action code:\n *\n * state - builder state object - learn about state https://www.builder.io/c/docs/guides/state-and-actions\n * context - builder context object - learn about context https://github.com/BuilderIO/builder/tree/main/packages/react#passing-data-and-functions-down\n * event - HTML Event - https://developer.mozilla.org/en-US/docs/Web/API/Event\n *\n * Learn more: https://www.builder.io/c/docs/guides/custom-code\n *\n */\nstate.myTextColor',
-                      },
-                    },
-                  ],
-                },
-              },
-            },
-            component: {
-              name: 'Text',
-              options: { text: 'This text should be red...' },
-            },
-            responsiveStyles: {
-              large: {
-                display: 'flex',
-                flexDirection: 'column',
-                position: 'relative',
-                flexShrink: '0',
-                boxSizing: 'border-box',
-                marginTop: '20px',
-                lineHeight: 'normal',
-                height: 'auto',
-              },
-            },
+        id: 'builder-6d7499351c7b402bb343a2b1492c6573',
+        component: {
+          name: 'Text',
+          options: {
+            text: '<span style="display: block;" class="builder-paragraph">hello world</span>',
           },
-        ],
+        },
         responsiveStyles: {
           large: {
             display: 'flex',
@@ -59,15 +21,23 @@ export const REACT_NATIVE_STRICT_STYLE_MODE_CONTENT = {
             position: 'relative',
             flexShrink: '0',
             boxSizing: 'border-box',
-            marginTop: '20px',
+            marginTop: '20p',
+            lineHeight: 'normal',
             height: 'auto',
-            paddingBottom: '30px',
+          },
+          small: {
+            width: '65%',
+            marginLeft: 'auto',
+            marginRight: 'auto',
+            borderRadius: '50%',
+            borderWidth: '4px',
+            borderStyle: 'solid',
+            color: 'rgba(255, 27, 27, 1)',
+            borderColor: 'rgba(80, 227, 194, 1)',
           },
         },
       },
     ],
-    state: {
-      myTextColor: 'red',
-    },
+    inputs: [],
   },
 };

--- a/packages/sdks-tests/src/specs/react-native-strict-style-mode.ts
+++ b/packages/sdks-tests/src/specs/react-native-strict-style-mode.ts
@@ -1,0 +1,73 @@
+export const REACT_NATIVE_STRICT_STYLE_MODE_CONTENT = {
+  data: {
+    themeId: false,
+    title: 'data-binding-styles',
+    blocks: [
+      {
+        '@type': '@builder.io/sdk:Element',
+        '@version': 2,
+        id: 'builder-53b3b3d1ab0e49e6b9645f0edb5cfa2c',
+        children: [
+          {
+            '@type': '@builder.io/sdk:Element',
+            '@version': 2,
+            bindings: { 'style.color': 'state.myTextColor' },
+            code: {
+              bindings: {
+                'style.color':
+                  '/**\n * Global objects available in custom action code:\n *\n * state - builder state object - learn about state https://www.builder.io/c/docs/guides/state-and-actions\n * context - builder context object - learn about context https://github.com/BuilderIO/builder/tree/main/packages/react#passing-data-and-functions-down\n * event - HTML Event - https://developer.mozilla.org/en-US/docs/Web/API/Event\n *\n * Learn more: https://www.builder.io/c/docs/guides/custom-code\n *\n */\nstate.myTextColor;\n',
+              },
+            },
+            id: 'builder-05cadf76ae1e4359aeb76b2b5e4febc4',
+            meta: {
+              bindingActions: {
+                style: {
+                  color: [
+                    {
+                      '@type': '@builder.io/core:Action',
+                      action: '@builder.io:customCode',
+                      options: {
+                        code: '/**\n * Global objects available in custom action code:\n *\n * state - builder state object - learn about state https://www.builder.io/c/docs/guides/state-and-actions\n * context - builder context object - learn about context https://github.com/BuilderIO/builder/tree/main/packages/react#passing-data-and-functions-down\n * event - HTML Event - https://developer.mozilla.org/en-US/docs/Web/API/Event\n *\n * Learn more: https://www.builder.io/c/docs/guides/custom-code\n *\n */\nstate.myTextColor',
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+            component: {
+              name: 'Text',
+              options: { text: 'This text should be red...' },
+            },
+            responsiveStyles: {
+              large: {
+                display: 'flex',
+                flexDirection: 'column',
+                position: 'relative',
+                flexShrink: '0',
+                boxSizing: 'border-box',
+                marginTop: '20px',
+                lineHeight: 'normal',
+                height: 'auto',
+              },
+            },
+          },
+        ],
+        responsiveStyles: {
+          large: {
+            display: 'flex',
+            flexDirection: 'column',
+            position: 'relative',
+            flexShrink: '0',
+            boxSizing: 'border-box',
+            marginTop: '20px',
+            height: 'auto',
+            paddingBottom: '30px',
+          },
+        },
+      },
+    ],
+    state: {
+      myTextColor: 'red',
+    },
+  },
+};

--- a/packages/sdks/mitosis.config.cjs
+++ b/packages/sdks/mitosis.config.cjs
@@ -144,6 +144,25 @@ const targets = target
       'angular',
     ];
 
+/**
+ * @type {Plugin}
+ */
+const ADD_IS_STRICT_STYLE_MODE_TO_CONTEXT_PLUGIN = () => ({
+  json: {
+    pre: (json) => {
+      if (json.name !== 'ContentComponent') return json;
+
+      json.state.builderContextSignal.code =
+        json.state.builderContextSignal.code.replace(
+          /^\s*{/,
+          '{isStrictStyleMode: props.isStrictStyleMode,'
+        );
+
+      return json;
+    },
+  },
+});
+
 const INJECT_ENABLE_EDITOR_ON_EVENT_HOOKS_PLUGIN = () => ({
   json: {
     pre: (json) => {
@@ -695,6 +714,7 @@ module.exports = {
         BASE_TEXT_PLUGIN,
         INJECT_ENABLE_EDITOR_ON_EVENT_HOOKS_PLUGIN,
         REMOVE_SET_CONTEXT_PLUGIN_FOR_FORM,
+        ADD_IS_STRICT_STYLE_MODE_TO_CONTEXT_PLUGIN,
         () => ({
           json: {
             pre: (json) => {

--- a/packages/sdks/overrides/react-native/src/components/content-variants/extra-framework-props-types.ts
+++ b/packages/sdks/overrides/react-native/src/components/content-variants/extra-framework-props-types.ts
@@ -1,0 +1,6 @@
+export interface ExtraFrameworkProps {
+  /**
+   * A strict style mode that will ignore any style properties that are not supported by the React Native style engine.
+   */
+  isStrictStyleMode?: boolean;
+}

--- a/packages/sdks/overrides/react-native/src/context/extra-context-types.ts
+++ b/packages/sdks/overrides/react-native/src/context/extra-context-types.ts
@@ -1,0 +1,3 @@
+export interface ExtraContextTypes {
+  isStrictStyleMode: boolean;
+}

--- a/packages/sdks/src/components/content-variants/content-variants.lite.tsx
+++ b/packages/sdks/src/components/content-variants/content-variants.lite.tsx
@@ -127,6 +127,12 @@ export default function ContentVariants(props: VariantsProviderProps) {
               contentWrapper={props.contentWrapper}
               contentWrapperProps={props.contentWrapperProps}
               trustedHosts={props.trustedHosts}
+              {...useTarget({
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-expect-error
+                reactNative: { isStrictStyleMode: props.isStrictStyleMode },
+                default: {},
+              })}
             />
           )}
         </For>
@@ -136,6 +142,9 @@ export default function ContentVariants(props: VariantsProviderProps) {
         isNestedRender={props.isNestedRender}
         {...useTarget({
           vue: { key: state.shouldRenderVariants.toString() },
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-expect-error
+          reactNative: { isStrictStyleMode: props.isStrictStyleMode },
           default: {},
         })}
         content={state.defaultContent}

--- a/packages/sdks/src/components/content-variants/content-variants.types.ts
+++ b/packages/sdks/src/components/content-variants/content-variants.types.ts
@@ -5,8 +5,9 @@ import type {
 import type { ApiVersion } from '../../types/api-version.js';
 import type { BuilderContent } from '../../types/builder-content.js';
 import type { Nullable } from '../../types/typescript.js';
+import type { ExtraFrameworkProps } from './extra-framework-props-types.js';
 
-export interface ContentVariantsPrps {
+export interface ContentVariantsPrps extends ExtraFrameworkProps {
   /**
    * The Builder content JSON to render (required).
    */

--- a/packages/sdks/src/components/content-variants/extra-framework-props-types.ts
+++ b/packages/sdks/src/components/content-variants/extra-framework-props-types.ts
@@ -1,0 +1,1 @@
+export interface ExtraFrameworkProps {}

--- a/packages/sdks/src/components/content/content.lite.tsx
+++ b/packages/sdks/src/components/content/content.lite.tsx
@@ -152,8 +152,13 @@ export default function ContentComponent(props: ContentProps) {
       {...useTarget({
         // eslint-disable-next-line object-shorthand
         react: { setBuilderContextSignal: setBuilderContextSignal },
-        // eslint-disable-next-line object-shorthand
-        reactNative: { setBuilderContextSignal: setBuilderContextSignal },
+        reactNative: {
+          // eslint-disable-next-line object-shorthand
+          setBuilderContextSignal: setBuilderContextSignal,
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          isStrictStyleMode: props.isStrictStyleMode,
+        },
         // eslint-disable-next-line object-shorthand
         solid: { setBuilderContextSignal: setBuilderContextSignal },
         default: {},

--- a/packages/sdks/src/context/extra-context-types.ts
+++ b/packages/sdks/src/context/extra-context-types.ts
@@ -1,0 +1,5 @@
+/**
+ * no-op type for extra context types on a per-SDK basis
+ * See `overrides/react-native/src/context/extra-context-types.ts` for an example
+ * */
+export interface ExtraContextTypes {}

--- a/packages/sdks/src/context/types.ts
+++ b/packages/sdks/src/context/types.ts
@@ -3,6 +3,7 @@ import type { ApiVersion } from '../types/api-version.js';
 import type { BuilderContent } from '../types/builder-content.js';
 import type { ComponentInfo } from '../types/components.js';
 import type { Dictionary, Nullable } from '../types/typescript.js';
+import type { ExtraContextTypes } from './extra-context-types.js';
 
 export type RegisteredComponent = ComponentInfo & {
   component: any;
@@ -15,7 +16,8 @@ export type BuilderRenderState = Record<string, unknown>;
 export type BuilderRenderContext = Record<string, unknown>;
 
 export interface BuilderContextInterface
-  extends Pick<BlocksWrapperProps, 'BlocksWrapper' | 'BlocksWrapperProps'> {
+  extends Pick<BlocksWrapperProps, 'BlocksWrapper' | 'BlocksWrapperProps'>,
+    ExtraContextTypes {
   content: Nullable<BuilderContent>;
   context: BuilderRenderContext;
   /**


### PR DESCRIPTION
## Description

React Native:

- Feature: add optional `isStrictStyleMode` prop to `<Content>` that will validate and ignore any style that does not work on React Native. The validation logic is identical to the one in the Visual Editor's "Strict React Native Styling" advanced setting.
- Fix: gracefully handle css sanitization errors.