### PR TITLE
fix[qwik-gen2]: export `initializeNodeRuntime` for qwik SDK

### DIFF
--- a/.changeset/grumpy-poets-applaud.md
+++ b/.changeset/grumpy-poets-applaud.md
@@ -1,0 +1,25 @@
+---
+'@builder.io/sdk-qwik': patch
+---
+
+Feature: add `@builder.io/sdk-qwik/node/init` entry point with `initializeNodeRuntime` export that sets the IVM instance.
+
+This import should be called in a server-only location such as,
+
+```tsx
+// entry.ssr.tsx
+import { renderToStream, type RenderToStreamOptions } from '@builder.io/qwik/server';
+import { manifest } from '@qwik-client-manifest';
+import Root from './root';
+import { initializeNodeRuntime } from '@builder.io/sdk-qwik/node/init';
+
+initializeNodeRuntime();
+
+export default function (opts: RenderToStreamOptions) {
+  return renderToStream(<Root />, {
+    manifest,
+    ...opts,
+    // ...
+  });
+}
+```

--- a/packages/sdks/output/qwik/package.json
+++ b/packages/sdks/output/qwik/package.json
@@ -78,6 +78,11 @@
         "require": "./lib/browser/index.qwik.cjs"
       }
     },
+    "./node/init": {
+      "types": "./types/functions/evaluate/node-runtime/init.d.ts",
+      "import": "./lib/node/functions/evaluate/node-runtime/init.qwik.mjs",
+      "require": "./lib/node/functions/evaluate/node-runtime/init.qwik.cjs"
+    },
     "./bundle/edge": {
       "types": "./types/src/index.d.ts",
       "import": "./lib/edge/index.qwik.mjs",

--- a/packages/sdks/output/qwik/package.json
+++ b/packages/sdks/output/qwik/package.json
@@ -79,7 +79,7 @@
       }
     },
     "./node/init": {
-      "types": "./types/functions/evaluate/node-runtime/init.d.ts",
+      "types": "./types/src/functions/evaluate/node-runtime/init.d.ts",
       "import": "./lib/node/functions/evaluate/node-runtime/init.qwik.mjs",
       "require": "./lib/node/functions/evaluate/node-runtime/init.qwik.cjs"
     },

--- a/packages/sdks/output/qwik/vite.config.ts
+++ b/packages/sdks/output/qwik/vite.config.ts
@@ -11,19 +11,14 @@ export default defineConfig(() => {
         /**
          * https://github.com/BuilderIO/qwik/issues/4952
          */
-        fileName: (format) => `index.qwik.${format === 'es' ? 'mjs' : 'cjs'}`,
+        fileName: (format, entryName) => `${entryName}.qwik.${format === 'es' ? 'mjs' : 'cjs'}`,
       },
       rollupOptions: {
-        external: ['@builder.io/qwik', 'node:module'],
+        external: ['@builder.io/qwik', 'node:module', 'isolated-vm'],
+        input: ['./src/index.ts', './src/functions/evaluate/node-runtime/init.ts'],
         output: {
-          manualChunks(id, { getModuleIds, getModuleInfo }) {
-            const moduleInfo = getModuleInfo(id);
-
-            // We need to move this node-only code to its own file so that `isServer` can tree-shake it.
-            if (moduleInfo?.code?.includes('node:module')) {
-              return 'node-evaluate';
-            }
-          },
+          preserveModules: true,
+          preserveModulesRoot: 'src',
         },
       },
     },

--- a/packages/sdks/src/functions/evaluate/node-runtime/init.ts
+++ b/packages/sdks/src/functions/evaluate/node-runtime/init.ts
@@ -23,6 +23,7 @@ import type { IsolateOptions } from 'isolated-vm';
  * from a server-only location, such as:
  * - The NextJS Pages router's `_document.tsx`
  * - Your Remix route's `loader`
+ * - Qwik's `entry.ssr.tsx` file
  */
 export const initializeNodeRuntime = (args?: {
   ivmIsolateOptions?: IsolateOptions;

--- a/packages/sdks/src/functions/evaluate/node-runtime/node-runtime.ts
+++ b/packages/sdks/src/functions/evaluate/node-runtime/node-runtime.ts
@@ -94,7 +94,8 @@ export const setIvm = (ivm: IsolatedVMImport, options: IsolateOptions = {}) => {
 // only mention the script for SDKs that have it.
 const SHOULD_MENTION_INITIALIZE_SCRIPT =
   SDK_NAME === '@builder.io/sdk-react-nextjs' ||
-  SDK_NAME === '@builder.io/sdk-react';
+  SDK_NAME === '@builder.io/sdk-react' ||
+  SDK_NAME === '@builder.io/sdk-qwik';
 
 const getIvm = (): IsolatedVMImport => {
   try {
@@ -110,7 +111,7 @@ const getIvm = (): IsolatedVMImport => {
     
     SOLUTION: In a server-only execution path within your application, do one of the following:
   
-    ${SHOULD_MENTION_INITIALIZE_SCRIPT ? '- import and call `initializeNodeRuntime()` from "${SDK_NAME}/node/init".' : ''}
+    ${SHOULD_MENTION_INITIALIZE_SCRIPT ? `- import and call \`initializeNodeRuntime()\` from "${SDK_NAME}/node/init".` : ''}
     - add the following import: \`await import('isolated-vm')\`.
 
     For more information, visit https://builder.io/c/docs/integration-tips#enabling-data-bindings-in-node-environments`;


### PR DESCRIPTION
## Description

Exports `initializeNodeRuntime` in Qwik SDK so that customers can import this in a server-side only call to correctly import and initialize `isolated-vm` and handle bindings correctly.

**Jira**
https://builder-io.atlassian.net/browse/ENG-6287

_Screenshot_
Build structure now:
![Screenshot 2024-09-04 at 12 03 24 PM](https://github.com/user-attachments/assets/f4feafda-4010-408d-b4e3-b3bd98b620a7)

