### PR TITLE
fix[gen2][fetchEntries] ENG-7327 ensure fetchEntries function throws an error when API fails

### DIFF
--- a/packages/sdks/src/functions/get-content/index.ts
+++ b/packages/sdks/src/functions/get-content/index.ts
@@ -104,18 +104,13 @@ export const _processContentResult = async (
  * Returns a paginated array of entries that match the given options.
  */
 export async function fetchEntries(options: GetContentOptions) {
-  try {
-    const url = generateContentUrl(options);
-    const content = await _fetchContent(options);
+  const url = generateContentUrl(options);
+  const content = await _fetchContent(options);
 
-    if (!checkContentHasResults(content)) {
-      logger.error('Error fetching data. ', { url, content, options });
-      return null;
-    }
-
-    return _processContentResult(options, content);
-  } catch (error) {
-    logger.error('Error fetching data. ', error);
-    return null;
+  if (!checkContentHasResults(content)) {
+    logger.error('Error fetching data. ', { url, content, options });
+    throw content;
   }
+
+  return _processContentResult(options, content);
 }


### PR DESCRIPTION
## Description

`fetchEntries` does not throw error

**Jira Ticket**
https://builder-io.atlassian.net/browse/ENG-7327
