### PR TITLE
Fix Changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,7 +10,7 @@
       "@builder.io/sdk-react-native",
       "@builder.io/sdk-solid"
     ],
-    ["@builder.io/sdk-react-nextjs", "@builder.io/sdk-qwik"]
+    ["@builder.io/sdk-react-nextjs", "@builder.io/sdk-qwik", "@builder.io/sdk-angular"]
   ],
   "fixed": [],
   "access": "public",

--- a/.changeset/odd-pandas-look.md
+++ b/.changeset/odd-pandas-look.md
@@ -1,7 +1,7 @@
 ---
-'@builder.io/sdk-angular': major
-'@builder.io/sdk-react-nextjs': major
-'@builder.io/sdk-qwik': major
+'@builder.io/sdk-angular': minor
+'@builder.io/sdk-react-nextjs': minor
+'@builder.io/sdk-qwik': minor
 '@builder.io/sdk-react': major
 '@builder.io/sdk-react-native': major
 '@builder.io/sdk-solid': major


### PR DESCRIPTION
## Description

NextJS SDK, Angular SDK and Qwik SDK are still not 1.0 so they should get a `minor` version bump