### PR TITLE
feat(personaliztion-utils): Add A/B Test Trimming Support to trimHtml Function

### DIFF
--- a/packages/personalization-utils/README.md
+++ b/packages/personalization-utils/README.md
@@ -91,7 +91,7 @@ const abTests = {
   'content-id-2': 'variant-b'
 };
 
-const trimmedHTML = trimHtml(fullHTML, { userAttributes, abTests });
+const { html } = trimHtml(fullHTML, { userAttributes, abTests });
 ```
 
 To get the `userAttributes`, you should parse the `builder.userAttributes` cookie. Here's an example of how you might do this:
@@ -130,7 +130,7 @@ function getAbTests(req) {
 
 // Then in your request handler:
 const abTests = getAbTests(req);
-const trimmedHTML = trimHtml(fullHTML, { userAttributes, abTests });
+const { html } = trimHtml(fullHTML, { userAttributes, abTests });
 ```
 
 The `trimHtml` function processes the HTML in the following order:

--- a/packages/personalization-utils/README.md
+++ b/packages/personalization-utils/README.md
@@ -8,7 +8,7 @@ npm install @builder.io/personalization-utils
 
 # How to start with personalized rewrites? 
 
- This utility library helps you encode/decode targeting attributes as parts of the URL to allow for caching (or statically generating) render results, it should be used in middleware in combination with a page path handler (for e.g a catch all page `pages/[[...path]].jsx`):
+This utility library helps you encode/decode targeting attributes as parts of the URL to allow for caching (or statically generating) render results, it should be used in middleware in combination with a page path handler (for e.g a catch all page `pages/[[...path]].jsx`):
 
 ```ts
 import { parsePersonalizedURL } from '@builder.io/personalization-utils/next'
@@ -62,7 +62,6 @@ export default function middleware(request) {
   }
   return NextResponse.next();
 }
-
 ```
 
 ```typescript
@@ -73,22 +72,26 @@ builder.setUserAttributes({ audience })
 
 Once the cookie is set, all builder content matching from now on will weigh in the current audience segment.
 
-## Using trimHtml for Dynamic Containers
+## Using trimHtml for Dynamic Containers and A/B Tests
 
-The `trimHtml` function is a utility for handling dynamic personalization containers in your HTML content. It's particularly useful for processing personalized content at the edge or in server-side rendering scenarios.
+The `trimHtml` function is a utility for handling dynamic personalization containers and A/B test variants in your HTML content. It's particularly useful for processing personalized content at the edge or in server-side rendering scenarios.
 
 ### Usage
 
 ```typescript
 import { trimHtml } from '@builder.io/personalization-utils'
 
-const fullHTML = '... your full HTML string with personalization containers ...';
+const fullHTML = '... your full HTML string with personalization containers and A/B test variants ...';
 const userAttributes = {
   audience: 'segment-a',
   date: '2023-06-15T12:00:00Z'
 };
+const abTests = {
+  'content-id-1': 'variant-a',
+  'content-id-2': 'variant-b'
+};
 
-const trimmedHTML = trimHtml(fullHTML, userAttributes);
+const trimmedHTML = trimHtml(fullHTML, { userAttributes, abTests });
 ```
 
 To get the `userAttributes`, you should parse the `builder.userAttributes` cookie. Here's an example of how you might do this:
@@ -104,9 +107,35 @@ function getUserAttributes(req) {
 
 // Then in your request handler:
 const userAttributes = getUserAttributes(req);
-const trimmedHTML = trimHtml(fullHTML, userAttributes);
 ```
 
-The `trimHtml` function processes the HTML, evaluates personalization containers against the provided user attributes, and returns a new HTML string with the appropriate personalized content.
+To get the `abTests` data, you can parse the relevant cookies like this:
 
-This approach allows you to deliver personalized content while still leveraging edge caching or static site generation, as the personalization logic is applied after the initial HTML is generated.
+```typescript
+import { parse } from 'cookie'
+
+function getAbTests(req) {
+  const cookies = parse(req.headers.cookie || '');
+  const abTests = Object.entries(cookies).reduce((acc, [cookieName, cookieValue]) => {
+    if (cookieName.startsWith('builder.tests')) {
+      return {
+        ...acc,
+        [cookieName.split('.').slice(-1)[0]]: cookieValue
+      }
+    }
+    return acc;
+  }, {});
+  return abTests;
+}
+
+// Then in your request handler:
+const abTests = getAbTests(req);
+const trimmedHTML = trimHtml(fullHTML, { userAttributes, abTests });
+```
+
+The `trimHtml` function processes the HTML in the following order:
+1. It first applies A/B test variants based on the provided `abTests` object.
+2. Then it evaluates personalization containers against the provided user attributes.
+3. Finally, it returns a new HTML string with the appropriate personalized content and A/B test variants.
+
+This approach allows you to deliver personalized content and A/B test variants while still leveraging edge caching or static site generation, as the personalization and A/B test logic is applied after the initial HTML is generated.

--- a/packages/personalization-utils/package-lock.json
+++ b/packages/personalization-utils/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/personalization-utils",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/personalization-utils",
-      "version": "3.0.0",
+      "version": "4.0.0",
       "dependencies": {
         "cheerio": "^1.0.0-rc.12",
         "json-stringify-deterministic": "^1.0.6"

--- a/packages/personalization-utils/package.json
+++ b/packages/personalization-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/personalization-utils",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Utils for personalization at the edge",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/personalization-utils/src/trim-html.test.ts
+++ b/packages/personalization-utils/src/trim-html.test.ts
@@ -24,7 +24,7 @@ describe('trimHtml', () => {
 
   it('should return winning variant content when a variant matches', () => {
     const userAttributes = { itemInCart: 'item1' };
-    const result = trimHtml(baseHtml, { userAttributes });
+    const result = trimHtml(baseHtml, { userAttributes }).html;
     expect(result).toContain(
       '<div class="builder-personalization-container" style="display: block;">'
     );
@@ -36,7 +36,7 @@ describe('trimHtml', () => {
 
   it('should return default content when no variant matches', () => {
     const userAttributes = { itemInCart: 'item3' };
-    const result = trimHtml(baseHtml, { userAttributes });
+    const result = trimHtml(baseHtml, { userAttributes }).html;
     expect(result).toContain(
       '<div class="builder-personalization-container" style="display: block;">'
     );
@@ -54,7 +54,7 @@ describe('trimHtml', () => {
       ${baseHtml.replace('builder-123', 'builder-456')}
     `;
     const userAttributes = { itemInCart: 'item2' };
-    const result = trimHtml(multipleContainersHtml, { userAttributes });
+    const result = trimHtml(multipleContainersHtml, { userAttributes }).html;
     const occurrences = (result.match(/Variant 2 Content/g) || []).length;
     expect(occurrences).toBe(2);
     expect(result).toContain('<div class="other-content">Some other content</div>');
@@ -67,7 +67,7 @@ describe('trimHtml', () => {
       'class="builder-personalization-container extra-class" data-test="value"'
     );
     const userAttributes = { itemInCart: 'item1' };
-    const result = trimHtml(htmlWithExtraAttributes, { userAttributes });
+    const result = trimHtml(htmlWithExtraAttributes, { userAttributes }).html;
     expect(result).toContain('class="builder-personalization-container extra-class"');
     expect(result).toContain('data-test="value"');
   });
@@ -75,7 +75,7 @@ describe('trimHtml', () => {
   it('should not modify content when no personalization container is present', () => {
     const htmlWithoutContainer = '<div>Regular content</div>';
     const userAttributes = { itemInCart: 'item1' };
-    const result = trimHtml(htmlWithoutContainer, { userAttributes });
+    const result = trimHtml(htmlWithoutContainer, { userAttributes }).html;
     expect(result).toBe(htmlWithoutContainer);
   });
 
@@ -89,14 +89,14 @@ describe('trimHtml', () => {
       'var variants = [];'
     );
     const userAttributes = { itemInCart: 'item1' };
-    const result = trimHtml(htmlWithEmptyVariants, { userAttributes });
+    const result = trimHtml(htmlWithEmptyVariants, { userAttributes }).html;
     expect(result).toContain('<div>Default Content</div>');
   });
 
   it('should handle malformed JSON in variants', () => {
     const htmlWithMalformedJson = baseHtml.replace('"query":[{', '"query":[{malformed');
     const userAttributes = { itemInCart: 'item1' };
-    const result = trimHtml(htmlWithMalformedJson, { userAttributes });
+    const result = trimHtml(htmlWithMalformedJson, { userAttributes }).html;
     expect(result).toContain('<div>Default Content</div>');
   });
 
@@ -127,7 +127,7 @@ describe('trimHtml', () => {
 
   it('should return the current variant when within date range', () => {
     const userAttributes = { date: '2024-06-15T12:00:00Z' };
-    const result = trimHtml(baseHtmlWithDates, { userAttributes });
+    const result = trimHtml(baseHtmlWithDates, { userAttributes }).html;
     expect(result).toContain('<div>Current Variant</div>');
     expect(result).not.toContain('Future Variant');
     expect(result).not.toContain('Past Variant');
@@ -136,7 +136,7 @@ describe('trimHtml', () => {
 
   it('should return default content when current date is before all variant start dates', () => {
     const userAttributes = { date: '2019-06-15T12:00:00Z' };
-    const result = trimHtml(baseHtmlWithDates, { userAttributes });
+    const result = trimHtml(baseHtmlWithDates, { userAttributes }).html;
     expect(result).toContain('<div>Default Content</div>');
     expect(result).not.toContain('Current Variant');
     expect(result).not.toContain('Future Variant');
@@ -145,7 +145,7 @@ describe('trimHtml', () => {
 
   it('should return default content when current date is after all variant end dates', () => {
     const userAttributes = { date: '2028-06-15T12:00:00Z' };
-    const result = trimHtml(baseHtmlWithDates, { userAttributes });
+    const result = trimHtml(baseHtmlWithDates, { userAttributes }).html;
     expect(result).toContain('<div>Default Content</div>');
     expect(result).not.toContain('Current Variant');
     expect(result).not.toContain('Future Variant');
@@ -158,7 +158,7 @@ describe('trimHtml', () => {
       '"startDate":"2023-01-01T00:00:00Z"'
     );
     const userAttributes = { date: '2024-06-15T12:00:00Z' };
-    const result = trimHtml(htmlWithOnlyStartDate, { userAttributes });
+    const result = trimHtml(htmlWithOnlyStartDate, { userAttributes }).html;
     expect(result).toContain('<div>Current Variant</div>');
   });
 
@@ -168,7 +168,7 @@ describe('trimHtml', () => {
       '"endDate":"2025-12-31T23:59:59Z"'
     );
     const userAttributes = { date: '2024-06-15T12:00:00Z' };
-    const result = trimHtml(htmlWithOnlyEndDate, { abTests: {} });
+    const result = trimHtml(htmlWithOnlyEndDate, { abTests: {} }).html;
     expect(result).toContain('<div>Current Variant</div>');
   });
 
@@ -198,7 +198,7 @@ describe('trimHtml', () => {
       userAttributes: {},
       abTests: { 'test-content-1': 'variant-1' },
     };
-    const result = trimHtml(baseHtmlWithAbTest, options);
+    const result = trimHtml(baseHtmlWithAbTest, options).html;
     expect(result).toContain('Variant 1 Content');
     expect(result).not.toContain('Variant 2 Content');
     expect(result).not.toContain('Default Content');
@@ -211,7 +211,7 @@ describe('trimHtml', () => {
       userAttributes: {},
       abTests: { 'test-content-1': 'non-existent-variant' },
     };
-    const result = trimHtml(baseHtmlWithAbTest, options);
+    const result = trimHtml(baseHtmlWithAbTest, options).html;
     expect(result).toContain('Default Content');
     expect(result).not.toContain('Variant 1 Content');
     expect(result).not.toContain('Variant 2 Content');
@@ -248,7 +248,7 @@ describe('trimHtml', () => {
         'test-content-2': 'variant-a',
       },
     };
-    const result = trimHtml(htmlWithMultipleTests, options);
+    const result = trimHtml(htmlWithMultipleTests, options).html;
     expect(result).toContain('Variant 2 Content');
     expect(result).toContain('Variant A Content');
     expect(result).not.toContain('Variant 1 Content');
@@ -302,7 +302,7 @@ describe('trimHtml', () => {
       userAttributes: { itemInCart: 'item1' },
       abTests: { 'test-content-1': 'variant-2' },
     };
-    const result = trimHtml(htmlWithAbTestAndPersonalization, options);
+    const result = trimHtml(htmlWithAbTestAndPersonalization, options).html;
     expect(result).toContain('Variant 2 Content');
     expect(result).not.toContain('Variant 1 Content');
     expect(result).not.toContain('Default Content');
@@ -317,7 +317,7 @@ describe('trimHtml', () => {
       userAttributes: {},
       abTests: { 'non-existent-content': 'some-variant' },
     };
-    const result = trimHtml(baseHtmlWithAbTest, options);
+    const result = trimHtml(baseHtmlWithAbTest, options).html;
     expect(result).toContain('Default Content');
     expect(result).toContain('<template');
     expect(result).toContain('<script');

--- a/packages/personalization-utils/src/utils.ts
+++ b/packages/personalization-utils/src/utils.ts
@@ -54,15 +54,55 @@ export type Query = {
 };
 import { CheerioAPI, Cheerio, load } from 'cheerio';
 
-export function trimHtml(html: string, userAttributes: UserAttributes): string {
-  const $ = load(html);
+type OptionalXOR<T, K extends keyof T> =
+  | ({ [P in K]-?: T[P] } & { [P in Exclude<keyof T, K>]?: T[P] })
+  | ({ [P in K]?: T[P] } & { [P in Exclude<keyof T, K>]-?: T[P] });
 
-  $('.builder-personalization-container').each((_, element) => {
-    const a = $(element);
-    processContainer($, a, userAttributes);
-  });
+type TrimHtmlOptions = OptionalXOR<
+  {
+    userAttributes: UserAttributes;
+    abTests: Record<string, string>;
+  },
+  'userAttributes' | 'abTests'
+>;
+
+export function trimHtml(html: string, options: TrimHtmlOptions): string {
+  let $ = load(html);
+  if (options.abTests) {
+    Object.entries(options.abTests).forEach(([contentId, winningVariantId]) => {
+      const $content = $(`.builder-component-${contentId}`);
+      if ($content.length) {
+        processAbTest($, $content, winningVariantId);
+      }
+    });
+    $ = load($.html() || '');
+  }
+
+  if (options.userAttributes) {
+    $('.builder-personalization-container').each((_, element) => {
+      processContainer($, $(element), options.userAttributes!);
+    });
+  }
 
   return $('body').html() || '';
+}
+
+function processAbTest($: CheerioAPI, $content: Cheerio<any>, winningVariantId: string) {
+  const $templates = $content.find('template[data-template-variant-id]');
+  const $script = $content.find('script[id^="variants-script-"]');
+
+  if ($templates.length > 0 && $script.length > 0) {
+    const $winningTemplate = $content.find(
+      `template[data-template-variant-id="${winningVariantId}"]`
+    );
+
+    if ($winningTemplate.length) {
+      $content.html($winningTemplate.html() || '');
+    } else {
+      // If winning template not found, keep default content
+      $content.find('template, script').remove();
+    }
+  }
 }
 
 function processContainer($: CheerioAPI, $container: Cheerio<any>, userAttributes: UserAttributes) {

--- a/packages/personalization-utils/src/utils.ts
+++ b/packages/personalization-utils/src/utils.ts
@@ -66,7 +66,7 @@ type TrimHtmlOptions = OptionalXOR<
   'userAttributes' | 'abTests'
 >;
 
-export function trimHtml(html: string, options: TrimHtmlOptions): string {
+export function trimHtml(html: string, options: TrimHtmlOptions): { html: string } {
   let $ = load(html);
   if (options.abTests) {
     Object.entries(options.abTests).forEach(([contentId, winningVariantId]) => {
@@ -84,7 +84,9 @@ export function trimHtml(html: string, options: TrimHtmlOptions): string {
     });
   }
 
-  return $('body').html() || '';
+  return {
+    html: $('body').html() || '',
+  };
 }
 
 function processAbTest($: CheerioAPI, $content: Cheerio<any>, winningVariantId: string) {


### PR DESCRIPTION
This PR extends the `trimHtml` function to support trimming A/B test variants in addition to personalization containers.

### Changes:

- Updated `trimHtml` function to process A/B test variants before personalization containers
- Added `abTests` parameter to `trimHtml` options
- Implemented logic to select winning A/B test variants based on provided `abTests` object
- Updated README with information on A/B test trimming and usage examples
