### PR TITLE
fix: hydration errors in next pages

### DIFF
--- a/packages/sdks/src/components/content/components/enable-editor.helpers.ts
+++ b/packages/sdks/src/components/content/components/enable-editor.helpers.ts
@@ -13,6 +13,10 @@ export const SDKS_USING_ELEMENT_REF_APPROACH = [
   'vue',
 ] as Target[];
 
+/**
+ * We need to attach this div only when content exists or isPreviewing/isEditing even when content is null,
+ * as we need to set the elementRef and allow previewing and visual editing
+ */
 export const needsElementRefDivForEditing =
   SDKS_USING_ELEMENT_REF_APPROACH.includes(TARGET) &&
   (isEditing() || isPreviewing());

--- a/packages/sdks/src/components/content/components/enable-editor.helpers.ts
+++ b/packages/sdks/src/components/content/components/enable-editor.helpers.ts
@@ -1,0 +1,18 @@
+import { TARGET } from '../../../constants/target.js';
+import { isEditing } from '../../../functions/is-editing.js';
+import { isPreviewing } from '../../../functions/is-previewing.js';
+import type { Target } from '../../../types/targets.js';
+
+/**
+ * SDKS that use the elementRef approach to enable visual editing.
+ * We don't need to render the div for other SDKs as they attach event listeners to the window.
+ */
+export const SDKS_USING_ELEMENT_REF_APPROACH = [
+  'svelte',
+  'qwik',
+  'vue',
+] as Target[];
+
+export const needsElementRefDivForEditing =
+  SDKS_USING_ELEMENT_REF_APPROACH.includes(TARGET) &&
+  (isEditing() || isPreviewing());

--- a/packages/sdks/src/components/content/components/enable-editor.helpers.ts
+++ b/packages/sdks/src/components/content/components/enable-editor.helpers.ts
@@ -17,6 +17,9 @@ export const SDKS_USING_ELEMENT_REF_APPROACH = [
  * We need to attach this div only when content exists or isPreviewing/isEditing even when content is null,
  * as we need to set the elementRef and allow previewing and visual editing
  */
-export const needsElementRefDivForEditing =
-  SDKS_USING_ELEMENT_REF_APPROACH.includes(TARGET) &&
-  (isEditing() || isPreviewing());
+export const needsElementRefDivForEditing = () => {
+  return (
+    SDKS_USING_ELEMENT_REF_APPROACH.includes(TARGET) &&
+    (isEditing() || isPreviewing())
+  );
+};

--- a/packages/sdks/src/components/content/components/enable-editor.lite.tsx
+++ b/packages/sdks/src/components/content/components/enable-editor.lite.tsx
@@ -444,10 +444,6 @@ export default function EnableEditor(props: BuilderEditorProps) {
   return (
     <Show
       when={
-        /**
-         * We need to attach this div only when content exists or isPreviewing/isEditing even when content is null,
-         * as we need to set the elementRef and allow previewing and visual editing
-         */
         props.builderContextSignal.value.content || needsElementRefDivForEditing
       }
     >

--- a/packages/sdks/src/components/content/components/enable-editor.lite.tsx
+++ b/packages/sdks/src/components/content/components/enable-editor.lite.tsx
@@ -40,6 +40,7 @@ import type {
   BuilderComponentStateChange,
   ContentProps,
 } from '../content.types.js';
+import { needsElementRefDivForEditing } from './enable-editor.helpers.js';
 import { getWrapperClassName } from './styles.helpers.js';
 
 useMetadata({
@@ -447,9 +448,7 @@ export default function EnableEditor(props: BuilderEditorProps) {
          * We need to attach this div only when content exists or isPreviewing/isEditing even when content is null,
          * as we need to set the elementRef and allow previewing and visual editing
          */
-        props.builderContextSignal.value.content ||
-        isPreviewing() ||
-        isEditing()
+        props.builderContextSignal.value.content || needsElementRefDivForEditing
       }
     >
       <state.ContentWrapper
@@ -479,7 +478,7 @@ export default function EnableEditor(props: BuilderEditorProps) {
         style={{
           display:
             !props.builderContextSignal.value.content &&
-            (isPreviewing() || isEditing())
+            needsElementRefDivForEditing
               ? 'none'
               : undefined,
         }}

--- a/packages/sdks/src/components/content/components/enable-editor.lite.tsx
+++ b/packages/sdks/src/components/content/components/enable-editor.lite.tsx
@@ -444,7 +444,8 @@ export default function EnableEditor(props: BuilderEditorProps) {
   return (
     <Show
       when={
-        props.builderContextSignal.value.content || needsElementRefDivForEditing
+        props.builderContextSignal.value.content ||
+        needsElementRefDivForEditing()
       }
     >
       <state.ContentWrapper
@@ -474,7 +475,7 @@ export default function EnableEditor(props: BuilderEditorProps) {
         style={{
           display:
             !props.builderContextSignal.value.content &&
-            needsElementRefDivForEditing
+            needsElementRefDivForEditing()
               ? 'none'
               : undefined,
         }}


### PR DESCRIPTION
## Description

#3726 causes hydration errors in next pages combination, to avoid that converted logic such that the div only gets attached to the SDKs that require it for visual editing

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
