### PR TITLE
warn users if they are on node 20 + Ubuntu

### DIFF
--- a/packages/sdks/output/vue/nuxt.js
+++ b/packages/sdks/output/vue/nuxt.js
@@ -1,4 +1,4 @@
-import { addPlugin, defineNuxtModule } from '@nuxt/kit';
+import { addPlugin, defineNuxtModule, createResolver } from '@nuxt/kit';
 
 export default defineNuxtModule({
   setup(options, nuxt) {
@@ -30,8 +30,9 @@ export default defineNuxtModule({
         };
       }
 
+      const resolver = createResolver(import.meta.url);
       addPlugin({
-        src: './nuxt-isolated-vm-plugin.js',
+        src: resolver.resolve('nuxt-isolated-vm-plugin.js'),
         mode: 'server',
       });
     }

--- a/packages/sdks/output/vue/vite.config.js
+++ b/packages/sdks/output/vue/vite.config.js
@@ -45,6 +45,10 @@ export default defineConfig({
                 __dirname,
                 'src/functions/evaluate/node-runtime/init.ts'
               ),
+              'check-os': resolve(
+                __dirname,
+                'src/functions/evaluate/node-runtime/check-os.ts'
+              ),
             }
           : {}),
       },
@@ -53,7 +57,7 @@ export default defineConfig({
         `${entryName}.${format === 'es' ? 'mjs' : 'cjs'}`,
     },
     rollupOptions: {
-      external: ['vue', 'node:module', 'isolated-vm'],
+      external: ['vue', 'node:module', 'isolated-vm', 'os', 'fs'],
       output: {
         globals: {
           vue: 'Vue',

--- a/packages/sdks/src/functions/evaluate/node-runtime/check-os.ts
+++ b/packages/sdks/src/functions/evaluate/node-runtime/check-os.ts
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import os from 'os';
+
+let cachedOS: string | null = null;
+
+const whichOS = (): string => {
+  if (cachedOS) return cachedOS;
+
+  const platform = os.platform();
+  switch (platform) {
+    case 'linux':
+      try {
+        const data = fs.readFileSync('/etc/os-release', 'utf8');
+        const nameMatch = data.match(/^NAME="(.+)"$/m);
+        const versionMatch = data.match(/^VERSION_ID="(.+)"$/m);
+        const osName = nameMatch?.[1] ?? 'Linux (unknown distribution)';
+        const osVersion = versionMatch?.[1] ?? 'unknown version';
+        cachedOS = `${osName} ${osVersion}`;
+      } catch (err) {
+        console.warn(
+          `Error reading Linux OS information from /etc/os-release:`,
+          err
+        );
+        cachedOS = 'Linux';
+      }
+      break;
+    case 'darwin':
+      cachedOS = 'macOS';
+      break;
+    case 'win32':
+      cachedOS = 'Windows';
+      break;
+    default:
+      cachedOS = platform;
+  }
+
+  return cachedOS;
+};
+
+const osName = whichOS();
+console.log('[Builder.io] running on OS:', osName);
+
+const ubuntuVersionMatch = osName.match(/Ubuntu (\d+)/);
+if (ubuntuVersionMatch) {
+  const ubuntuVersion = parseInt(ubuntuVersionMatch[1]);
+  if (ubuntuVersion >= 22) {
+    console.warn(
+      `WARNING: You are running Builder SDK on ${osName}. This is known to cause crashes with \`isolated-vm\`. See https://github.com/BuilderIO/builder/issues/3605 for more information.`
+    );
+  }
+}

--- a/packages/sdks/src/functions/evaluate/node-runtime/init.ts
+++ b/packages/sdks/src/functions/evaluate/node-runtime/init.ts
@@ -1,3 +1,37 @@
+import fs from 'fs';
+import os from 'os';
+
+const isNode20 = process.version.startsWith('v20');
+
+const whichOS = (): string => {
+  const platform = os.platform();
+
+  switch (platform) {
+    case 'linux':
+      try {
+        const data = fs.readFileSync('/etc/os-release', 'utf8');
+        const match = data.match(/^NAME="(.+)"$/m);
+        return match ? match[1] : 'Linux (unknown distribution)';
+      } catch (err) {
+        console.warn('Error reading OS information:', err);
+        return 'Linux';
+      }
+    case 'darwin':
+      return 'macOS';
+    case 'win32':
+      return 'Windows';
+    default:
+      return platform;
+  }
+};
+
+const osName = whichOS();
+if (osName.includes('Ubuntu') && isNode20) {
+  console.warn(
+    'WARNING: You are running Node 20 on Ubuntu. This combination is known to cause crashes with `isolated-vm`. See https://github.com/BuilderIO/builder/issues/3605 for more information.'
+  );
+}
+
 import { shouldForceBrowserRuntimeInNode } from '../should-force-browser-runtime-in-node.js';
 /**
  * This file:

--- a/packages/sdks/src/functions/evaluate/node-runtime/init.ts
+++ b/packages/sdks/src/functions/evaluate/node-runtime/init.ts
@@ -1,38 +1,5 @@
-import fs from 'fs';
-import os from 'os';
-
-const isNode20 = process.version.startsWith('v20');
-
-const whichOS = (): string => {
-  const platform = os.platform();
-
-  switch (platform) {
-    case 'linux':
-      try {
-        const data = fs.readFileSync('/etc/os-release', 'utf8');
-        const match = data.match(/^NAME="(.+)"$/m);
-        return match ? match[1] : 'Linux (unknown distribution)';
-      } catch (err) {
-        console.warn('Error reading OS information:', err);
-        return 'Linux';
-      }
-    case 'darwin':
-      return 'macOS';
-    case 'win32':
-      return 'Windows';
-    default:
-      return platform;
-  }
-};
-
-const osName = whichOS();
-if (osName.includes('Ubuntu') && isNode20) {
-  console.warn(
-    'WARNING: You are running Node 20 on Ubuntu. This combination is known to cause crashes with `isolated-vm`. See https://github.com/BuilderIO/builder/issues/3605 for more information.'
-  );
-}
-
 import { shouldForceBrowserRuntimeInNode } from '../should-force-browser-runtime-in-node.js';
+import './check-os.js';
 /**
  * This file:
  * - imports `isolated-vm`, which can only be made from a file that never runs


### PR DESCRIPTION
## Description

Checks if the OS is Ubuntu running Node.js v20, then warns users that it might cause issues with the `isolated-vm` library.

To test `whichOS` function where OS is Ubuntu: https://onecompiler.com/nodejs/42vd2jj7s

**Jira**
https://builder-io.atlassian.net/browse/PLAN-303

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
