### PR TITLE
fix[react-gen2]: remove `init` module from edge and browser builds

### DIFF
--- a/.changeset/real-parrots-love.md
+++ b/.changeset/real-parrots-love.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/sdk-react": patch
+---
+
+Fix: remove node-runtime logic from browser and edge bundles

--- a/packages/sdks/output/react/vite.config.ts
+++ b/packages/sdks/output/react/vite.config.ts
@@ -8,6 +8,7 @@ import recast from 'recast';
 import typescriptParser from 'recast/parsers/typescript.js';
 import { defineConfig } from 'vite';
 
+const SDK_ENV = getSdkEnv();
 const SERVER_ENTRY = 'server-entry';
 const BLOCKS_EXPORTS_ENTRY = 'blocks-exports';
 
@@ -37,7 +38,7 @@ export const lazyifyReactComponentsVitePlugin = (): import('vite').Plugin => {
   return {
     name: 'lazify-react-components',
     transform(src, id) {
-      if (getSdkEnv() !== 'edge') return src;
+      if (SDK_ENV !== 'edge') return src;
 
       if (id.includes('blocks-exports.ts')) {
         const ast = parse(src);
@@ -215,7 +216,11 @@ export default defineConfig({
         index: './src/index.ts',
         [SERVER_ENTRY]: './src/server-index.ts',
         [BLOCKS_EXPORTS_ENTRY]: './src/index-helpers/blocks-exports.ts',
-        init: './src/functions/evaluate/node-runtime/init.ts',
+        ...(SDK_ENV === 'node'
+          ? {
+              init: './src/functions/evaluate/node-runtime/init.ts',
+            }
+        : {}),
       },
       formats: ['es', 'cjs'],
       fileName: (format, entryName) =>


### PR DESCRIPTION
## Description

Removes `init` module logic from edge and browser builds

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
