### PR TITLE
feat[svelte-gen2]: dynamic loading of components

### DIFF
--- a/.changeset/few-crews-shop.md
+++ b/.changeset/few-crews-shop.md
@@ -28,7 +28,6 @@ Alternatively, you can pass the component directly, which will pre-bundle it as 
 
 ```html
 <script lang="ts">
-  import Loader from './Loader.svelte'; // Fallback loader component
   import type { RegisteredComponent } from '@builder.io/sdk-svelte';
   import NotLazyComponent from '../../components/NotLazyComponent.svelte';
 

--- a/.changeset/few-crews-shop.md
+++ b/.changeset/few-crews-shop.md
@@ -1,0 +1,42 @@
+---
+'@builder.io/sdk-svelte': patch
+---
+
+Feat: adds support for dynamically loading Svelte components using the `load` function and an optional `fallback` loader component.
+
+To dynamically load your custom component, you can do the following:
+
+```html
+<script lang="ts">
+  import Loader from './Loader.svelte'; // Fallback loader component
+  import type { RegisteredComponent } from '@builder.io/sdk-svelte';
+
+  const customComponents: RegisteredComponent[] = [
+    {
+      name: 'LazyComponent',
+      component: {
+        // dynamically loads the custom component only when it needs to be initialized
+        load: () => import('../../components/LazyComponent.svelte'),
+        fallback: Loader,
+      },
+    },
+  ];
+</script>
+```
+
+Alternatively, you can pass the component directly, which will pre-bundle it as before:
+
+```html
+<script lang="ts">
+  import Loader from './Loader.svelte'; // Fallback loader component
+  import type { RegisteredComponent } from '@builder.io/sdk-svelte';
+  import NotLazyComponent from '../../components/NotLazyComponent.svelte';
+
+  const customComponents: RegisteredComponent[] = [
+    {
+      name: 'NotLazyComponent',
+      component: NotLazyComponent,
+    },
+  ];
+</script>
+```

--- a/.changeset/few-crews-shop.md
+++ b/.changeset/few-crews-shop.md
@@ -8,7 +8,7 @@ To dynamically load your custom component, you can do the following:
 
 ```html
 <script lang="ts">
-  import Loader from './Loader.svelte'; // Fallback loader component
+  import LoadingSpinner from '../../components/LoadingSpinner.svelte'; // Fallback loader component
   import type { RegisteredComponent } from '@builder.io/sdk-svelte';
 
   const customComponents: RegisteredComponent[] = [
@@ -17,7 +17,7 @@ To dynamically load your custom component, you can do the following:
       component: {
         // dynamically loads the custom component only when it needs to be initialized
         load: () => import('../../components/LazyComponent.svelte'),
-        fallback: Loader,
+        fallback: LoadingSpinner,
       },
     },
   ];

--- a/packages/sdks-tests/playwright.config.ts
+++ b/packages/sdks-tests/playwright.config.ts
@@ -81,14 +81,14 @@ export default defineConfig({
     .map(({ packageName, port, portFlag }) => ({
       command: `PORT=${port} yarn workspace @${testType}/${packageName} ${IS_DEV_MODE ? 'dev' : 'serve'} ${portFlag}`,
       port,
-      reuseExistingServer: true,
+      reuseExistingServer: false,
       ...(packageName === 'react-native' ? { timeout: 120 * 1000 } : {}),
     }))
     .concat([
       {
         command: `PORT=${EMBEDDER_PORT} yarn workspace @sdk/tests run-embedder`,
         port: EMBEDDER_PORT,
-        reuseExistingServer: true,
+        reuseExistingServer: false,
       },
     ]),
 });

--- a/packages/sdks-tests/playwright.config.ts
+++ b/packages/sdks-tests/playwright.config.ts
@@ -81,14 +81,14 @@ export default defineConfig({
     .map(({ packageName, port, portFlag }) => ({
       command: `PORT=${port} yarn workspace @${testType}/${packageName} ${IS_DEV_MODE ? 'dev' : 'serve'} ${portFlag}`,
       port,
-      reuseExistingServer: false,
+      reuseExistingServer: true,
       ...(packageName === 'react-native' ? { timeout: 120 * 1000 } : {}),
     }))
     .concat([
       {
         command: `PORT=${EMBEDDER_PORT} yarn workspace @sdk/tests run-embedder`,
         port: EMBEDDER_PORT,
-        reuseExistingServer: false,
+        reuseExistingServer: true,
       },
     ]),
 });

--- a/packages/sdks-tests/src/e2e-tests/dynamic-loading.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/dynamic-loading.spec.ts
@@ -41,6 +41,7 @@ test.describe('Dynamic loading of custom components', () => {
 
           if (responseBody?.includes('Not lazy component loaded')) {
             // its bundled and sent in the initial requests
+            // even if we haven't clicked the button
             notLazyComponentRequested = true;
           }
         }

--- a/packages/sdks-tests/src/e2e-tests/dynamic-loading.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/dynamic-loading.spec.ts
@@ -1,0 +1,54 @@
+import { expect } from '@playwright/test';
+import { test } from '../helpers/index.js';
+
+test.describe('Dynamic loading of custom components', () => {
+  test('LazyComponent only loads when requested', async ({ page, packageName }) => {
+    test.skip(packageName !== 'sveltekit');
+    await page.goto('/dynamic-loading');
+
+    let lazyComponentRequested = false;
+
+    page.on('request', request => {
+      if (request.url().includes('LazyComponent')) {
+        lazyComponentRequested = true;
+      }
+    });
+
+    await page.waitForLoadState('networkidle');
+
+    expect(lazyComponentRequested).toBe(false);
+
+    const button = page.locator('text=Click me!');
+    await button.click();
+
+    expect(lazyComponentRequested).toBe(true);
+  });
+
+  test('NotLazyComponent loads immediately even if not requested', async ({
+    page,
+    packageName,
+  }) => {
+    test.skip(packageName !== 'sveltekit');
+    await page.goto('/dynamic-loading');
+
+    let notLazyComponentRequested = false;
+
+    page.on('requestfinished', request => {
+      void (async () => {
+        if (request.resourceType() === 'document' || request.resourceType() === 'script') {
+          const response = await request.response();
+          const responseBody = await response?.text();
+
+          if (responseBody?.includes('Not lazy component loaded')) {
+            // its bundled and sent in the initial requests
+            notLazyComponentRequested = true;
+          }
+        }
+      })();
+    });
+
+    await page.waitForLoadState('networkidle');
+
+    expect(notLazyComponentRequested).toBe(true);
+  });
+});

--- a/packages/sdks-tests/src/specs/dynamic-loading.ts
+++ b/packages/sdks-tests/src/specs/dynamic-loading.ts
@@ -1,0 +1,155 @@
+export const DYNAMIC_LOADING_CUSTOM_COMPONENTS = {
+  ownerId: 'ad30f9a246614faaa6a03374f83554c9',
+  lastUpdateBy: null,
+  createdDate: 1727698733481,
+  id: 'ecb200c7c9954212a276b1071a376f18',
+  '@version': 4,
+  name: 'fsafsggxz',
+  modelId: '17c6065109ef4062ba083f5741f4ee6a',
+  published: 'published',
+  meta: {
+    lastPreviewUrl:
+      'http://localhost:5173/fsafsggxz?builder.space=ad30f9a246614faaa6a03374f83554c9&builder.user.permissions=read%2Ccreate%2Cpublish%2CeditCode%2CeditDesigns%2Cadmin%2CeditLayouts%2CeditLayers&builder.user.role.name=Admin&builder.user.role.id=admin&builder.cachebust=true&builder.preview=page&builder.noCache=true&builder.allowTextEdit=true&__builder_editing__=true&builder.overrides.page=ecb200c7c9954212a276b1071a376f18&builder.overrides.ecb200c7c9954212a276b1071a376f18=ecb200c7c9954212a276b1071a376f18&builder.overrides.page:/fsafsggxz=ecb200c7c9954212a276b1071a376f18&builder.options.locale=Default',
+    kind: 'page',
+    hasLinks: false,
+    componentsUsed: {
+      LazyComponent: 1,
+    },
+  },
+  priority: -718,
+  stage: 'b3ee01559a244a078973f545ad475eba',
+  query: [
+    {
+      '@type': '@builder.io/core:Query',
+      property: 'urlPath',
+      operator: 'is',
+      value: '/fsafsggxz',
+    },
+  ],
+  data: {
+    title: 'fsafsggxz',
+    themeId: false,
+    tsCode: 'state.show = false',
+    jsCode: 'var _virtual_index=state.show=!1;return _virtual_index',
+    blocks: [
+      {
+        '@type': '@builder.io/sdk:Element',
+        '@version': 2,
+        actions: {
+          click: 'state.show=!state.show',
+        },
+        code: {
+          actions: {
+            click: 'state.show = !state.show;\n',
+          },
+        },
+        id: 'builder-2b8ddc89b1894011b3aa3309833bf3b9',
+        meta: {
+          eventActions: {
+            click: [
+              {
+                '@type': '@builder.io/core:Action',
+                action: '@builder.io:toggleState',
+                options: {
+                  name: 'show',
+                },
+              },
+            ],
+          },
+        },
+        component: {
+          name: 'Core:Button',
+          options: {
+            text: 'Click me!',
+            openLinkInNewTab: false,
+          },
+        },
+        responsiveStyles: {
+          large: {
+            display: 'flex',
+            flexDirection: 'column',
+            position: 'relative',
+            flexShrink: '0',
+            boxSizing: 'border-box',
+            marginTop: '20px',
+            appearance: 'none',
+            paddingTop: '15px',
+            paddingBottom: '15px',
+            paddingLeft: '25px',
+            paddingRight: '25px',
+            backgroundColor: 'black',
+            color: 'white',
+            borderRadius: '4px',
+            textAlign: 'center',
+            cursor: 'pointer',
+          },
+        },
+      },
+      {
+        '@type': '@builder.io/sdk:Element',
+        '@version': 2,
+        bindings: {
+          show: 'var _virtual_index=state.show;return _virtual_index',
+        },
+        code: {
+          bindings: {
+            show: 'state.show',
+          },
+        },
+        id: 'builder-5a8cdbbf69f14c79a4fa71438c8fd4cf',
+        component: {
+          name: 'LazyComponent',
+          options: {},
+        },
+        responsiveStyles: {
+          large: {
+            display: 'flex',
+            flexDirection: 'column',
+            position: 'relative',
+            flexShrink: '0',
+            boxSizing: 'border-box',
+            marginTop: '20px',
+          },
+        },
+      },
+      {
+        '@type': '@builder.io/sdk:Element',
+        '@version': 2,
+        bindings: {
+          show: 'var _virtual_index=state.show;return _virtual_index',
+        },
+        code: {
+          bindings: {
+            show: 'state.show',
+          },
+        },
+        id: 'builder-caf4d18da3d0439281f29eb144874e2e',
+        component: {
+          name: 'NotLazyComponent',
+          options: {},
+        },
+        responsiveStyles: {
+          large: {
+            display: 'flex',
+            flexDirection: 'column',
+            position: 'relative',
+            flexShrink: '0',
+            boxSizing: 'border-box',
+            marginTop: '20px',
+          },
+        },
+      },
+    ],
+  },
+  metrics: {
+    clicks: 0,
+    impressions: 0,
+  },
+  variations: {},
+  lastUpdated: 1727704258246,
+  firstPublished: 1727704258239,
+  testRatio: 1,
+  createdBy: 'RuGeCLr9ryVt1xRazFYc72uWwIK2',
+  lastUpdatedBy: 'RuGeCLr9ryVt1xRazFYc72uWwIK2',
+  folders: [],
+};

--- a/packages/sdks-tests/src/specs/index.ts
+++ b/packages/sdks-tests/src/specs/index.ts
@@ -61,6 +61,7 @@ import { REACT_NATIVE_STRICT_STYLE_MODE_CONTENT } from './react-native-strict-st
 import type { Sdk } from '../helpers/sdk.js';
 import { SYMBOL_WITH_REPEAT_INPUT_BINDING } from './symbol-with-repeat-input-binding.js';
 import { CUSTOM_COMPONENT_CHILDREN_SLOT_PLACEMENT } from './children-slot-placement.js';
+import { DYNAMIC_LOADING_CUSTOM_COMPONENTS } from './dynamic-loading.js';
 
 function isBrowser(): boolean {
   return typeof window !== 'undefined' && typeof document !== 'undefined';
@@ -139,6 +140,7 @@ export const PAGES = {
   '/editing-box-columns-inner-layout': EDITING_BOX_TO_COLUMN_INNER_LAYOUT,
   '/symbol-with-repeat-input-binding': SYMBOL_WITH_REPEAT_INPUT_BINDING,
   '/children-slot-placement': CUSTOM_COMPONENT_CHILDREN_SLOT_PLACEMENT,
+  '/dynamic-loading': DYNAMIC_LOADING_CUSTOM_COMPONENTS,
 } as const;
 
 const apiVersionPathToProp = {

--- a/packages/sdks/e2e/sveltekit/src/components/LazyComponent.svelte
+++ b/packages/sdks/e2e/sveltekit/src/components/LazyComponent.svelte
@@ -1,0 +1,4 @@
+<script>
+</script>
+
+<strong>Lazy component loaded</strong>

--- a/packages/sdks/e2e/sveltekit/src/components/NotLazyComponent.svelte
+++ b/packages/sdks/e2e/sveltekit/src/components/NotLazyComponent.svelte
@@ -1,0 +1,4 @@
+<script>
+</script>
+
+<strong>Not lazy component loaded</strong>

--- a/packages/sdks/e2e/sveltekit/src/routes/[...catchall]/+page.svelte
+++ b/packages/sdks/e2e/sveltekit/src/routes/[...catchall]/+page.svelte
@@ -1,14 +1,28 @@
 <script lang="ts">
   import { Content } from '@builder.io/sdk-svelte';
+    import NotLazyComponent from '../../components/NotLazyComponent.svelte';
 
   // this data comes from the function in `+page.server.ts`, which runs on the server only
   export let data;
+
+  const customComponents = [
+    {
+      name: 'LazyComponent',
+      component: {
+          load: () => import('../../components/LazyComponent.svelte'),
+      }
+    },
+    {
+      name: 'NotLazyComponent',
+      component: NotLazyComponent
+    }
+  ]
 </script>
 
 <main>
   {#if data.props}
     {#key data.props}
-      <Content {...data.props} />
+      <Content {...data.props} {customComponents} />
     {/key}
   {:else}
     Content Not Found

--- a/packages/sdks/overrides/svelte/src/components/awaiter.svelte
+++ b/packages/sdks/overrides/svelte/src/components/awaiter.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  export let load: () => Promise<any>;
+  export let fallback: any;
+  export let props: any;
+  export let attributes: any;
+</script>
+
+{#await load()}
+  {#if fallback}
+    <svelte:component this={fallback} />
+  {/if}
+  {:then { default: Component }}
+  <svelte:component
+    this={Component}
+    {...props}
+    attributes={attributes}
+  >
+    <slot />
+  </svelte:component>
+{/await}

--- a/packages/sdks/overrides/svelte/src/context/component-reference-types.ts
+++ b/packages/sdks/overrides/svelte/src/context/component-reference-types.ts
@@ -1,0 +1,16 @@
+import type { SvelteComponent } from 'svelte';
+
+export type ComponentReference =
+  | {
+      /**
+       * A dynamic import function pointing to the component.
+       * Example: `() => import('../components/my-component.svelte')`
+       * @returns A Promise that resolves to the loaded component.
+       */
+      load: () => Promise<{ default: typeof SvelteComponent<any> }>;
+      /**
+       * An optional fallback component to render while the dynamic component is loading.
+       */
+      fallback?: typeof SvelteComponent<any>;
+    }
+  | typeof SvelteComponent<any>;

--- a/packages/sdks/src/components/awaiter.lite.tsx
+++ b/packages/sdks/src/components/awaiter.lite.tsx
@@ -1,0 +1,16 @@
+/**
+ * Placeholder component to be overridden by specific SDKs.
+ * Allows to dynamically import components.
+ */
+
+type AwaiterProps = {
+  load: () => Promise<any>;
+  props?: any;
+  attributes?: any;
+  fallback?: any;
+  children?: any;
+};
+
+export default function Awaiter(props: AwaiterProps) {
+  return <>{props.children}</>;
+}

--- a/packages/sdks/src/components/block/components/interactive-element.lite.tsx
+++ b/packages/sdks/src/components/block/components/interactive-element.lite.tsx
@@ -1,9 +1,10 @@
-import { useMetadata, useStore, type Signal } from '@builder.io/mitosis';
+import { Show, useMetadata, useStore, type Signal } from '@builder.io/mitosis';
 import type { BuilderContextInterface } from '../../../context/types.js';
 import { getBlockActions } from '../../../functions/get-block-actions.js';
 import { getBlockProperties } from '../../../functions/get-block-properties.js';
 import type { BuilderBlock } from '../../../types/builder-block.js';
 import type { Dictionary } from '../../../types/typescript.js';
+import Awaiter from '../../awaiter.lite.jsx';
 
 export type InteractiveElementProps = {
   Wrapper: any;
@@ -51,8 +52,22 @@ export default function InteractiveElement(props: InteractiveElementProps) {
   });
 
   return (
-    <props.Wrapper {...props.wrapperProps} attributes={state.attributes}>
-      {props.children}
-    </props.Wrapper>
+    <Show
+      when={props.Wrapper.load}
+      else={
+        <props.Wrapper {...props.wrapperProps} attributes={state.attributes}>
+          {props.children}
+        </props.Wrapper>
+      }
+    >
+      <Awaiter
+        load={props.Wrapper.load}
+        fallback={props.Wrapper.fallback}
+        props={props.wrapperProps}
+        attributes={state.attributes}
+      >
+        {props.children}
+      </Awaiter>
+    </Show>
   );
 }

--- a/packages/sdks/src/context/component-reference-types.ts
+++ b/packages/sdks/src/context/component-reference-types.ts
@@ -1,0 +1,4 @@
+/**
+ * To be overriden to the correct `Component` type for each framework.
+ */
+export type ComponentReference = any;

--- a/packages/sdks/src/context/types.ts
+++ b/packages/sdks/src/context/types.ts
@@ -6,7 +6,14 @@ import type { Dictionary, Nullable } from '../types/typescript.js';
 import type { ExtraContextTypes } from './extra-context-types.js';
 
 export type RegisteredComponent = ComponentInfo & {
-  component: any;
+  component: /**
+   * Dynamically load components (currently only available for Svelte SDK)
+   */
+  | {
+        load: () => Promise<any>;
+        fallback?: any;
+      }
+    | any;
 };
 
 export type RegisteredComponents = Dictionary<RegisteredComponent>;

--- a/packages/sdks/src/context/types.ts
+++ b/packages/sdks/src/context/types.ts
@@ -3,17 +3,11 @@ import type { ApiVersion } from '../types/api-version.js';
 import type { BuilderContent } from '../types/builder-content.js';
 import type { ComponentInfo } from '../types/components.js';
 import type { Dictionary, Nullable } from '../types/typescript.js';
+import type { ComponentReference } from './component-reference-types.js';
 import type { ExtraContextTypes } from './extra-context-types.js';
 
 export type RegisteredComponent = ComponentInfo & {
-  component: /**
-   * Dynamically load components (currently only available for Svelte SDK)
-   */
-  | {
-        load: () => Promise<any>;
-        fallback?: any;
-      }
-    | any;
+  component: ComponentReference;
 };
 
 export type RegisteredComponents = Dictionary<RegisteredComponent>;


### PR DESCRIPTION
## Description

Able to dynamically load custom components in Svelte SDK by,

```html
<script lang="ts">
  import LoadingSpinner from '../../components/LoadingSpinner.svelte'; // Fallback loader component
  import type { RegisteredComponent } from '@builder.io/sdk-svelte';
  const customComponents: RegisteredComponent[] = [
    {
      name: 'LazyComponent',
      component: {
        // dynamically loads the custom component only when it needs to be initialized
        load: () => import('../../components/LazyComponent.svelte'),
        fallback: LoadingSpinner,
      },
    },
  ];
</script>

<Content
    content={data.content}
    apiKey={'YOUR_KEY'}
    model="page"
    customComponents={customComponents}
/>  
```

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
