### PR TITLE
fix[vue-gen2]: isolated-vm changelog - remove plugin approach and add example for manual approach

### DIFF
--- a/.changeset/five-cows-bow.md
+++ b/.changeset/five-cows-bow.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/sdk-vue": patch
+---
+
+Fix: remove `@builder.io/sdk-vue/nuxt-initialize-node-runtime-plugin` plugin export

--- a/packages/sdks/output/vue/CHANGELOG.md
+++ b/packages/sdks/output/vue/CHANGELOG.md
@@ -8,16 +8,6 @@
 
   This import should be called in a server-only environment. For convenience, we offer:
 
-  - a new Nuxt plugin (`@builder.io/sdk-vue/nuxt-initialize-node-runtime-plugin`) that takes care of calling `initializeNodeRuntime`:
-
-    ```ts
-    // nuxt.config.ts
-    export default defineNuxtConfig({
-      // ...
-      plugins: ["@builder.io/sdk-vue/nuxt-initialize-node-runtime-plugin"],
-    });
-    ```
-
   - (Recommended) Updates to `@builder.io/sdk-vue/nuxt` Nuxt module which helps you achieve this in one place:
 
     - added `includeCompiledCss` flag that adds the compiled Builder.io CSS in Nuxt (defaults to `true`)
@@ -36,6 +26,18 @@
           },
         ],
       ],
+    });
+    ```
+  
+  - If you prefer to call this manually without using our Nuxt module, you can import and call `initializeNodeRuntime()` from the package `@builder.io/sdk-vue/node/init`. Make sure that this function is imported and executed only in the Node runtime environment, for example:
+
+    ```ts
+    // server/middleware/builder.global.ts
+    export default defineEventHandler(async (event) => {
+      const { initializeNodeRuntime } = await import(
+        "@builder.io/sdk-vue/node/init"
+      );
+      initializeNodeRuntime();
     });
     ```
 

--- a/packages/sdks/output/vue/CHANGELOG.md
+++ b/packages/sdks/output/vue/CHANGELOG.md
@@ -11,7 +11,7 @@
   - (Recommended) Updates to `@builder.io/sdk-vue/nuxt` Nuxt module which helps you achieve this in one place:
 
     - added `includeCompiledCss` flag that adds the compiled Builder.io CSS in Nuxt (defaults to `true`)
-    - added `initializeNodeRuntime` flag that executes `nuxt-initialize-node-runtime-plugin` plugin (defaults to `false`)
+    - added `initializeNodeRuntime` flag that automatically imports and executes `initializeNodeRuntime()` in the server.
 
     ```ts
     // nuxt.config.ts

--- a/packages/sdks/output/vue/CHANGELOG.md
+++ b/packages/sdks/output/vue/CHANGELOG.md
@@ -11,7 +11,7 @@
   - (Recommended) Updates to `@builder.io/sdk-vue/nuxt` Nuxt module which helps you achieve this in one place:
 
     - added `includeCompiledCss` flag that adds the compiled Builder.io CSS in Nuxt (defaults to `true`)
-    - added `initializeNodeRuntime` flag that automatically imports and executes `initializeNodeRuntime()` in the server.
+    - added `initializeNodeRuntime` flag that automatically imports and executes `initializeNodeRuntime()` in the server (defaults to `false`)
 
     ```ts
     // nuxt.config.ts

--- a/packages/sdks/output/vue/nuxt.js
+++ b/packages/sdks/output/vue/nuxt.js
@@ -31,7 +31,7 @@ export default defineNuxtModule({
       }
 
       addPlugin({
-        src: '@builder.io/sdk-vue/nuxt-initialize-node-runtime-plugin',
+        src: './nuxt-isolated-vm-plugin.js',
         mode: 'server',
       });
     }

--- a/packages/sdks/output/vue/package.json
+++ b/packages/sdks/output/vue/package.json
@@ -26,7 +26,6 @@
   "exports": {
     "./css": "./lib/browser/style.css",
     "./nuxt": "./nuxt.js",
-    "./nuxt-initialize-node-runtime-plugin": "./nuxt-isolated-vm-plugin.js",
     "./bundle/edge": {
       "import": "./lib/edge/index.mjs",
       "require": "./lib/edge/index.cjs"


### PR DESCRIPTION
## Description

Removes the plugin from being exported from the SDK and the plugin approach mentioned in the CHANGELOG

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
