### PR TITLE
[phrasePlugin][Stale Private Key]: 

### DIFF
--- a/plugins/phrase-conector/package-lock.json
+++ b/plugins/phrase-conector/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/plugin-phrase-connector",
-  "version": "0.0.11",
+  "version": "0.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-phrase-connector",
-      "version": "0.0.11",
+      "version": "0.0.14",
       "license": "MIT",
       "dependencies": {
         "@builder.io/commerce-plugin-tools": "^0.3.0",

--- a/plugins/phrase-conector/package.json
+++ b/plugins/phrase-conector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-phrase-connector",
-  "version": "0.0.11",
+  "version": "0.0.14",
   "description": "",
   "keywords": [],
   "main": "dist/plugin.system.js",

--- a/plugins/phrase-conector/src/phrase.ts
+++ b/plugins/phrase-conector/src/phrase.ts
@@ -1,3 +1,4 @@
+import { action } from 'mobx';
 import pkg from '../package.json';
 import appState from '@builder.io/app-context';
 
@@ -24,6 +25,11 @@ export class Phrase {
   constructor(private apiHost?: string) {
     this.loaded = new Promise(resolve => (this.resolveLoaded = resolve));
     this.init();
+    appState.globalState.orgChanged?.subscribe(
+      action(async () => {
+        await this.init();
+      })
+    );
   }
 
   async init() {
@@ -34,12 +40,11 @@ export class Phrase {
   }
 
   async request(path: string, config?: RequestInit, search = {}) {
-    let privateKey = await appState.globalState.getPluginPrivateKey(pkg.name);
     await this.loaded;
     return fetch(`${this.getBaseUrl(path, search)}`, {
       ...config,
       headers: {
-        Authorization: `Bearer ${privateKey}`,
+        Authorization: `Bearer ${this.privateKey}`,
         'Content-Type': 'application/json',
       },
     }).then(res => res.json());

--- a/plugins/phrase-conector/src/phrase.ts
+++ b/plugins/phrase-conector/src/phrase.ts
@@ -34,11 +34,12 @@ export class Phrase {
   }
 
   async request(path: string, config?: RequestInit, search = {}) {
+    let privateKey = await appState.globalState.getPluginPrivateKey(pkg.name);
     await this.loaded;
     return fetch(`${this.getBaseUrl(path, search)}`, {
       ...config,
       headers: {
-        Authorization: `Bearer ${this.privateKey}`,
+        Authorization: `Bearer ${privateKey}`,
         'Content-Type': 'application/json',
       },
     }).then(res => res.json());

--- a/plugins/phrase-conector/src/phrase.ts
+++ b/plugins/phrase-conector/src/phrase.ts
@@ -25,7 +25,7 @@ export class Phrase {
   constructor(private apiHost?: string) {
     this.loaded = new Promise(resolve => (this.resolveLoaded = resolve));
     this.init();
-    appState.globalState.orgChanged?.subscribe(
+    appState.globalState.orgSwitched?.subscribe(
       action(async () => {
         await this.init();
       })

--- a/plugins/smartling/package-lock.json
+++ b/plugins/smartling/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/plugin-smartling",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-smartling",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "license": "MIT",
       "dependencies": {
         "@builder.io/commerce-plugin-tools": "^0.3.0",

--- a/plugins/smartling/package.json
+++ b/plugins/smartling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-smartling",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "",
   "keywords": [],
   "main": "dist/plugin.system.js",

--- a/plugins/smartling/src/smartling.ts
+++ b/plugins/smartling/src/smartling.ts
@@ -30,7 +30,7 @@ export class SmartlingApi {
          constructor() {
            this.loaded = new Promise(resolve => (this.resolveLoaded = resolve));
            this.init();
-           appState.globalState.orgChanged?.subscribe(
+           appState.globalState.orgSwitched?.subscribe(
             action(async () => {
               await this.init();
             })

--- a/plugins/smartling/src/smartling.ts
+++ b/plugins/smartling/src/smartling.ts
@@ -1,6 +1,7 @@
 import pkg from '../package.json';
 import appState from '@builder.io/app-context';
 import { getTranslationModel } from './model-template';
+import { action } from 'mobx';
 
 export type Project = {
   targetLocales: Array<{ enabled: boolean; localeId: string; description: string }>;
@@ -29,6 +30,11 @@ export class SmartlingApi {
          constructor() {
            this.loaded = new Promise(resolve => (this.resolveLoaded = resolve));
            this.init();
+           appState.globalState.orgChanged?.subscribe(
+            action(async () => {
+              await this.init();
+            })
+          );
          }
 
          async init() {


### PR DESCRIPTION
## Description
The Private key in phrase plugin gets updated only in constructor i.e. when the plugin loads. This happens on initial set-up or when we refresh builder web-app. This stale private key causes authorization failure when we switch b/w environments.
The solution is a small fix which gets the latest private key everytime before making api-call.

**Loom showing before after**

https://www.loom.com/share/63c07935720749b7800aaf422b771ae4
