### PR TITLE
fix[sdkCore][Symbols]: ENG-7640 Set preview to true only if its not a symbol call

### DIFF
--- a/.changeset/blue-ducks-cover.md
+++ b/.changeset/blue-ducks-cover.md
@@ -1,6 +1,6 @@
 ---
-"@builder.io/sdk": patch
-"@builder.io/react": patch
+'@builder.io/sdk': patch
+'@builder.io/react': patch
 ---
 
-symbols will show published content now
+Fix: symbols will now show published content instead of preview/autosave content while editing a page

--- a/.changeset/blue-ducks-cover.md
+++ b/.changeset/blue-ducks-cover.md
@@ -1,0 +1,6 @@
+---
+"@builder.io/sdk": patch
+"@builder.io/react": patch
+---
+
+symbols will show published content now

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -2630,15 +2630,18 @@ export class Builder {
         }
       }
     }
-    if (this.preview) {
-      queryParams.preview = 'true';
-    }
-    const hasParams = Object.keys(queryParams).length > 0;
 
     // TODO: option to force dev or qa api here
     const host = this.host;
 
     const keyNames = queue.map(item => encodeURIComponent(item.key!)).join(',');
+
+    const isSymbol = keyNames.includes('symbol');
+
+    if (this.preview && !isSymbol) {
+      queryParams.preview = 'true';
+    }
+    const hasParams = Object.keys(queryParams).length > 0;
 
     if (this.overrideParams) {
       const params = omit(QueryString.parse(this.overrideParams), 'apiKey');

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -2630,18 +2630,15 @@ export class Builder {
         }
       }
     }
+    if (this.preview && this.previewingModel === queue?.[0]?.model) {
+      queryParams.preview = 'true';
+    }
+    const hasParams = Object.keys(queryParams).length > 0;
 
     // TODO: option to force dev or qa api here
     const host = this.host;
 
     const keyNames = queue.map(item => encodeURIComponent(item.key!)).join(',');
-
-    const isSymbol = keyNames.includes('symbol');
-
-    if (this.preview && !isSymbol) {
-      queryParams.preview = 'true';
-    }
-    const hasParams = Object.keys(queryParams).length > 0;
 
     if (this.overrideParams) {
       const params = omit(QueryString.parse(this.overrideParams), 'apiKey');


### PR DESCRIPTION
## Description
If we are using Symbol in any page. It reflects the unpublished changes. This is happening only on the content editor and not the actual website.

**Before/After loom**
https://www.loom.com/share/4ac7c396c70a4887a19b9f0eec295c63
