### PR TITLE
[smartling][deleteFeatureFlag] Removing feature flag check

### DIFF
--- a/plugins/smartling/package-lock.json
+++ b/plugins/smartling/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/plugin-smartling",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-smartling",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "license": "MIT",
       "dependencies": {
         "@builder.io/commerce-plugin-tools": "^0.3.0",

--- a/plugins/smartling/package.json
+++ b/plugins/smartling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-smartling",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "",
   "keywords": [],
   "main": "dist/plugin.system.js",

--- a/plugins/smartling/src/plugin.tsx
+++ b/plugins/smartling/src/plugin.tsx
@@ -210,12 +210,6 @@ registerPlugin(
           if(!isEqual(currentLocales?.enum, combinedLocales)){
             appState.user.organization.value.customTargetingAttributes?.get('locale').set('enum', combinedLocales);
           }
-        } else if(appState.hasFeatureFlag('manage-locales-in-smartling') && !isEqual(currentLocales?.enum, smartlingLocales)){
-          // overwrite all builder locales by smartling locales
-            appState.user.organization.value.customTargetingAttributes.set('locale', {
-              type: 'string',
-              enum: smartlingLocales,
-            });
         }
     });
     // create a new action on content to add to job


### PR DESCRIPTION
## Description
The feature flag was temporarily added while users migrate their locales from smartling to builder. We have communicated with the users. The migration is completed and it has been turned off since long time. It is now safe to delete it.

Once the pr is merged and plugin is deployed, will delete the feature flag from launch darkly.


