### PR TITLE
fix[angular-gen2]: slot placement in dynamic components in Angular

### DIFF
--- a/.changeset/funny-items-walk.md
+++ b/.changeset/funny-items-walk.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/sdk-angular": patch
+---
+
+Fix: children placement in dynamic components

--- a/packages/sdks-tests/src/e2e-tests/custom-components.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/custom-components.spec.ts
@@ -33,6 +33,14 @@ test.describe('Custom components', () => {
     await customComponentMsgPromise;
   });
 
+  test('children placement is correct', async ({ page, sdk }) => {
+    test.skip(!['angular'].includes(sdk));
+    await page.goto('/children-slot-placement');
+    const h1 = page.locator('h1').first();
+    await expect(h1).toBeVisible();
+    await expect(h1.locator('text=inside an h1').first()).toBeVisible();
+  });
+
   test('do not show component in `page` model when restricted to `test-model`', async ({
     page,
     packageName,

--- a/packages/sdks-tests/src/specs/children-slot-placement.ts
+++ b/packages/sdks-tests/src/specs/children-slot-placement.ts
@@ -1,0 +1,76 @@
+export const CUSTOM_COMPONENT_CHILDREN_SLOT_PLACEMENT = {
+  ownerId: 'ad30f9a246614faaa6a03374f83554c9',
+  lastUpdateBy: null,
+  createdDate: 1727714988310,
+  id: '42556074e0b94251b0b4f5e35c7e7aab',
+  '@version': 4,
+  name: 'aegteqtwqt',
+  modelId: '17c6065109ef4062ba083f5741f4ee6a',
+  published: 'draft',
+  meta: {
+    kind: 'page',
+    hasLinks: false,
+    lastPreviewUrl:
+      'http://localhost:4200/aegteqtwqt?builder.space=ad30f9a246614faaa6a03374f83554c9&builder.user.permissions=read%2Ccreate%2Cpublish%2CeditCode%2CeditDesigns%2Cadmin%2CeditLayouts%2CeditLayers&builder.user.role.name=Admin&builder.user.role.id=admin&builder.cachebust=true&builder.preview=page&builder.noCache=true&builder.allowTextEdit=true&__builder_editing__=true&builder.overrides.page=42556074e0b94251b0b4f5e35c7e7aab&builder.overrides.42556074e0b94251b0b4f5e35c7e7aab=42556074e0b94251b0b4f5e35c7e7aab&builder.overrides.page:/aegteqtwqt=42556074e0b94251b0b4f5e35c7e7aab&builder.options.locale=Default',
+    componentsUsed: {
+      Hello: 1,
+    },
+  },
+  priority: -728,
+  query: [
+    {
+      '@type': '@builder.io/core:Query',
+      property: 'urlPath',
+      operator: 'is',
+      value: '/aegteqtwqt',
+    },
+  ],
+  data: {
+    title: 'aegteqtwqt',
+    themeId: false,
+    blocks: [
+      {
+        '@type': '@builder.io/sdk:Element',
+        '@version': 2,
+        id: 'builder-a0a9b4983fa845438e6cdc22d14cb223',
+        component: {
+          name: 'Hello',
+          options: {},
+        },
+        children: [
+          {
+            '@type': '@builder.io/sdk:Element',
+            '@version': 2,
+            id: 'builder-ebca7d55d34f4fc9a6536600959cef5d',
+            component: {
+              name: 'Text',
+              options: {
+                text: 'inside an h1',
+              },
+            },
+          },
+        ],
+        responsiveStyles: {
+          large: {
+            display: 'flex',
+            flexDirection: 'column',
+            position: 'relative',
+            flexShrink: '0',
+            boxSizing: 'border-box',
+            marginTop: '20px',
+          },
+        },
+      },
+    ],
+  },
+  metrics: {
+    clicks: 0,
+    impressions: 0,
+  },
+  variations: {},
+  lastUpdated: 1727972343858,
+  testRatio: 1,
+  createdBy: 'RuGeCLr9ryVt1xRazFYc72uWwIK2',
+  lastUpdatedBy: 'RuGeCLr9ryVt1xRazFYc72uWwIK2',
+  folders: [],
+};

--- a/packages/sdks-tests/src/specs/index.ts
+++ b/packages/sdks-tests/src/specs/index.ts
@@ -60,6 +60,7 @@ import { EDITING_BOX_TO_COLUMN_INNER_LAYOUT } from './editing-columns-inner-layo
 import { REACT_NATIVE_STRICT_STYLE_MODE_CONTENT } from './react-native-strict-style-mode.js';
 import type { Sdk } from '../helpers/sdk.js';
 import { SYMBOL_WITH_REPEAT_INPUT_BINDING } from './symbol-with-repeat-input-binding.js';
+import { CUSTOM_COMPONENT_CHILDREN_SLOT_PLACEMENT } from './children-slot-placement.js';
 
 function isBrowser(): boolean {
   return typeof window !== 'undefined' && typeof document !== 'undefined';
@@ -137,6 +138,7 @@ export const PAGES = {
   '/custom-components-models-not-show': CUSTOM_COMPONENTS_MODELS_RESTRICTION,
   '/editing-box-columns-inner-layout': EDITING_BOX_TO_COLUMN_INNER_LAYOUT,
   '/symbol-with-repeat-input-binding': SYMBOL_WITH_REPEAT_INPUT_BINDING,
+  '/children-slot-placement': CUSTOM_COMPONENT_CHILDREN_SLOT_PLACEMENT,
 } as const;
 
 const apiVersionPathToProp = {

--- a/packages/sdks/e2e/angular-ssr/src/app/catch-all.component.ts
+++ b/packages/sdks/e2e/angular-ssr/src/app/catch-all.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 // fails because type imports cannot be injected
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import { ActivatedRoute } from '@angular/router';
+import type { RegisteredComponent } from '@builder.io/sdk-angular';
 import { HelloComponent } from './hello.component';
 
 interface BuilderProps {
@@ -42,11 +43,24 @@ export class CatchAllComponent {
   content: BuilderProps['content'];
   data: BuilderProps['data'];
 
-  customComponents = [
+  customComponents: RegisteredComponent[] = [
     {
       component: HelloComponent,
       name: 'Hello',
       inputs: [],
+      defaultChildren: [
+        {
+          '@type': '@builder.io/sdk:Element',
+          '@version': 2,
+          id: 'builder-ebca7d55d34f4fc9a6536600959cef5d',
+          component: {
+            name: 'Text',
+            options: {
+              text: 'inside an h1',
+            },
+          },
+        },
+      ],
     },
   ];
 

--- a/packages/sdks/e2e/angular-ssr/src/app/hello.component.ts
+++ b/packages/sdks/e2e/angular-ssr/src/app/hello.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'hello',
-  template: ` <h1>hello {{ name }}</h1> `,
+  template: ` <h1>hello {{ name }}<ng-content></ng-content></h1> `,
 })
 export class HelloComponent {
   name = 'World';

--- a/packages/sdks/e2e/angular/src/app/app.component.ts
+++ b/packages/sdks/e2e/angular/src/app/app.component.ts
@@ -3,6 +3,7 @@ import {
   _processContentResult,
   fetchOneEntry,
   getBuilderSearchParams,
+  type RegisteredComponent,
 } from '@builder.io/sdk-angular';
 import { getProps } from '@sdk/tests';
 import { HelloComponent } from './hello.component';
@@ -47,11 +48,24 @@ export class AppComponent {
   content: BuilderProps['content'];
   data: BuilderProps['data'];
 
-  customComponents = [
+  customComponents: RegisteredComponent[] = [
     {
       component: HelloComponent,
       name: 'Hello',
       inputs: [],
+      defaultChildren: [
+        {
+          '@type': '@builder.io/sdk:Element',
+          '@version': 2,
+          id: 'builder-ebca7d55d34f4fc9a6536600959cef5d',
+          component: {
+            name: 'Text',
+            options: {
+              text: 'inside an h1',
+            },
+          },
+        },
+      ],
     },
   ];
 

--- a/packages/sdks/e2e/angular/src/app/hello.component.ts
+++ b/packages/sdks/e2e/angular/src/app/hello.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'hello',
-  template: ` <h1>hello {{ name }}</h1> `,
+  template: ` <h1>hello {{ name }}<ng-content></ng-content></h1> `,
 })
 export class HelloComponent {
   name = 'World';

--- a/packages/sdks/mitosis.config.cjs
+++ b/packages/sdks/mitosis.config.cjs
@@ -316,7 +316,11 @@ const ANGULAR_OVERRIDE_COMPONENT_REF_PLUGIN = () => ({
 const ANGULAR_RENAME_NG_ONINIT_TO_NG_AFTERCONTENTINIT_PLUGIN = () => ({
   code: {
     post: (code) => {
-      if (code?.includes('selector: "blocks-wrapper"')) {
+      if (
+        code?.includes('selector: "blocks-wrapper"') ||
+        code?.includes('selector: "component-ref"') ||
+        code?.includes('selector: "interactive-element"')
+      ) {
         code = code.replace('ngOnInit', 'ngAfterContentInit');
       }
       return code;

--- a/packages/sdks/output/angular/scripts/generate-dynamic-renderer.mjs
+++ b/packages/sdks/output/angular/scripts/generate-dynamic-renderer.mjs
@@ -185,7 +185,7 @@ export default class DynamicRenderer {
 
   constructor(private vcRef: ViewContainerRef) {}
 
-  ngOnInit() {
+  ngAfterContentInit() {
     if (typeof this.TagName === 'string') {
       switch (this.TagName) {
         ${htmlElements.map((el) => `case '${el}': this.TagName = Dynamic${capitalize(el)}; break;`).join('\n        ')}


### PR DESCRIPTION
## Description

`ngAfterContentInit` makes sure that we have access to children and project them in a slot

Ref: https://stackoverflow.com/questions/36545478/angular-2-access-ng-content-within-component/53527323#53527323

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
