### PR TITLE
chore:Changing email from help to support

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,4 +2,4 @@
 
 ## Reporting a Vulnerability
 
-Please report (suspected) security vulnerabilities to help@builder.io. If the issue is confirmed, we will release a patch as soon as possible depending on complexity. Thank you!
+Please report (suspected) security vulnerabilities to support@builder.io. If the issue is confirmed, we will release a patch as soon as possible depending on complexity. Thank you!

--- a/examples/embed-starter-kit/plugin/README.md
+++ b/examples/embed-starter-kit/plugin/README.md
@@ -2,7 +2,7 @@
 
 ## Getting started
 
-This example relies on enterprise features of Builder, please make sure you have the right space permissions/subscription before starting, if you don't, you can contact help@builder.io with your use case, and we'll set a proof of concept space for you.
+This example relies on enterprise features of Builder, please make sure you have the right space permissions/subscription before starting, if you don't, you can contact support@builder.io with your use case, and we'll set a proof of concept space for you.
 
 ### Install
 

--- a/packages/angular/src/app/modules/builder/services/builder.service.ts
+++ b/packages/angular/src/app/modules/builder/services/builder.service.ts
@@ -68,7 +68,7 @@ export class BuilderService extends Builder {
     if (!Builder.isBrowser && !this.request) {
       console.warn(
         'No express request set! Builder cannot target appropriately without this, ' +
-          'please contact help@builder.io to learn how to set this as required'
+          'please contact support@builder.io to learn how to set this as required'
       );
     }
   }

--- a/packages/plugin-tools/src/components/error-boundary.tsx
+++ b/packages/plugin-tools/src/components/error-boundary.tsx
@@ -33,9 +33,9 @@ export const ErrorMessage = () => (
     <a
       css={{ color: 'steelblue', cursor: 'pointer', fontWeight: 'bold' }}
       target="_blank"
-      href="mailto:help@builder.io"
+      href="mailto:support@builder.io"
     >
-      help@builder.io
+      support@builder.io
     </a>{' '}
     if this continues
   </div>

--- a/packages/widgets/README.md
+++ b/packages/widgets/README.md
@@ -59,4 +59,4 @@ For more detail, read the official Builder widgets documentation, [Using Widgets
 
 ## Help and troubleshooting
 
-If you have questions or feedback, contact us at <help@builder.io>. We are happy to help!
+If you have questions or feedback, contact us at <support@builder.io>. We are happy to help!

--- a/plugins/algolia/package.json
+++ b/plugins/algolia/package.json
@@ -10,7 +10,7 @@
   "files": [
     "dist"
   ],
-  "author": "Builder.io <help@builder.io>",
+  "author": "Builder.io <support@builder.io>",
   "repository": {
     "type": "git",
     "url": ""

--- a/plugins/example-data-plugin/README.md
+++ b/plugins/example-data-plugin/README.md
@@ -13,4 +13,4 @@ This folder is a starting point to connecting your custom data plugins.
     3. add `http://locahost:1268/plugin.system.js?pluginId={{fill this with your package.json id form first bullet point above}}`
     4. now page will refresh to add your plugin code to the app
     5. navigate to any builder content and in the data tab test your data plugin.
- - Once you're done coding make a PR to this repo, or contact us @ help@builder.io if you're interested in building private plugins.
+ - Once you're done coding make a PR to this repo, or contact us @ support@builder.io if you're interested in building private plugins.

--- a/plugins/rich-text/README.md
+++ b/plugins/rich-text/README.md
@@ -5,7 +5,7 @@ See [here](src/plugin.tsx) for the React component that powers this plugin
 ## Status
 
 Builder plugins are in beta. If you run into any issues or have questions please
-contact help@builder.io for help
+contact support@builder.io for help
 
 ## Creating a new plugin from this example
 

--- a/plugins/shopify-demo/src/plugin.tsx
+++ b/plugins/shopify-demo/src/plugin.tsx
@@ -84,7 +84,7 @@ registerCommercePlugin(
         } catch (e) {
           console.error(e);
           appState.dialogs.alert(
-            'If this problem persists, please contact help@builder.io',
+            'If this problem persists, please contact support@builder.io',
             'Uh oh! An error occured :('
           );
         }


### PR DESCRIPTION
## Description

Changing the email from `help@builder.io` to `support@builder.io` as the email help@builder.io is not under monitoring.
This email is used in some error messages, for example:

```
No express request set! Builder cannot target appropriately without this, please contact [help@builder.io](mailto:help@builder.io) to learn how to set this as required
```
