### PR TITLE
FIX[sdk][editor]:ENG-6884 Symbol with image using content-input doesn't reflect change

### DIFF
--- a/.changeset/new-cougars-rescue.md
+++ b/.changeset/new-cougars-rescue.md
@@ -1,0 +1,6 @@
+---
+"@builder.io/react": patch
+---
+
+In symbol content-input, the editor wasn't able to clear the image unless page is realoaded. So this is fixed by removing "Builder.isEditing" check so a new "dataString" is generated with evry new data.
+Issue ticket - https://builder-io.atlassian.net/browse/ENG-6884

--- a/packages/react/src/blocks/Symbol.tsx
+++ b/packages/react/src/blocks/Symbol.tsx
@@ -113,7 +113,7 @@ class SymbolComponent extends React.Component<PropsWithChildren<SymbolProps>> {
     }
 
     let key = dynamic ? undefined : [model, entry].join(':');
-    const dataString = Builder.isEditing ? null : data && size(data) && hash(data);
+    const dataString = data && size(data) && hash(data);
 
     if (key && dataString && dataString.length < 300) {
       key += ':' + dataString;


### PR DESCRIPTION

## Description

Removed "isEditing" check as "dataString" will be always null when it's true. "dataString" needs to change as per change in the data being received.

_Screenshot_
loom - https://www.loom.com/share/1d30069497c94148b67b1afaa575030e