### PR TITLE
Update package.json with zone.js version adhering to semver

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -44,7 +44,7 @@
   "peerDependencies": {
     "rxjs": ">= 2",
     "tslib": ">= 1.10.0",
-    "zone.js": "0.14.7"
+    "zone.js": "0.14.x"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "18.0.7",


### PR DESCRIPTION
## Description

The intent of this change is to "assume that only changes in the host package's major version will break your plugin."  This allows apps using the latest version of Angular with 0.14.10 version of zone.js to still "build."

I am not sure how to create a changeset, but I do believe this will require a new release.  Is that correct?  Currently, I cannot use @builder.io/angular in Angular projects using the latest version.
