### PR TITLE
fix[widgets]: SUPP-653 extra inline-block styles getting applied

### DIFF
--- a/packages/widgets/src/components/Carousel.tsx
+++ b/packages/widgets/src/components/Carousel.tsx
@@ -195,13 +195,14 @@ export class CarouselComponent extends React.Component<CarouselProps> {
                         this.props.slides.map((slide, index) => (
                           // TODO: how make react compatible with plain react components
                           // slides: <Foo><Bar> <- builder blocks if passed react nodes as blocks just forward them
-                          <BuilderBlocks
-                            key={index}
-                            parentElementId={this.props.builderBlock && this.props.builderBlock.id}
-                            dataPath={`component.options.slides.${index}.content`}
-                            child
-                            blocks={(slide as any).content || slide}
-                          />
+                          <React.Fragment key={index}>
+                            <BuilderBlocks
+                              parentElementId={this.props.builderBlock && this.props.builderBlock.id}
+                              dataPath={`component.options.slides.${index}.content`}
+                              child
+                              blocks={(slide as any).content || slide}
+                            />
+                          </React.Fragment>
                         ))}
                   </Slider>
                 </div>


### PR DESCRIPTION
## Description
React Slick applies extra styles - inline-block and width: 100% to each item. By wrapping them in a fragment, no extra styles are applied.

Ref: https://github.com/akiran/react-slick/issues/1378#issuecomment-636649924

Jira
https://builder-io.atlassian.net/browse/SUPP-653

Loom
https://www.loom.com/share/a486a37834d246eaaa84b40ff39468ae
