### PR TITLE
chore: add jsdoc for some types in BuilderElement

### DIFF
--- a/.changeset/thirty-apples-thank.md
+++ b/.changeset/thirty-apples-thank.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/sdk": patch
+---
+
+Types: add jsdoc comments for some Builder SDK types

--- a/packages/core/src/types/element.ts
+++ b/packages/core/src/types/element.ts
@@ -31,9 +31,26 @@ export interface BuilderElement {
   };
   component?: {
     name: string;
+    /**
+     * el.component.options is a key-value record where the values are static, literal expressions.
+     * These may be set as a result of el.bindings being evaluated.
+     * These get passed as props to the underlying component, such as a React component.
+     * 
+     * el.component.options["bar"] = "abc" --> <CustomReactComponent bar={"abc"} ...>
+     */
     options?: any;
     tag?: string;
   };
+
+  /**
+   * el.bindings is a key-value record where the values can be dynamic JS expressions. 
+   * These may be set as a result of el.code.bindings being edited and then transpiled.
+   * After the expressions are evaluated, the key and result value get bound elsewhere 
+   * according to this pattern:
+   * 
+   * el.bindings["foo"] will be bound to el.properties["foo"]
+   * el.bindings["component.options.bar"] will be bound to el.component.options["bar"]
+   */
   bindings?: {
     [key: string]: string;
   };
@@ -43,10 +60,24 @@ export interface BuilderElement {
   actions?: {
     [key: string]: string;
   };
+
+  /**
+   * el.properties is a key-value record where the values are static, literal expressions.
+   * These may be set as a result of el.bindings being evaluated.
+   * These get applied as attributes on the top-level HTML element inside this Element.
+   * 
+   * el.properties["foo"] = "1" --> <htmlnode foo="1" ...>
+   */
   properties?: {
     [key: string]: string;
   };
   code?: {
+    /**
+     * el.code.bindings is a key-value record where the values represent user-authored code 
+     * written in Builder's Data view. The values can be literal or dynamic expressions, 
+     * can use Types, and can even add complex logic like async/await. These values get transpiled 
+     * and the results override the matching key-value pair in el.bindings.
+     */
     bindings?: {
       [key: string]: string;
     };


### PR DESCRIPTION
## Description

Adding jsdoc types for some types in BuilderElement to clarify how they are used by Builder.

