### PR TITLE
fix: update `package.json` to not consider next and other frameworks as deps

### DIFF
--- a/packages/widgets/package-lock.json
+++ b/packages/widgets/package-lock.json
@@ -66,17 +66,32 @@
       "engines": {
         "node": ">=10.0.0"
       },
-      "optionalDependencies": {
+      "peerDependencies": {
+        "@builder.io/react": ">=1.1.0",
         "next": ">=12.1.0",
         "preact": "^8.4.2",
         "preact-compat": "^3.18.4",
         "preact-context": "^1.1.3",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "@builder.io/react": ">=1.1.0",
+        "prop-types": "^15.7.2",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "next": {
+          "optional": true
+        },
+        "preact": {
+          "optional": true
+        },
+        "preact-compat": {
+          "optional": true
+        },
+        "preact-context": {
+          "optional": true
+        },
+        "prop-types": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -9159,15 +9174,6 @@
         "ev-emitter": "^1.0.0"
       }
     },
-    "node_modules/immutability-helper": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.9.1.tgz",
-      "integrity": "sha512-r/RmRG8xO06s/k+PIaif2r5rGc3j4Yhc01jSBfwPCXDLYZwp/yxralI37Df1mwmuzcCsen/E/ITKcTEvc1PQmQ==",
-      "optional": true,
-      "dependencies": {
-        "invariant": "^2.2.0"
-      }
-    },
     "node_modules/import-fresh": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
@@ -9333,7 +9339,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -16474,60 +16480,6 @@
         "url": "https://opencollective.com/postcss/"
       }
     },
-    "node_modules/preact": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-8.5.3.tgz",
-      "integrity": "sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw==",
-      "hasInstallScript": true,
-      "optional": true
-    },
-    "node_modules/preact-compat": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/preact-compat/-/preact-compat-3.19.0.tgz",
-      "integrity": "sha512-f83A4hIhH8Uzhb9GbIcGk8SM19ffWlwP9mDaYwQdRnMdekZwcCA7eIAbeV4EMQaV9C0Yuy8iKgBAtyTKPZQt/Q==",
-      "optional": true,
-      "dependencies": {
-        "immutability-helper": "^2.7.1",
-        "preact-context": "^1.1.3",
-        "preact-render-to-string": "^3.8.2",
-        "preact-transition-group": "^1.1.1",
-        "prop-types": "^15.6.2",
-        "standalone-react-addons-pure-render-mixin": "^0.1.1"
-      },
-      "peerDependencies": {
-        "preact": "<10"
-      }
-    },
-    "node_modules/preact-context": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/preact-context/-/preact-context-1.1.4.tgz",
-      "integrity": "sha512-gcCjPJ65R0MiW9hDu8W/3WAmyTElIvwLyEO6oLQiM6/TbLKLxCpBCWV8GJjx52TTEyUr60HLDcmoCXZlslelzQ==",
-      "optional": true,
-      "peerDependencies": {
-        "preact": "^8.2.7"
-      }
-    },
-    "node_modules/preact-render-to-string": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-3.8.2.tgz",
-      "integrity": "sha512-przuZPajiurStGgxMoJP0EJeC4xj5CgHv+M7GfF3YxAdhGgEWAkhOSE0xympAFN20uMayntBZpttIZqqLl77fw==",
-      "optional": true,
-      "dependencies": {
-        "pretty-format": "^3.5.1"
-      },
-      "peerDependencies": {
-        "preact": "*"
-      }
-    },
-    "node_modules/preact-transition-group": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/preact-transition-group/-/preact-transition-group-1.1.1.tgz",
-      "integrity": "sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA=",
-      "optional": true,
-      "peerDependencies": {
-        "preact": "*"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -16557,12 +16509,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/pretty-format": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-      "integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=",
-      "optional": true
     },
     "node_modules/private": {
       "version": "0.1.8",
@@ -16745,6 +16691,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -16756,6 +16703,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -18534,6 +18482,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -19743,12 +19692,6 @@
       "bin": {
         "sgf": "bin/cli.js"
       }
-    },
-    "node_modules/standalone-react-addons-pure-render-mixin": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/standalone-react-addons-pure-render-mixin/-/standalone-react-addons-pure-render-mixin-0.1.1.tgz",
-      "integrity": "sha1-PHQJ9MecQN6axyxhbPZ5qZTzdVE=",
-      "optional": true
     },
     "node_modules/static-extend": {
       "version": "0.1.2",
@@ -21821,8 +21764,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "6.2.0",
@@ -28364,15 +28306,6 @@
         "ev-emitter": "^1.0.0"
       }
     },
-    "immutability-helper": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.9.1.tgz",
-      "integrity": "sha512-r/RmRG8xO06s/k+PIaif2r5rGc3j4Yhc01jSBfwPCXDLYZwp/yxralI37Df1mwmuzcCsen/E/ITKcTEvc1PQmQ==",
-      "optional": true,
-      "requires": {
-        "invariant": "^2.2.0"
-      }
-    },
     "import-fresh": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
@@ -28501,7 +28434,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -34027,49 +33960,6 @@
         "source-map-js": "^1.0.1"
       }
     },
-    "preact": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-8.5.3.tgz",
-      "integrity": "sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw==",
-      "optional": true
-    },
-    "preact-compat": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/preact-compat/-/preact-compat-3.19.0.tgz",
-      "integrity": "sha512-f83A4hIhH8Uzhb9GbIcGk8SM19ffWlwP9mDaYwQdRnMdekZwcCA7eIAbeV4EMQaV9C0Yuy8iKgBAtyTKPZQt/Q==",
-      "optional": true,
-      "requires": {
-        "immutability-helper": "^2.7.1",
-        "preact-context": "^1.1.3",
-        "preact-render-to-string": "^3.8.2",
-        "preact-transition-group": "^1.1.1",
-        "prop-types": "^15.6.2",
-        "standalone-react-addons-pure-render-mixin": "^0.1.1"
-      }
-    },
-    "preact-context": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/preact-context/-/preact-context-1.1.4.tgz",
-      "integrity": "sha512-gcCjPJ65R0MiW9hDu8W/3WAmyTElIvwLyEO6oLQiM6/TbLKLxCpBCWV8GJjx52TTEyUr60HLDcmoCXZlslelzQ==",
-      "optional": true,
-      "requires": {}
-    },
-    "preact-render-to-string": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-3.8.2.tgz",
-      "integrity": "sha512-przuZPajiurStGgxMoJP0EJeC4xj5CgHv+M7GfF3YxAdhGgEWAkhOSE0xympAFN20uMayntBZpttIZqqLl77fw==",
-      "optional": true,
-      "requires": {
-        "pretty-format": "^3.5.1"
-      }
-    },
-    "preact-transition-group": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/preact-transition-group/-/preact-transition-group-1.1.1.tgz",
-      "integrity": "sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA=",
-      "optional": true,
-      "requires": {}
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -34087,12 +33977,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
       "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
-    },
-    "pretty-format": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-      "integrity": "sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=",
-      "optional": true
     },
     "private": {
       "version": "0.1.8",
@@ -34229,6 +34113,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -34237,6 +34122,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -35654,6 +35540,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -36580,12 +36467,6 @@
       "integrity": "sha512-H89UNKr1rQJvI1c/PIR3kiAMBV23yvR7LItZiV74HWZwzt7f3YHuujJ9nJZlt58WlFox7XQsOahexwk7nTe69A==",
       "dev": true
     },
-    "standalone-react-addons-pure-render-mixin": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/standalone-react-addons-pure-render-mixin/-/standalone-react-addons-pure-render-mixin-0.1.1.tgz",
-      "integrity": "sha1-PHQJ9MecQN6axyxhbPZ5qZTzdVE=",
-      "optional": true
-    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -36758,8 +36639,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.0.tgz",
       "integrity": "sha512-qUqsWoBquEdERe10EW8vLp3jT25s/ssG1/qX5gZ4wu15OZpmSMFI2v+fWlRhLfykA5rFtlJ1ME8A8pm/peV4WA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "subarg": {
       "version": "1.0.0",

--- a/packages/widgets/package-lock.json
+++ b/packages/widgets/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/widgets",
-  "version": "1.2.24",
+  "version": "1.2.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/widgets",
-      "version": "1.2.24",
+      "version": "1.2.25",
       "license": "MIT",
       "dependencies": {
         "@emotion/core": ">=10",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -129,17 +129,32 @@
     "react": "^17.0.2 || ^18.0.0-0",
     "react-dom": "^17.0.2 || ^18.0.0-0"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "preact": "^8.4.2",
     "preact-compat": "^3.18.4",
     "preact-context": "^1.1.3",
     "prop-types": "^15.7.2",
-    "next": ">=12.1.0"
-  },
-  "peerDependencies": {
+    "next": ">=12.1.0",
     "@builder.io/react": ">=1.1.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
+  },
+  "peerDependenciesMeta": {
+    "preact": {
+      "optional": true
+    },
+    "preact-compat": {
+      "optional": true
+    },
+    "preact-context": {
+      "optional": true
+    },
+    "prop-types": {
+      "optional": true
+    },
+    "next": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@emotion/core": ">=10",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/widgets",
-  "version": "1.2.24",
+  "version": "1.2.25",
   "description": "",
   "keywords": [],
   "main": "dist/builder-widgets.cjs.js",


### PR DESCRIPTION
## Description

we wanted to set a framework as an optional peer dep but we added it to `optionalDependencies` which automatically added it as a dep for our widgets package

https://stackoverflow.com/questions/62047806/how-do-i-set-a-peer-dependency-optional

Dev release: https://www.npmjs.com/package/@builder.io/widgets/v/1.2.25-0?activeTab=dependencies
Current release: https://www.npmjs.com/package/@builder.io/widgets/v/1.2.24?activeTab=dependencies

**Loom**
https://www.loom.com/share/b89d3690c1fe400aaf690ec2b72a1376

**Jira**
https://builder-io.atlassian.net/browse/ENG-6589

TODO:
- [x] release `v1.2.25` after approval
- [x] update lock and commit
