### PR TITLE
EDU-256: Angular Gen 2 Product Editorial Blueprints 

### DIFF
--- a/packages/sdks-tests/src/snippet-tests/blueprints-editorial.spec.ts
+++ b/packages/sdks-tests/src/snippet-tests/blueprints-editorial.spec.ts
@@ -3,7 +3,7 @@ import { test } from '../helpers/index.js';
 
 test.describe('Product Editorial Page with Real Data', () => {
   test.beforeEach(async ({ page, packageName }) => {
-    test.skip(!['angular', 'angular-ssr'].includes(packageName));
+    test.skip(!['angular'].includes(packageName));
     // Navigate to the product editorial page
     await page.goto('/products/1');
   });

--- a/packages/sdks-tests/src/snippet-tests/blueprints-editorial.spec.ts
+++ b/packages/sdks-tests/src/snippet-tests/blueprints-editorial.spec.ts
@@ -17,17 +17,15 @@ test.describe('Product Editorial Page with Real Data', () => {
   test('should render the product info with real data', async ({ page }) => {
     // Wait for the product image element to appear
     const productImage = page.locator('.product-image img');
-    await productImage.waitFor();
+    await expect(productImage).toBeAttached();
+    await expect(productImage).toHaveAttribute('src', /.+/);
+    await expect(productImage).toBeVisible();
 
-    const imgSrc = await productImage.getAttribute('src');
-    expect(imgSrc).toBeTruthy();
-
-    // Retrieve the image properties after it is loaded
-    await productImage.evaluate((img: HTMLImageElement) => ({
-      complete: img.complete,
-      naturalWidth: img.naturalWidth,
-      naturalHeight: img.naturalHeight,
-    }));
+    // Wait for the image to load completely
+    await page.waitForFunction(imgSelector => {
+      const img = document.querySelector(imgSelector) as HTMLImageElement;
+      return img && img.complete && img.naturalWidth > 0;
+    }, '.product-image img');
 
     // Verify the product title, description, price, and rating are displayed
     const productTitle = page.locator('.product-info h2');

--- a/packages/sdks-tests/src/snippet-tests/blueprints-editorial.spec.ts
+++ b/packages/sdks-tests/src/snippet-tests/blueprints-editorial.spec.ts
@@ -15,19 +15,19 @@ test.describe('Product Editorial Page with Real Data', () => {
   });
 
   test('should render the product info with real data', async ({ page }) => {
-    // Verify the product image exists
-    const imageElement = page.locator('.product-image > img');
-    await expect(imageElement).toBeVisible();
+    // Wait for the product image element to appear
+    const productImage = page.locator('.product-image img');
+    await productImage.waitFor();
 
-    const imageInfo = await imageElement.evaluate((img: HTMLImageElement) => ({
+    const imgSrc = await productImage.getAttribute('src');
+    expect(imgSrc).toBeTruthy();
+
+    // Retrieve the image properties after it is loaded
+    await productImage.evaluate((img: HTMLImageElement) => ({
+      complete: img.complete,
       naturalWidth: img.naturalWidth,
       naturalHeight: img.naturalHeight,
-      complete: img.complete,
     }));
-
-    expect(imageInfo.complete).toBe(true);
-    expect(imageInfo.naturalWidth).toBeGreaterThan(0);
-    expect(imageInfo.naturalHeight).toBeGreaterThan(0);
 
     // Verify the product title, description, price, and rating are displayed
     const productTitle = page.locator('.product-info h2');

--- a/packages/sdks-tests/src/snippet-tests/blueprints-editorial.spec.ts
+++ b/packages/sdks-tests/src/snippet-tests/blueprints-editorial.spec.ts
@@ -1,0 +1,58 @@
+import { expect } from '@playwright/test';
+import { test } from '../helpers/index.js';
+
+test.describe('Product Editorial Page with Real Data', () => {
+  test.beforeEach(async ({ page, packageName }) => {
+    test.skip(!['angular', 'angular-ssr'].includes(packageName));
+    // Navigate to the product editorial page
+    await page.goto('/products/1');
+  });
+
+  test('should render the header component', async ({ page }) => {
+    const header = page.locator('app-header');
+    await expect(header).toBeVisible();
+    await expect(header.locator('h1')).toHaveText('Acme Corp');
+  });
+
+  test('should render the product info with real data', async ({ page }) => {
+    // Verify the product image exists
+    const imageElement = page.locator('.product-image > img');
+    await expect(imageElement).toBeVisible();
+
+    const imageInfo = await imageElement.evaluate((img: HTMLImageElement) => ({
+      naturalWidth: img.naturalWidth,
+      naturalHeight: img.naturalHeight,
+      complete: img.complete,
+    }));
+
+    expect(imageInfo.complete).toBe(true);
+    expect(imageInfo.naturalWidth).toBeGreaterThan(0);
+    expect(imageInfo.naturalHeight).toBeGreaterThan(0);
+
+    // Verify the product title, description, price, and rating are displayed
+    const productTitle = page.locator('.product-info h2');
+    const productDescription = page.locator('.product-info p').nth(0);
+    const productPrice = page.locator('.product-info p').nth(1);
+    const productRating = page.locator('.product-info p').nth(2);
+
+    await expect(productTitle).toBeVisible();
+    await expect(productDescription).toBeVisible();
+    await expect(productPrice).toBeVisible();
+    await expect(productRating).toBeVisible();
+  });
+
+  test('should render the editorial content with real data', async ({ page }) => {
+    const editorialContent = page.locator('builder-content');
+    await expect(editorialContent).toBeVisible();
+
+    // Verify that the editorial content contains some text (as the real data may vary)
+    const editorialText = editorialContent.locator('div').nth(1);
+    await expect(editorialText).toBeVisible();
+  });
+
+  test('should render the footer component', async ({ page }) => {
+    const footer = page.locator('app-footer');
+    await expect(footer).toBeVisible();
+    await expect(footer.locator('p')).toHaveText('© 2024 Acme Corp. All rights reserved.');
+  });
+});

--- a/packages/sdks/snippets/angular/src/app/app.module.ts
+++ b/packages/sdks/snippets/angular/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { AnnouncementBarComponent } from './announcement-bar/announcement-bar.co
 import { AppComponent } from './app.component';
 import { BlogArticleComponent } from './blog-article/blog-article.component';
 import { CatchAllComponent } from './catch-all/catch-all.component';
+import { ProductEditorialComponent } from './product-editorial/product-editorial.component';
 
 @NgModule({
   declarations: [AppComponent, AnnouncementBarComponent, CatchAllComponent],
@@ -19,9 +20,11 @@ import { CatchAllComponent } from './catch-all/catch-all.component';
     BrowserModule,
     Content,
     BlogArticleComponent,
+    ProductEditorialComponent,
     RouterModule.forRoot([
       { path: 'announcements/:id', component: AnnouncementBarComponent },
       { path: 'blogs/new-product-line', component: BlogArticleComponent },
+      { path: 'products/:id', component: ProductEditorialComponent },
       { path: '**', component: CatchAllComponent },
     ]),
   ],

--- a/packages/sdks/snippets/angular/src/app/product-editorial/footer/footer.component.ts
+++ b/packages/sdks/snippets/angular/src/app/product-editorial/footer/footer.component.ts
@@ -1,0 +1,22 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-footer',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div
+      style="display: flex; 
+      justify-content: center; 
+      align-items: center; 
+      padding: 0.2rem; 
+      background-color: #f0f0f0; 
+      border-top: 1px solid #e0e0e0; 
+      margin: 1rem 0;"
+    >
+      <p>© 2024 Acme Corp. All rights reserved.</p>
+    </div>
+  `,
+})
+export class FooterComponent {}

--- a/packages/sdks/snippets/angular/src/app/product-editorial/header/header.component.ts
+++ b/packages/sdks/snippets/angular/src/app/product-editorial/header/header.component.ts
@@ -1,0 +1,22 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-header',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div
+      style="display: flex; 
+      justify-content: center; 
+      align-items: center; 
+      background-color: #f0f0f0; 
+      border-bottom: 1px solid #e0e0e0;
+      padding: 0.2rem;
+      margin: 1rem 0;"
+    >
+      <h1>Acme Corp</h1>
+    </div>
+  `,
+})
+export class HeaderComponent {}

--- a/packages/sdks/snippets/angular/src/app/product-editorial/product-editorial.component.ts
+++ b/packages/sdks/snippets/angular/src/app/product-editorial/product-editorial.component.ts
@@ -1,0 +1,70 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import {
+  Content,
+  fetchOneEntry,
+  type BuilderContent,
+} from '@builder.io/sdk-angular';
+import { FooterComponent } from './footer/footer.component';
+import { HeaderComponent } from './header/header.component';
+import { ProductInfoComponent } from './product-info/product-info.component';
+
+@Component({
+  selector: 'app-product-editorial',
+  standalone: true,
+  imports: [
+    Content,
+    CommonModule,
+    ProductInfoComponent,
+    HeaderComponent,
+    FooterComponent,
+  ],
+  template: `
+    <!-- Header -->
+    <app-header />
+
+    <!-- Product info -->
+    <div *ngIf="product">
+      <app-product-info [product]="product" />
+
+      <!-- Builder content -->
+      <builder-content
+        *ngIf="editorial"
+        [content]="editorial"
+        model="product-editorial"
+      >
+      </builder-content>
+    </div>
+
+    <!-- Footer -->
+    <app-footer />
+  `,
+})
+export class ProductEditorialComponent {
+  product: any;
+  editorial: BuilderContent | null = null;
+  productId?: string;
+
+  async ngOnInit() {
+    this.productId = window.location.pathname.split('/').pop() || '';
+    if (this.productId) {
+      await this.fetchProductAndEditorial();
+    }
+  }
+
+  private async fetchProductAndEditorial() {
+    // Fetch product data from external API or your own CMS
+    this.product = await fetch(
+      `https://fakestoreapi.com/products/${this.productId}`
+    ).then((res) => res.json());
+
+    // Fetch editorial content from Builder.io
+    this.editorial = await fetchOneEntry({
+      apiKey: 'ee9f13b4981e489a9a1209887695ef2b',
+      model: 'product-editorial',
+      userAttributes: {
+        urlPath: window.location.pathname || '/',
+      },
+    });
+  }
+}

--- a/packages/sdks/snippets/angular/src/app/product-editorial/product-editorial.component.ts
+++ b/packages/sdks/snippets/angular/src/app/product-editorial/product-editorial.component.ts
@@ -20,7 +20,6 @@ import { ProductInfoComponent } from './product-info/product-info.component';
     FooterComponent,
   ],
   template: `
-    <!-- Header -->
     <app-header />
 
     <!-- Product info -->
@@ -36,7 +35,6 @@ import { ProductInfoComponent } from './product-info/product-info.component';
       </builder-content>
     </div>
 
-    <!-- Footer -->
     <app-footer />
   `,
 })

--- a/packages/sdks/snippets/angular/src/app/product-editorial/product-editorial.component.ts
+++ b/packages/sdks/snippets/angular/src/app/product-editorial/product-editorial.component.ts
@@ -23,17 +23,15 @@ import { ProductInfoComponent } from './product-info/product-info.component';
     <app-header />
 
     <!-- Product info -->
-    <div *ngIf="product">
-      <app-product-info [product]="product" />
+    <app-product-info [product]="product" />
 
-      <!-- Builder content -->
-      <builder-content
-        *ngIf="editorial"
-        [content]="editorial"
-        model="product-editorial"
-      >
-      </builder-content>
-    </div>
+    <!-- Builder content -->
+    <builder-content
+      *ngIf="editorial"
+      [content]="editorial"
+      model="product-editorial"
+    >
+    </builder-content>
 
     <app-footer />
   `,

--- a/packages/sdks/snippets/angular/src/app/product-editorial/product-info/product-info.component.ts
+++ b/packages/sdks/snippets/angular/src/app/product-editorial/product-info/product-info.component.ts
@@ -1,0 +1,30 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+@Component({
+  selector: 'app-product-info',
+  standalone: true,
+  imports: [CommonModule],
+  template: ` <div
+    *ngIf="product"
+    style="display: flex; gap: 200px; max-width: 1200px"
+  >
+    <div class="product-image">
+      <img
+        [src]="product.image"
+        [style.width.px]="300"
+        [style.height.px]="300"
+        [alt]="product.title"
+      />
+    </div>
+    <div class="product-info">
+      <h2>{{ product.title }}</h2>
+      <p>{{ product.description }}</p>
+      <p>Price: {{ product.price }} $</p>
+      <p>Rating: {{ product.rating.rate }} / 5</p>
+      <button>Buy now</button>
+    </div>
+  </div>`,
+})
+export class ProductInfoComponent {
+  @Input() product: any;
+}


### PR DESCRIPTION
## Description

This PR includes the Angular Gen 2 product editorial example code but excludes the SSR example, which will be raised in another PR.

@samijaber As you suggested, I have tried my best to keep it as close to the react example as possible with `<ProductInfo/>` component and `<builder-content/>` in between `<Header> `and `<Footer>` 

Developers can quickly implement the Header and Footer and connect it to their CMS or e-commerce backend API. By abstracting this logic, we can focus on the ProductEditorialComponent, which demonstrates what we are trying to achieve with these components displayed here. We can safely automate this single file, and it will still work if they create some placeholders inline. 

If you think, this is still a lot of cognitive overload for them, I can refactor it and keep everything inline in one single file. 

Kindly review :)
