### PR TITLE
fix[resourcePicker][SFCC]: Initialization bug for Picker Modal when Targeting Multi Select input types

### DIFF
--- a/packages/plugin-tools/package-lock.json
+++ b/packages/plugin-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/plugin-tools",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-tools",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/packages/plugin-tools/package.json
+++ b/packages/plugin-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-tools",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "",
   "keywords": [],
   "main": "dist/index.umd.js",

--- a/packages/plugin-tools/src/commerce.tsx
+++ b/packages/plugin-tools/src/commerce.tsx
@@ -52,7 +52,7 @@ export const registerCommercePlugin = async (
       const contextProps = {
         resourceName,
         pluginId: config.id,
-        plulginName: config.name,
+        pluginName: config.name,
         api: apiOperations,
       };
       Builder.register('editor.onLoad', onEditorLoad(config, apiOperations, resourceName));

--- a/packages/plugin-tools/src/editors/ResourcesList.tsx
+++ b/packages/plugin-tools/src/editors/ResourcesList.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React, { useEffect } from 'react';
-import { action } from 'mobx';
+import { action, toJS } from 'mobx';
 import { useObserver, useLocalStore } from 'mobx-react';
 import {
   ResourcePreviewCell,
@@ -69,7 +69,7 @@ const ResourcePreviewById = (
 
 export function PickResourceList(props: PickResourceListProps) {
   const store = useLocalStore(() => ({
-    value: props.value || [], // initialize it directly
+    value: props.value || [],
   }));
 
 
@@ -136,10 +136,12 @@ export function PickResourceList(props: PickResourceListProps) {
                 omitIds={store.value}
                 onChange={action(resource => {
                   if (resource) {
-                    if(store.value){
-                      store.value.push(String(resource.id));
+                    if (!Array.isArray(store.value)) {
+                      store.value = [];
                     }
+                    store.value.push(String(resource.id));
                     props.onChange(store.value);
+                    
                   }
                   close();
                 })}

--- a/packages/plugin-tools/src/editors/ResourcesList.tsx
+++ b/packages/plugin-tools/src/editors/ResourcesList.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import React, { useEffect } from 'react';
-import { action, toJS } from 'mobx';
+import { action } from 'mobx';
 import { useObserver, useLocalStore } from 'mobx-react';
 import {
   ResourcePreviewCell,

--- a/packages/plugin-tools/src/editors/ResourcesList.tsx
+++ b/packages/plugin-tools/src/editors/ResourcesList.tsx
@@ -69,10 +69,10 @@ const ResourcePreviewById = (
 
 export function PickResourceList(props: PickResourceListProps) {
   const store = useLocalStore(() => ({
-    get value() {
-      return props.value || [];
-    },
+    value: props.value || [], // initialize it directly
   }));
+
+
   return useObserver(() => {
     return (
       <React.Fragment>
@@ -107,9 +107,10 @@ export function PickResourceList(props: PickResourceListProps) {
                   }}
                   onClick={() => {
                     const res = [
-                      ...props.value!.slice(0, props.value!.indexOf(item)),
-                      ...props.value!.slice(props.value!.indexOf(item) + 1),
+                      ...store.value!.slice(0, store.value!.indexOf(item)),
+                      ...store.value!.slice(store.value!.indexOf(item) + 1),
                     ];
+                    store.value=res;
                     props.onChange(res);
                   }}
                 >
@@ -135,7 +136,10 @@ export function PickResourceList(props: PickResourceListProps) {
                 omitIds={store.value}
                 onChange={action(resource => {
                   if (resource) {
-                    props.onChange([...(store.value || []), String(resource.id)]);
+                    if(store.value){
+                      store.value.push(String(resource.id));
+                    }
+                    props.onChange(store.value);
                   }
                   close();
                 })}

--- a/plugins/salesforce-commerce-api-plugin/package-lock.json
+++ b/plugins/salesforce-commerce-api-plugin/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@builder.io/plugin-sfcc-commerce-api",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-sfcc-commerce-api",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "MIT",
       "dependencies": {
-        "@builder.io/plugin-tools": "^0.0.3",
+        "@builder.io/plugin-tools": "0.0.4",
         "commerce-sdk-isomorphic": "2.1.0"
       },
       "devDependencies": {
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@builder.io/plugin-tools": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@builder.io/plugin-tools/-/plugin-tools-0.0.3.tgz",
-      "integrity": "sha512-YoRHFxR7b/PfucuuVYW7rXUODP3mB/6LhYaU/3C11pQN5+KDmko9JjlN4JWQbZJPGPdH59gR9KPEkASgf6gzsA==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@builder.io/plugin-tools/-/plugin-tools-0.0.4.tgz",
+      "integrity": "sha512-HHEw+u+2eUcezEqGUYCH874MBC0OLd1KLSGfTPd2iKMTmJAGZNKQiLyZHI1/y6ftWSM/yQ+g32tfCz5O2PqWqg==",
       "dependencies": {
         "lodash": "^4.17.21",
         "pluralize": "^8.0.0"
@@ -5500,9 +5500,9 @@
   },
   "dependencies": {
     "@builder.io/plugin-tools": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@builder.io/plugin-tools/-/plugin-tools-0.0.3.tgz",
-      "integrity": "sha512-YoRHFxR7b/PfucuuVYW7rXUODP3mB/6LhYaU/3C11pQN5+KDmko9JjlN4JWQbZJPGPdH59gR9KPEkASgf6gzsA==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@builder.io/plugin-tools/-/plugin-tools-0.0.4.tgz",
+      "integrity": "sha512-HHEw+u+2eUcezEqGUYCH874MBC0OLd1KLSGfTPd2iKMTmJAGZNKQiLyZHI1/y6ftWSM/yQ+g32tfCz5O2PqWqg==",
       "requires": {
         "lodash": "^4.17.21",
         "pluralize": "^8.0.0"

--- a/plugins/salesforce-commerce-api-plugin/package-lock.json
+++ b/plugins/salesforce-commerce-api-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/plugin-sfcc-commerce-api",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-sfcc-commerce-api",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "license": "MIT",
       "dependencies": {
         "@builder.io/plugin-tools": "0.0.4",

--- a/plugins/salesforce-commerce-api-plugin/package.json
+++ b/plugins/salesforce-commerce-api-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-sfcc-commerce-api",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "",
   "keywords": [],
   "main": "dist/plugin.system.js",

--- a/plugins/salesforce-commerce-api-plugin/package.json
+++ b/plugins/salesforce-commerce-api-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-sfcc-commerce-api",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "",
   "keywords": [],
   "main": "dist/plugin.system.js",
@@ -52,7 +52,7 @@
     "typescript": "^3.0.3"
   },
   "dependencies": {
-    "@builder.io/plugin-tools": "^0.0.3",
+    "@builder.io/plugin-tools": "^0.0.4",
     "commerce-sdk-isomorphic": "2.1.0"
   }
 }


### PR DESCRIPTION
## Description

The multi-select pickers for SF Commerce Products and SF Commerce Categories do not update properly when selecting an item for the first time (coming from an empty targeting menu). This does not happen when using this input type as a data model input. 

Once the array has data in it, reopening the picker works as expected, and any additions / removals are instantly updated in the UI.

**Loom**
https://www.loom.com/share/9278b07dac9549699213c4653ee8bbd3
