### PR TITLE
feat[plugins][commerceTools]: ENG-7187 CommerceTools Plugin request object breaks when Bearer token refreshes

### DIFF
--- a/packages/plugin-tools/src/interfaces/builder-request.ts
+++ b/packages/plugin-tools/src/interfaces/builder-request.ts
@@ -5,6 +5,7 @@ export interface BuilderRequest {
     query?: { [key: string]: string };
     headers?: { [key: string]: string };
     method?: string;
+    body?: { [key: string]: any };
   };
   options?: { [key: string]: any };
   bindings?: { [key: string]: string };

--- a/packages/plugin-tools/src/interfaces/builder-request.ts
+++ b/packages/plugin-tools/src/interfaces/builder-request.ts
@@ -5,7 +5,6 @@ export interface BuilderRequest {
     query?: { [key: string]: string };
     headers?: { [key: string]: string };
     method?: string;
-    body?: { [key: string]: any };
   };
   options?: { [key: string]: any };
   bindings?: { [key: string]: string };

--- a/plugins/commercetools/src/plugin.ts
+++ b/plugins/commercetools/src/plugin.ts
@@ -148,15 +148,12 @@ registerCommercePlugin(
           return {
             '@type': '@builder.io/core:Request' as const,
             request: {
-              url: `${appState.config.apiRoot()}/api/v1/plugin-proxy?pluginId=${pkg.name}&apiKey=${appState.user.apiKey}`,
-              method: 'POST',
-              body: {
-                request: {
-                  url: `${apiUrl}${requestBuilder.products.byId(id).build()}`,
-                  headers,
-                  method: 'GET',
-                }
-              }
+              url: `${appState.config.apiRoot()}/api/v1/plugin-proxy?pluginId=${pkg.name}&apiKey=${appState.user.apiKey}&request=${encodeURIComponent(JSON.stringify({
+                url: `${apiUrl}${requestBuilder.products.byId(id).build()}`,
+                headers,
+                method: 'GET',
+              }))}`,
+              method: 'GET',
             },
             options: {
               product: id,
@@ -204,15 +201,12 @@ registerCommercePlugin(
           return {
             '@type': '@builder.io/core:Request' as const,
             request: {
-              url: `${appState.config.apiRoot()}/api/v1/plugin-proxy?pluginId=${pkg.name}&apiKey=${appState.user.apiKey}`,
-              method: 'POST',
-              body: {
-                request: {
-                  url: `${apiUrl}${requestBuilder.categories.byId(id).build()}`,
-                  headers,
-                  method: 'GET',
-                }
-              }
+              url: `${appState.config.apiRoot()}/api/v1/plugin-proxy?pluginId=${pkg.name}&apiKey=${appState.user.apiKey}&request=${encodeURIComponent(JSON.stringify({
+                url: `${apiUrl}${requestBuilder.categories.byId(id).build()}`,
+                headers,
+                method: 'GET',
+              }))}`,
+              method: 'GET',
             },
             options: {
               category: id,

--- a/plugins/commercetools/src/plugin.ts
+++ b/plugins/commercetools/src/plugin.ts
@@ -150,7 +150,6 @@ registerCommercePlugin(
             request: {
               url: `${appState.config.apiRoot()}/api/v1/plugin-proxy?pluginId=${pkg.name}&apiKey=${appState.user.apiKey}&request=${encodeURIComponent(JSON.stringify({
                 url: `${apiUrl}${requestBuilder.products.byId(id).build()}`,
-                headers,
                 method: 'GET',
               }))}`,
               method: 'GET',
@@ -203,7 +202,6 @@ registerCommercePlugin(
             request: {
               url: `${appState.config.apiRoot()}/api/v1/plugin-proxy?pluginId=${pkg.name}&apiKey=${appState.user.apiKey}&request=${encodeURIComponent(JSON.stringify({
                 url: `${apiUrl}${requestBuilder.categories.byId(id).build()}`,
-                headers,
                 method: 'GET',
               }))}`,
               method: 'GET',

--- a/plugins/commercetools/src/plugin.ts
+++ b/plugins/commercetools/src/plugin.ts
@@ -1,4 +1,4 @@
-import { registerCommercePlugin } from '@builder.io/plugin-tools';
+import { registerCommercePlugin, BuilderRequest, CommerceAPIOperations } from '@builder.io/plugin-tools';
 import { Resource } from '@builder.io/plugin-tools/dist/types/interfaces/resource';
 import pkg from '../package.json';
 import { createRequestBuilder } from '@commercetools/api-request-builder';
@@ -79,7 +79,7 @@ registerCommercePlugin(
     ],
     ctaText: `Connect your Commercetools API`,
   },
-  async settings => {
+  async (settings: any): Promise<CommerceAPIOperations> => {
     const clientId = settings.get('clientId');
     const secret = settings.get('secret');
     const scopes = settings.get('scopes');
@@ -143,13 +143,20 @@ registerCommercePlugin(
             .then(res => res.results.map((product: any) => transform(product)));
           return results;
         },
-        getRequestObject(id: string) {
+        getRequestObject(id: string): BuilderRequest {
           const requestBuilder = createRequestBuilder({ projectKey });
           return {
             '@type': '@builder.io/core:Request' as const,
             request: {
-              url: `${apiUrl}${requestBuilder.products.byId(id).build()}`,
-              headers,
+              url: `${appState.config.apiRoot()}/api/v1/plugin-proxy?pluginId=${pkg.name}&apiKey=${appState.user.apiKey}`,
+              method: 'POST',
+              body: {
+                request: {
+                  url: `${apiUrl}${requestBuilder.products.byId(id).build()}`,
+                  headers,
+                  method: 'GET',
+                }
+              }
             },
             options: {
               product: id,
@@ -192,13 +199,20 @@ registerCommercePlugin(
             .then(res => res.results.map((product: any) => transform(product)));
           return results;
         },
-        getRequestObject(id: string) {
+        getRequestObject(id: string): BuilderRequest {
           const requestBuilder = createRequestBuilder({ projectKey });
           return {
             '@type': '@builder.io/core:Request' as const,
             request: {
-              url: `${apiUrl}${requestBuilder.categories.byId(id).build()}`,
-              headers,
+              url: `${appState.config.apiRoot()}/api/v1/plugin-proxy?pluginId=${pkg.name}&apiKey=${appState.user.apiKey}`,
+              method: 'POST',
+              body: {
+                request: {
+                  url: `${apiUrl}${requestBuilder.categories.byId(id).build()}`,
+                  headers,
+                  method: 'GET',
+                }
+              }
             },
             options: {
               category: id,


### PR DESCRIPTION
**Description**

- When adding the custom component to ContentEditor, modify the `requestObject` to point to the `plugin-proxy` endpoint from which the bearer token gets refreshed.
- Include the target url and other parameters in the body of the request.

**Link to JIRA ticket:**
https://builder-io.atlassian.net/browse/ENG-7187

**Steps to test:**
1. Use the commercetools plugin to create a component with `@builder.io/core:Request` property
```
{
  "@type": "@builder.io/core:Request",
  "request": {
    "url": "https://cdn.builder.io/api/v1/plugin-proxy?pluginId=@builder.io/plugin-commercetools&apiKey=XXX",
    "method": "POST",
    "body": {
      "request": {
        "url": "https://api.australia-southeast1.gcp.commercetools.com/eng-7186/products/XXX",
        "headers": {
          "Authorization": "Bearer XXX"
        },
        "method": "GET"
      }
    }
  }
```

**Loom**
https://www.loom.com/share/1626f858e0d64c36a756939955d779b6
