### PR TITLE
fix(vue-sdk): imperatively enable editor using hook

### DIFF
--- a/.changeset/many-items-type.md
+++ b/.changeset/many-items-type.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/sdk-vue": patch
+---
+
+Fix: imperatively enable editor for symbol preview

--- a/packages/sdks/mitosis.config.cjs
+++ b/packages/sdks/mitosis.config.cjs
@@ -634,6 +634,7 @@ module.exports = {
       namePrefix: (path) => (path.includes('/blocks/') ? 'builder' : ''),
       cssNamespace: getSeededId,
       plugins: [
+        INJECT_ENABLE_EDITOR_ON_EVENT_HOOKS_PLUGIN,
         () => ({
           json: {
             // This plugin handles binding our actions to the `v-on:` Vue syntax:

--- a/packages/sdks/src/components/content/components/enable-editor.lite.tsx
+++ b/packages/sdks/src/components/content/components/enable-editor.lite.tsx
@@ -341,6 +341,9 @@ export default function EnableEditor(props: BuilderEditorProps) {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           angular: () => INJECT_EDITING_HOOK_HERE,
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          vue: () => INJECT_EDITING_HOOK_HERE,
           default: () => {
             if (elementRef) {
               elementRef.dispatchEvent(new CustomEvent('initeditingbldr'));


### PR DESCRIPTION
## Description

This pull request ensures that the Editor is initialized even if no content is passed solving the issue https://github.com/BuilderIO/builder/issues/3653 where Symbol preview does not work as expected.

It uses the same method as the other frameworks.