### PR TITLE
docs(nuxt): use proper key to useAsyncData

### DIFF
--- a/examples/vue/nuxt-3-catchall/pages/[...app].vue
+++ b/examples/vue/nuxt-3-catchall/pages/[...app].vue
@@ -45,7 +45,7 @@ const BUILDER_PUBLIC_API_KEY = 'f1a790f8c3204b3b8c5c1795aeac4660'; // ggignore
 const route = useRoute();
 
 // fetch builder content data
-const { data: content } = await useAsyncData('builderData', () =>
+const { data: content } = await useAsyncData(`builderData-page-${route.path}`, () =>
   fetchOneEntry({
     model: 'page',
     apiKey: BUILDER_PUBLIC_API_KEY,

--- a/examples/vue/nuxt-3/app.vue
+++ b/examples/vue/nuxt-3/app.vue
@@ -45,7 +45,7 @@ const BUILDER_PUBLIC_API_KEY = 'f1a790f8c3204b3b8c5c1795aeac4660'; // ggignore
 const route = useRoute();
 
 // fetch builder content data
-const { data: content } = await useAsyncData('builderData', () =>
+const { data: content } = await useAsyncData(`builderData-page-${route.path}`, () =>
   fetchOneEntry({
     model: 'page',
     apiKey: BUILDER_PUBLIC_API_KEY,

--- a/packages/sdks/snippets/nuxt/pages/[...app].vue
+++ b/packages/sdks/snippets/nuxt/pages/[...app].vue
@@ -16,13 +16,15 @@ const model = 'page';
 const apiKey = 'ee9f13b4981e489a9a1209887695ef2b';
 const canShowContent = ref(false);
 
-const { data: content } = await useAsyncData('builderData', () =>
-  fetchOneEntry({
-    model,
-    apiKey,
-    options: getBuilderSearchParams(route.query),
-    userAttributes: { urlPath: route.path },
-  })
+const { data: content } = await useAsyncData(
+  `builderData-${model}-${route.path}`,
+  () =>
+    fetchOneEntry({
+      model,
+      apiKey,
+      options: getBuilderSearchParams(route.query),
+      userAttributes: { urlPath: route.path },
+    })
 );
 
 canShowContent.value = content.value ? true : isPreviewing(route.query);

--- a/packages/sdks/snippets/nuxt/pages/announcements/[...app].vue
+++ b/packages/sdks/snippets/nuxt/pages/announcements/[...app].vue
@@ -17,13 +17,15 @@ const model = 'announcement-bar';
 const apiKey = 'ee9f13b4981e489a9a1209887695ef2b';
 const canShowAnnouncementBar = ref(false);
 
-const { data: announcement } = await useAsyncData('builderData', () =>
-  fetchOneEntry({
-    model,
-    apiKey,
-    options: getBuilderSearchParams(route.query),
-    userAttributes: { urlPath: route.path },
-  })
+const { data: announcement } = await useAsyncData(
+  `builderData-${model}-${route.path}`,
+  () =>
+    fetchOneEntry({
+      model,
+      apiKey,
+      options: getBuilderSearchParams(route.query),
+      userAttributes: { urlPath: route.path },
+    })
 );
 
 canShowAnnouncementBar.value = announcement.value


### PR DESCRIPTION
## Description

After struggling to understand why navigation was not working properly on prerendered routes I finally understood what was the culprit.

Nuxt uses the key of `useAsyncData` to cache that value on the server and the client. Prerendered routes will have their async data stored inside a payload file that is shared to the client when navigating.

In the current documentation it uses a static key for all pages content:
```ts
const { data: content } = await useAsyncData('builderData', () =>
  fetchOneEntry({
    model,
    apiKey,
    userAttributes: {
      urlPath: route.path,
    },
  })
))
```

When routes are prerender, navigation will fetch the payload of the page and replace async data on the client based on the key. If the key already exist, it is not replaced. So in this case, navigating between pages will always result with the content of the first visited page.

To avoid this issue, each page should have its own key:

```ts
const { data: content } = await useAsyncData(`builderData-page-${route.path}`, () =>
  fetchOneEntry({
    model,
    apiKey,
    userAttributes: {
      urlPath: route.path,
    },
  })
))
```

This PR update the documentation accordingly