### PR TITLE
fix[gen1][gen2] ENG-7760 onChange does not fire when an `async` function is passed to it

### DIFF
--- a/.changeset/odd-bobcats-act.md
+++ b/.changeset/odd-bobcats-act.md
@@ -1,0 +1,14 @@
+---
+"@builder.io/sdk": patch
+"@builder.io/react": patch
+"@builder.io/sdk-angular": patch
+"@builder.io/sdk-react-nextjs": patch
+"@builder.io/sdk-qwik": patch
+"@builder.io/sdk-react": patch
+"@builder.io/sdk-react-native": patch
+"@builder.io/sdk-solid": patch
+"@builder.io/sdk-svelte": patch
+"@builder.io/sdk-vue": patch
+---
+
+Fix: Serialization function has been modified to correctly serialize async-functions

--- a/.changeset/odd-bobcats-act.md
+++ b/.changeset/odd-bobcats-act.md
@@ -11,4 +11,4 @@
 "@builder.io/sdk-vue": patch
 ---
 
-Fix: Serialization function has been modified to correctly serialize async-functions
+Fix: `onChange` functions passed to builder inputs can now receive async functions

--- a/packages/core/src/builder.class.test.ts
+++ b/packages/core/src/builder.class.test.ts
@@ -121,11 +121,60 @@ describe('serializeIncludingFunctions', () => {
     expect(result.inputs[2].onChange).toContain('v.toLowerCase()');
   });
 
+  test('serializes arrow functions with non-parenthesized args in inputs', () => {
+    // Using eval and template literal to prevent TypeScript from adding parens
+    const fn = eval(`(${`e => !0 === e.get("isABTest")`})`);
+    const input = {
+      name: 'onChangeComponent',
+      inputs: [
+        {
+          name: 'number',
+          type: 'number',
+          // @ts-expect-error required for this test
+          onChange: value => value * 2,
+          showIf: fn,
+        },
+      ],
+    };
+
+    const result = Builder['serializeIncludingFunctions'](input);
+
+    expect(typeof result.inputs[0].onChange).toBe('string');
+    expect(result.inputs[0].onChange).toBe(`return ((value) => value * 2).apply(this, arguments)`);
+  });
+
+  test('serializes functions with parenthesized args in inputs', () => {
+    // Using eval and template literal to prevent TypeScript from adding parens
+    const fn = eval(`(${`e => !0 === e.get("isABTest")`})`);
+    const input = {
+      name: 'onChangeComponent',
+      inputs: [
+        {
+          name: 'number',
+          type: 'number',
+          onChange: function (value: number) {
+            return value * 2;
+          },
+          showIf: fn,
+        },
+      ],
+    };
+
+    const result = Builder['serializeIncludingFunctions'](input);
+
+    expect(typeof result.inputs[0].onChange).toBe('string');
+    expect(result.inputs[0].onChange).toBe(
+      `return (function(value) {
+            return value * 2;
+          }).apply(this, arguments)`
+    );
+  });
+
   test('serializes async functions with parenthesized args in inputs', () => {
     // Using eval and template literal to prevent TypeScript from adding parens
     const fn = eval(`(${`e => !0 === e.get("isABTest")`})`);
     const input = {
-      name: 'AsyncArrowComponent',
+      name: 'AsyncOnChangeComponent',
       inputs: [
         {
           name: 'number',
@@ -152,7 +201,7 @@ describe('serializeIncludingFunctions', () => {
     // Using eval and template literal to prevent TypeScript from adding parens
     const fn = eval(`(${`e => !0 === e.get("isABTest")`})`);
     const input = {
-      name: 'AsyncArrowComponent',
+      name: 'AsyncOnChangeComponent',
       inputs: [
         {
           name: 'number',
@@ -175,7 +224,7 @@ describe('serializeIncludingFunctions', () => {
     // Using eval and template literal to prevent TypeScript from adding parens
     const fn = eval(`(${`e => !0 === e.get("isABTest")`})`);
     const input = {
-      name: 'AsyncArrowComponent',
+      name: 'AsyncOnChangeComponent',
       inputs: [
         {
           name: 'number',

--- a/packages/core/src/builder.class.test.ts
+++ b/packages/core/src/builder.class.test.ts
@@ -120,6 +120,80 @@ describe('serializeIncludingFunctions', () => {
     expect(typeof result.inputs[2].onChange).toBe('string');
     expect(result.inputs[2].onChange).toContain('v.toLowerCase()');
   });
+
+  test('serializes async functions with parenthesized args in inputs', () => {
+    // Using eval and template literal to prevent TypeScript from adding parens
+    const fn = eval(`(${`e => !0 === e.get("isABTest")`})`);
+    const input = {
+      name: 'AsyncArrowComponent',
+      inputs: [
+        {
+          name: 'number',
+          type: 'number',
+          onChange: async function (value: number) {
+            return value * 2;
+          },
+          showIf: fn,
+        },
+      ],
+    };
+
+    const result = Builder['serializeIncludingFunctions'](input);
+
+    expect(typeof result.inputs[0].onChange).toBe('string');
+    expect(result.inputs[0].onChange).toBe(
+      `return (async function(value) {
+            return value * 2;
+          }).apply(this, arguments)`
+    );
+  });
+
+  test('serializes async arrow functions with parenthesized args in inputs', () => {
+    // Using eval and template literal to prevent TypeScript from adding parens
+    const fn = eval(`(${`e => !0 === e.get("isABTest")`})`);
+    const input = {
+      name: 'AsyncArrowComponent',
+      inputs: [
+        {
+          name: 'number',
+          type: 'number',
+          onChange: async (value: number) => value * 2,
+          showIf: fn,
+        },
+      ],
+    };
+
+    const result = Builder['serializeIncludingFunctions'](input);
+
+    expect(typeof result.inputs[0].onChange).toBe('string');
+    expect(result.inputs[0].onChange).toBe(
+      'return (async (value) => value * 2).apply(this, arguments)'
+    );
+  });
+
+  test('serializes async arrow functions without parenthesized args in inputs', () => {
+    // Using eval and template literal to prevent TypeScript from adding parens
+    const fn = eval(`(${`e => !0 === e.get("isABTest")`})`);
+    const input = {
+      name: 'AsyncArrowComponent',
+      inputs: [
+        {
+          name: 'number',
+          type: 'number',
+          // @ts-expect-error
+          onChange: async value => value * 2,
+          showIf: fn,
+        },
+      ],
+    };
+
+    const result = Builder['serializeIncludingFunctions'](input);
+
+    expect(typeof result.inputs[0].onChange).toBe('string');
+    expect(result.inputs[0].onChange).toBe(
+      'return (async (value) => value * 2).apply(this, arguments)'
+    );
+  });
 });
 
 describe('prepareComponentSpecToSend', () => {

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -1104,9 +1104,15 @@ export class Builder {
       // 2. `name(args) => {code}`
       // 3. `(args) => {}`
       // 4. `args => {}`
+      // 5. `async name(args) => {code}`
+      // 6. `async (args) => {}`
+      // 7. `async args => {}`
       const isArrowWithoutParens = /^[a-zA-Z0-9_]+\s*=>/i.test(fnStr);
       const appendFunction =
-        !fnStr.startsWith('function') && !fnStr.startsWith('(') && !isArrowWithoutParens;
+        !fnStr.startsWith('function') &&
+        !fnStr.startsWith('async') &&
+        !fnStr.startsWith('(') &&
+        !isArrowWithoutParens;
 
       return `return (${appendFunction ? 'function ' : ''}${fnStr}).apply(this, arguments)`;
     };

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -1104,7 +1104,7 @@ export class Builder {
       // 2. `name(args) => {code}`
       // 3. `(args) => {}`
       // 4. `args => {}`
-      // 5. `async name(args) => {code}`
+      // 5. `async function(args) {code}`
       // 6. `async (args) => {}`
       // 7. `async args => {}`
       const isArrowWithoutParens = /^[a-zA-Z0-9_]+\s*=>/i.test(fnStr);

--- a/packages/sdks/src/functions/__snapshots__/register-component.test.ts.snap
+++ b/packages/sdks/src/functions/__snapshots__/register-component.test.ts.snap
@@ -15,6 +15,66 @@ exports[`Component Registration and Serialization > serializeComponentInfo handl
 }
 `;
 
+exports[`Component Registration and Serialization > serializeComponentInfo handles async arrow functions correctly 1`] = `
+{
+  "inputs": [
+    {
+      "name": "testInput",
+      "onChange": "return (async (value) => {
+            return value.toUpperCase();
+          }).apply(this, arguments)",
+      "type": "string",
+    },
+  ],
+  "name": "TestComponent",
+}
+`;
+
+exports[`Component Registration and Serialization > serializeComponentInfo handles async arrow functions without parenthesis correctly 1`] = `
+{
+  "inputs": [
+    {
+      "name": "testInput",
+      "onChange": "return (async (value) => {
+            return value.toUpperCase();
+          }).apply(this, arguments)",
+      "type": "string",
+    },
+  ],
+  "name": "TestComponent",
+}
+`;
+
+exports[`Component Registration and Serialization > serializeComponentInfo handles async arrow functions without parenthesis correctly 2`] = `
+{
+  "inputs": [
+    {
+      "name": "testInput",
+      "onChange": "return (async (value) => {
+            return value;
+          }).apply(this, arguments)",
+      "type": "string",
+    },
+  ],
+  "name": "TestComponent",
+}
+`;
+
+exports[`Component Registration and Serialization > serializeComponentInfo handles async functions correctly 1`] = `
+{
+  "inputs": [
+    {
+      "name": "testInput",
+      "onChange": "return (async function(value) {
+            return value.toUpperCase();
+          }).apply(this, arguments)",
+      "type": "string",
+    },
+  ],
+  "name": "TestComponent",
+}
+`;
+
 exports[`Component Registration and Serialization > serializeComponentInfo handles functions correctly 1`] = `
 {
   "hooks": {

--- a/packages/sdks/src/functions/__snapshots__/register-component.test.ts.snap
+++ b/packages/sdks/src/functions/__snapshots__/register-component.test.ts.snap
@@ -15,6 +15,19 @@ exports[`Component Registration and Serialization > serializeComponentInfo handl
 }
 `;
 
+exports[`Component Registration and Serialization > serializeComponentInfo handles arrow functions without parenthesis correctly 1`] = `
+{
+  "inputs": [
+    {
+      "name": "testInput",
+      "onChange": "return ((value) => value.toUpperCase()).apply(this, arguments)",
+      "type": "string",
+    },
+  ],
+  "name": "TestComponent",
+}
+`;
+
 exports[`Component Registration and Serialization > serializeComponentInfo handles async arrow functions correctly 1`] = `
 {
   "inputs": [
@@ -85,6 +98,21 @@ exports[`Component Registration and Serialization > serializeComponentInfo handl
   "inputs": [
     {
       "name": "testInput",
+      "type": "string",
+    },
+  ],
+  "name": "TestComponent",
+}
+`;
+
+exports[`Component Registration and Serialization > serializeComponentInfo handles functions with parenthesis correctly 1`] = `
+{
+  "inputs": [
+    {
+      "name": "testInput",
+      "onChange": "return (function(value) {
+            return value.toUpperCase();
+          }).apply(this, arguments)",
       "type": "string",
     },
   ],

--- a/packages/sdks/src/functions/register-component.test.ts
+++ b/packages/sdks/src/functions/register-component.test.ts
@@ -50,9 +50,8 @@ describe('Component Registration and Serialization', () => {
           name: 'testInput',
           type: 'string',
           // eslint-disable-next-line
-          // @ts-expect-error
           onChange: async (value) => {
-            // @ts-expect-error
+            // @ts-expect-error required for passing tests
             return value.toUpperCase();
           },
         },
@@ -83,7 +82,7 @@ describe('Component Registration and Serialization', () => {
           name: 'testInput',
           type: 'string',
           // eslint-disable-next-line
-          // @ts-expect-error
+          // @ts-expect-error required for passing tests
           // eslint-disable-next-line object-shorthand
           onChange: async function (value: string) {
             return value.toUpperCase();
@@ -116,7 +115,7 @@ describe('Component Registration and Serialization', () => {
           name: 'testInput',
           type: 'string',
           // eslint-disable-next-line
-          // @ts-expect-error
+          // @ts-expect-error required for passing tests
           // eslint-disable-next-line object-shorthand
           onChange: async (value) => {
             return value;

--- a/packages/sdks/src/functions/register-component.test.ts
+++ b/packages/sdks/src/functions/register-component.test.ts
@@ -42,6 +42,105 @@ describe('Component Registration and Serialization', () => {
     expect(result.hooks.onChange).toContain('return value.toUpperCase();');
   });
 
+  test('serializeComponentInfo handles async arrow functions without parenthesis correctly', () => {
+    const mockComponentInfo: ComponentInfo = {
+      name: 'TestComponent',
+      inputs: [
+        {
+          name: 'testInput',
+          type: 'string',
+          // eslint-disable-next-line
+          // @ts-expect-error
+          onChange: async (value) => {
+            // @ts-expect-error
+            return value.toUpperCase();
+          },
+        },
+      ],
+      // Add other required fields as necessary
+    };
+
+    const result = serializeIncludingFunctions(mockComponentInfo);
+
+    expect(result).toMatchSnapshot();
+    expect(result.name).toBe('TestComponent');
+    expect(result.inputs).toEqual([
+      {
+        name: 'testInput',
+        type: 'string',
+        onChange: `return (async (value) => {
+            return value.toUpperCase();
+          }).apply(this, arguments)`,
+      },
+    ]);
+  });
+
+  test('serializeComponentInfo handles async functions correctly', () => {
+    const mockComponentInfo: ComponentInfo = {
+      name: 'TestComponent',
+      inputs: [
+        {
+          name: 'testInput',
+          type: 'string',
+          // eslint-disable-next-line
+          // @ts-expect-error
+          // eslint-disable-next-line object-shorthand
+          onChange: async function (value: string) {
+            return value.toUpperCase();
+          },
+        },
+      ],
+      // Add other required fields as necessary
+    };
+
+    const result = serializeIncludingFunctions(mockComponentInfo);
+
+    expect(result).toMatchSnapshot();
+    expect(result.name).toBe('TestComponent');
+    expect(result.inputs).toEqual([
+      {
+        name: 'testInput',
+        type: 'string',
+        onChange: `return (async function(value) {
+            return value.toUpperCase();
+          }).apply(this, arguments)`,
+      },
+    ]);
+  });
+
+  test('serializeComponentInfo handles async arrow functions without parenthesis correctly', () => {
+    const mockComponentInfo: ComponentInfo = {
+      name: 'TestComponent',
+      inputs: [
+        {
+          name: 'testInput',
+          type: 'string',
+          // eslint-disable-next-line
+          // @ts-expect-error
+          // eslint-disable-next-line object-shorthand
+          onChange: async (value) => {
+            return value;
+          },
+        },
+      ],
+      // Add other required fields as necessary
+    };
+
+    const result = serializeIncludingFunctions(mockComponentInfo);
+
+    expect(result).toMatchSnapshot();
+    expect(result.name).toBe('TestComponent');
+    expect(result.inputs).toEqual([
+      {
+        name: 'testInput',
+        type: 'string',
+        onChange: `return (async (value) => {
+            return value;
+          }).apply(this, arguments)`,
+      },
+    ]);
+  });
+
   test('serializeComponentInfo handles arrow functions', () => {
     const mockComponentInfo: ComponentInfo = {
       name: 'ArrowComponent',

--- a/packages/sdks/src/functions/register-component.test.ts
+++ b/packages/sdks/src/functions/register-component.test.ts
@@ -42,6 +42,67 @@ describe('Component Registration and Serialization', () => {
     expect(result.hooks.onChange).toContain('return value.toUpperCase();');
   });
 
+  test('serializeComponentInfo handles arrow functions without parenthesis correctly', () => {
+    const mockComponentInfo: ComponentInfo = {
+      name: 'TestComponent',
+      inputs: [
+        {
+          name: 'testInput',
+          type: 'string',
+          // eslint-disable-next-line
+          // @ts-expect-error required for passing tests
+          // prettier-ignore
+          onChange: value => value.toUpperCase(),
+        },
+      ],
+      // Add other required fields as necessary
+    };
+
+    const result = serializeIncludingFunctions(mockComponentInfo);
+
+    expect(result).toMatchSnapshot();
+    expect(result.name).toBe('TestComponent');
+    expect(result.inputs).toEqual([
+      {
+        name: 'testInput',
+        type: 'string',
+        onChange: `return ((value) => value.toUpperCase()).apply(this, arguments)`,
+      },
+    ]);
+  });
+
+  test('serializeComponentInfo handles functions with parenthesis correctly', () => {
+    const mockComponentInfo: ComponentInfo = {
+      name: 'TestComponent',
+      inputs: [
+        {
+          name: 'testInput',
+          type: 'string',
+          // eslint-disable-next-line
+          onChange: function (value) {
+            // @ts-expect-error required for passing tests
+            return value.toUpperCase();
+          },
+        },
+      ],
+      // Add other required fields as necessary
+    };
+
+    const result = serializeIncludingFunctions(mockComponentInfo);
+
+    expect(result).toMatchSnapshot();
+    expect(result.name).toBe('TestComponent');
+    expect(result.inputs).toEqual([
+      {
+        name: 'testInput',
+        type: 'string',
+        onChange: `return (function(value) {
+            return value.toUpperCase();
+          }).apply(this, arguments)`,
+      },
+    ]);
+  });
+
   test('serializeComponentInfo handles async arrow functions without parenthesis correctly', () => {
     const mockComponentInfo: ComponentInfo = {
       name: 'TestComponent',

--- a/packages/sdks/src/functions/register-component.ts
+++ b/packages/sdks/src/functions/register-component.ts
@@ -14,7 +14,7 @@ const serializeFn = (fnValue: Function) => {
   // 2. `name(args) => {code}`
   // 3. `(args) => {}`
   // 4. `args => {}`
-  // 5. `async name(args) => {code}`
+  // 5. `async function(args) {code}`
   // 6. `async (args) => {}`
   // 7. `async args => {}`
   const isArrowWithoutParens = /^[a-zA-Z0-9_]+\s*=>/i.test(fnStr);

--- a/packages/sdks/src/functions/register-component.ts
+++ b/packages/sdks/src/functions/register-component.ts
@@ -14,9 +14,13 @@ const serializeFn = (fnValue: Function) => {
   // 2. `name(args) => {code}`
   // 3. `(args) => {}`
   // 4. `args => {}`
+  // 5. `async name(args) => {code}`
+  // 6. `async (args) => {}`
+  // 7. `async args => {}`
   const isArrowWithoutParens = /^[a-zA-Z0-9_]+\s*=>/i.test(fnStr);
   const appendFunction =
     !fnStr.startsWith('function') &&
+    !fnStr.startsWith('async') &&
     !fnStr.startsWith('(') &&
     !isArrowWithoutParens;
 


### PR DESCRIPTION
## Description

onChange does not fire when an `async` function is passed to it

**Jira ticket**
https://builder-io.atlassian.net/browse/ENG-7760

**Loom**
Gen1: https://www.loom.com/share/b6012b2b37f54944ab94074c264f3bb6
Gen2: https://www.loom.com/share/ca3d895ddf5d4b69b13eab341003dde1
