### PR TITLE
fix: support for bundler mode

### DIFF
--- a/.changeset/tough-lamps-joke.md
+++ b/.changeset/tough-lamps-joke.md
@@ -1,0 +1,9 @@
+---
+"@builder.io/sdk-angular": patch
+"@builder.io/sdk-react-nextjs": patch
+"@builder.io/sdk-qwik": patch
+"@builder.io/sdk-react": patch
+"@builder.io/sdk-svelte": patch
+---
+
+Fix: add `types` `exports` key to fix TS types support for projects in `bundler` mode.

--- a/packages/sdks/output/angular/package.json
+++ b/packages/sdks/output/angular/package.json
@@ -95,7 +95,8 @@
         "esm": "./lib/browser/esm2022/builder.io-sdk-angular.mjs",
         "types": "./lib/browser/index.d.ts",
         "default": "./lib/browser/fesm2022/builder.io-sdk-angular.mjs"
-      }
+      },
+      "types": "./lib/node/index.d.ts"
     }
   },
   "main": "lib/node/fesm2022/builder.io-sdk-angular.mjs",

--- a/packages/sdks/output/nextjs/package.json
+++ b/packages/sdks/output/nextjs/package.json
@@ -65,7 +65,8 @@
       "default": {
         "import": "./lib/browser/index.mjs",
         "require": "./lib/browser/index.cjs"
-      }
+      },
+      "types": "./types/index.d.ts"
     },
     "./node/init": {
       "types": "./types/esm/functions/evaluate/node-runtime/init.d.ts",

--- a/packages/sdks/output/qwik/package.json
+++ b/packages/sdks/output/qwik/package.json
@@ -76,7 +76,8 @@
         "types": "./types/src/index.d.ts",
         "import": "./lib/browser/index.qwik.mjs",
         "require": "./lib/browser/index.qwik.cjs"
-      }
+      },
+      "types": "./types/src/index.d.ts"
     },
     "./node/init": {
       "types": "./types/src/functions/evaluate/node-runtime/init.d.ts",

--- a/packages/sdks/output/react/package.json
+++ b/packages/sdks/output/react/package.json
@@ -77,7 +77,8 @@
         "types": "./types/index.d.ts",
         "import": "./lib/browser/index.mjs",
         "require": "./lib/browser/index.cjs"
-      }
+      },
+      "types": "./types/index.d.ts"
     },
     "./node/init": {
       "types": "./types/functions/evaluate/node-runtime/init.d.ts",

--- a/packages/sdks/output/svelte/package.json
+++ b/packages/sdks/output/svelte/package.json
@@ -29,7 +29,8 @@
       "edge-light": "./lib/edge/index.js",
       "bun": "./lib/edge/index.js",
       "electron": "./lib/node/index.js",
-      "default": "./lib/browser/index.js"
+      "default": "./lib/browser/index.js",
+      "types": "./lib/browser/index.d.ts"
     },
     "./bundle/edge": "./lib/edge/index.js",
     "./bundle/node": "./lib/node/index.js",


### PR DESCRIPTION
## Description

Bundler mode in typescript needs types in the exports, otherwise it does not resolve the types.
<img width="1252" alt="Screenshot 2024-09-24 at 07 11 04" src="https://github.com/user-attachments/assets/b594aa2e-8749-41f5-8bb1-53ac0b5de411">

The PR fixes it