### PR TITLE
fix: standardize locale handling and pass through to personalization …

### DIFF
--- a/.changeset/mighty-ways-bathe.md
+++ b/.changeset/mighty-ways-bathe.md
@@ -1,0 +1,6 @@
+---
+"@builder.io/react": patch
+"@builder.io/sdk": patch
+---
+
+fix: standardize locale handling and pass through locale prop to personalization containers when filtering

--- a/.changeset/perfect-toes-taste.md
+++ b/.changeset/perfect-toes-taste.md
@@ -1,0 +1,12 @@
+---
+"@builder.io/sdk-angular": patch
+"@builder.io/sdk-react-nextjs": patch
+"@builder.io/sdk-qwik": patch
+"@builder.io/sdk-react": patch
+"@builder.io/sdk-react-native": patch
+"@builder.io/sdk-solid": patch
+"@builder.io/sdk-svelte": patch
+"@builder.io/sdk-vue": patch
+---
+
+fix: standardize locale handling

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -2204,6 +2204,17 @@ export class Builder {
     } = {}
   ) {
     let instance: Builder = this;
+    let finalLocale = options.locale || options.userAttributes?.locale || this.getUserAttributes().locale;
+    let finalOptions = {
+      ...options,
+      ...(finalLocale && {
+        locale: String(finalLocale),
+        userAttributes: {
+          ...options.userAttributes,
+          locale: String(finalLocale),
+        },
+      }),
+    };
     if (!Builder.isBrowser) {
       instance = new Builder(
         options.apiKey || this.apiKey,
@@ -2227,7 +2238,7 @@ export class Builder {
         this.apiVersion = options.apiVersion;
       }
     }
-    return instance.queueGetContent(modelName, options).map(
+    return instance.queueGetContent(modelName, finalOptions).map(
       /* map( */ (matches: any[] | null) => {
         const match = matches && matches[0];
         if (Builder.isStatic) {
@@ -2475,9 +2486,9 @@ export class Builder {
     }
 
     const pageQueryParams: ParamsMap =
-      typeof location !== 'undefined'
+      (typeof location !== 'undefined'
         ? QueryString.parseDeep(location.search.substr(1))
-        : undefined || {}; // TODO: WHAT about SSR (this.request) ?
+        : undefined) || {}; // TODO: WHAT about SSR (this.request) ?
 
     const userAttributes =
       // FIXME: HACK: only checks first in queue for user attributes overrides, should check all

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -2210,8 +2210,8 @@ export class Builder {
       ...(finalLocale && {
         locale: String(finalLocale),
         userAttributes: {
-          ...options.userAttributes,
           locale: String(finalLocale),
+          ...options.userAttributes,
         },
       }),
     };

--- a/packages/sdks/src/functions/get-content/__snapshots__/generate-content-url.test.ts.snap
+++ b/packages/sdks/src/functions/get-content/__snapshots__/generate-content-url.test.ts.snap
@@ -2,6 +2,10 @@
 
 exports[`Generate Content URL > Handles overrides correctly 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
 
+exports[`Generate Content URL > add options.locale in userAttributes when no locale attribute set 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&locale=en-US&omit=meta.componentsUsed&userAttributes=%7B%22locale%22%3A%22en-US%22%7D"`;
+
+exports[`Generate Content URL > add userAttributes.locale when top-level locale option exist 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&locale=en-US&omit=meta.componentsUsed&userAttributes=%7B%22locale%22%3A%22en-US%22%7D"`;
+
 exports[`Generate Content URL > generate content url when given invalid values of offset, includeUnpublished, cacheSeconds, staleCacheSeconds 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed&includeUnpublished=false"`;
 
 exports[`Generate Content URL > generate content url with apiVersion as default 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
@@ -25,3 +29,5 @@ exports[`Generate Content URL > generate content url with limit unset and check 
 exports[`Generate Content URL > generate content url with omit, fields, offset, includeUnpublished, cacheSeconds, staleCacheSeconds and sort combination 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=someId%2C+some.nested.id&fields=id%2C+nested.property&offset=1&includeUnpublished=true&cacheSeconds=5&staleCacheSeconds=10&sort.updatedDate=-1&sort.createdDate=1"`;
 
 exports[`Generate Content URL > generates the proper value for a simple query 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
+
+exports[`Generate Content URL > keep userAttributes.locale unaltered when both are provided 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&locale=en-US&omit=meta.componentsUsed&userAttributes=%7B%22locale%22%3A%22es-ES%22%2C%22foo%22%3A%22bar%22%7D"`;

--- a/packages/sdks/src/functions/get-content/__snapshots__/generate-content-url.test.ts.snap
+++ b/packages/sdks/src/functions/get-content/__snapshots__/generate-content-url.test.ts.snap
@@ -30,4 +30,4 @@ exports[`Generate Content URL > generate content url with omit, fields, offset, 
 
 exports[`Generate Content URL > generates the proper value for a simple query 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
 
-exports[`Generate Content URL > keep userAttributes.locale unaltered when both are provided 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&locale=en-US&omit=meta.componentsUsed&userAttributes=%7B%22locale%22%3A%22es-ES%22%2C%22foo%22%3A%22bar%22%7D"`;
+exports[`Generate Content URL > preserves both userAttributes.locale and top-level locale when both provided 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&locale=en-US&omit=meta.componentsUsed&userAttributes=%7B%22locale%22%3A%22es-ES%22%2C%22foo%22%3A%22bar%22%7D"`;

--- a/packages/sdks/src/functions/get-content/generate-content-url.test.ts
+++ b/packages/sdks/src/functions/get-content/generate-content-url.test.ts
@@ -228,7 +228,7 @@ describe('Generate Content URL', () => {
     expect(output).toMatchSnapshot();
   });
 
-  test('keep userAttributes.locale unaltered when both are provided', () => {
+  test('preserves both userAttributes.locale and top-level locale when both provided', () => {
     const output = generateContentUrl({
       apiKey: testKey,
       model: testModel,

--- a/packages/sdks/src/functions/get-content/generate-content-url.test.ts
+++ b/packages/sdks/src/functions/get-content/generate-content-url.test.ts
@@ -209,4 +209,32 @@ describe('Generate Content URL', () => {
     });
     expect(output).toMatchSnapshot();
   });
+
+  test('add userAttributes.locale when top-level locale option exist', () => {
+    const output = generateContentUrl({
+      apiKey: testKey,
+      model: testModel,
+      locale: 'en-US',
+    });
+    expect(output).toMatchSnapshot();
+  });
+
+  test('add options.locale in userAttributes when no locale attribute set', () => {
+    const output = generateContentUrl({
+      apiKey: testKey,
+      model: testModel,
+      userAttributes: { locale: 'en-US' },
+    });
+    expect(output).toMatchSnapshot();
+  });
+
+  test('keep userAttributes.locale unaltered when both are provided', () => {
+    const output = generateContentUrl({
+      apiKey: testKey,
+      model: testModel,
+      locale: 'en-US',
+      userAttributes: { locale: 'es-ES', foo: 'bar' },
+    });
+    expect(output).toMatchSnapshot();
+  });
 });

--- a/packages/sdks/src/functions/get-content/generate-content-url.ts
+++ b/packages/sdks/src/functions/get-content/generate-content-url.ts
@@ -48,7 +48,7 @@ export const generateContentUrl = (options: GetContentOptions): URL => {
   url.searchParams.set('noTraverse', String(noTraverse));
   url.searchParams.set('includeRefs', String(true));
 
-  let finalLocale = locale || userAttributes?.locale;
+  const finalLocale = locale || userAttributes?.locale;
   let finalUserAttributes = userAttributes;
 
   if (finalLocale) {

--- a/packages/sdks/src/functions/get-content/generate-content-url.ts
+++ b/packages/sdks/src/functions/get-content/generate-content-url.ts
@@ -48,7 +48,16 @@ export const generateContentUrl = (options: GetContentOptions): URL => {
   url.searchParams.set('noTraverse', String(noTraverse));
   url.searchParams.set('includeRefs', String(true));
 
-  if (locale) url.searchParams.set('locale', locale);
+  let finalLocale = locale || userAttributes?.locale;
+  let finalUserAttributes = userAttributes;
+
+  if (finalLocale) {
+    url.searchParams.set('locale', finalLocale);
+    finalUserAttributes = {
+      locale: finalLocale,
+      ...finalUserAttributes,
+    }
+  }
   if (enrich) url.searchParams.set('enrich', String(enrich));
 
   url.searchParams.set('omit', omit || 'meta.componentsUsed');
@@ -92,8 +101,8 @@ export const generateContentUrl = (options: GetContentOptions): URL => {
     url.searchParams.set(key, String(flattened[key]));
   }
 
-  if (userAttributes) {
-    url.searchParams.set('userAttributes', JSON.stringify(userAttributes));
+  if (finalUserAttributes) {
+    url.searchParams.set('userAttributes', JSON.stringify(finalUserAttributes));
   }
   if (query) {
     const flattened = flattenMongoQuery({ query });


### PR DESCRIPTION
…containers attributes when filtering

This change makes the following two ways of setting locale interchangeable:

```ts
builder.get(..., { userAttributes: { locale: 'en-us' } })
builder.get(..., { locale: 'en-us' })
```
Additionally, the `locale` prop on `BuilderComponent` is now properly considered when calculating matching variants in personalization containers.
