### PR TITLE
fix[angular-gen2]: build after awaiter addition

### DIFF
--- a/packages/sdks/mitosis.config.cjs
+++ b/packages/sdks/mitosis.config.cjs
@@ -234,7 +234,11 @@ const filterActionAttrBindings = (json, item) => {
 const ANGULAR_ADD_UNUSED_PROP_TYPES = () => ({
   json: {
     post: (json) => {
-      if (json.name === 'BuilderImage' || json.name === 'BuilderSymbol') {
+      if (
+        json.name === 'BuilderImage' ||
+        json.name === 'BuilderSymbol' ||
+        json.name === 'Awaiter'
+      ) {
         json.hooks.onMount = json.hooks.onMount.filter(
           (hook) =>
             !hook.code.includes(

--- a/packages/sdks/src/components/awaiter.lite.tsx
+++ b/packages/sdks/src/components/awaiter.lite.tsx
@@ -3,6 +3,8 @@
  * Allows to dynamically import components.
  */
 
+import { onMount, useTarget } from '@builder.io/mitosis';
+
 type AwaiterProps = {
   load: () => Promise<any>;
   props?: any;
@@ -12,5 +14,18 @@ type AwaiterProps = {
 };
 
 export default function Awaiter(props: AwaiterProps) {
+  onMount(() => {
+    useTarget({
+      angular: () => {
+        /** this is a hack to include the input in angular */
+        const _ = {
+          a: props.load,
+          b: props.props,
+          c: props.attributes,
+          d: props.fallback,
+        };
+      },
+    });
+  });
   return <>{props.children}</>;
 }


### PR DESCRIPTION
## Description

Build was failing because it was expecting it to annotate `@Input()`s have added a quick fix for now. Tested locally this change didn't affect any other framework SDK

Jira
https://builder-io.atlassian.net/browse/ENG-7035

Error:
```
 ✖ Compiling with Angular sources in Ivy partial compilation mode.
      src/components/block/components/interactive-element.ts:34:9 - error NG8002: Can't bind to 'load' since it isn't a known property of 'awaiter'.
      
      34         [load]="Wrapper.load"
                 ~~~~~~~~~~~~~~~~~~~~~
      src/components/block/components/interactive-element.ts:35:9 - error NG8002: Can't bind to 'fallback' since it isn't a known property of 'awaiter'.
      
      35         [fallback]="Wrapper.fallback"
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      src/components/block/components/interactive-element.ts:36:9 - error NG8002: Can't bind to 'props' since it isn't a known property of 'awaiter'.
      
      36         [props]="wrapperProps"
                 ~~~~~~~~~~~~~~~~~~~~~~
      src/components/block/components/interactive-element.ts:37:9 - error NG8002: Can't bind to 'attributes' since it isn't a known property of 'awaiter'.
      
      37         [attributes]="attributes"
```

_Screenshot_
![Screenshot 2024-10-08 at 2 39 07 PM](https://github.com/user-attachments/assets/20b11542-6e37-4664-8b80-001eb29d3112)

