### PR TITLE
Export text evaluate function

### DIFF
--- a/.changeset/new-lemons-visit.md
+++ b/.changeset/new-lemons-visit.md
@@ -1,0 +1,14 @@
+---
+'@builder.io/sdk': patch
+'@builder.io/react': patch
+'@builder.io/sdk-angular': patch
+'@builder.io/sdk-react-nextjs': patch
+'@builder.io/sdk-qwik': patch
+'@builder.io/sdk-react': patch
+'@builder.io/sdk-react-native': patch
+'@builder.io/sdk-solid': patch
+'@builder.io/sdk-svelte': patch
+'@builder.io/sdk-vue': patch
+---
+
+Export the evaluate function to allow custom Text components to evaluate Custom Data and Context

--- a/packages/sdks/src/server-index.ts
+++ b/packages/sdks/src/server-index.ts
@@ -40,6 +40,8 @@ export { track } from './functions/track/index.js';
 
 export { subscribeToEditor } from './helpers/subscribe-to-editor.js';
 
+export { evaluate } from './functions/evaluate/index.js';
+
 /**
  * Content fetching
  */


### PR DESCRIPTION
## Description

We're overwriting the default Text component in order to add some functionality.

However by doing this we've lost the ability to use [Custom data and Context](https://www.builder.io/c/docs/custom-actions) in our text component ( inserting values into text fields like this: {{state.value}}.

By exporting the evaluate function we will be able to add this functionality into our custom text component.
