### PR TITLE
chore[gen1]: update changelog about removing enrich=true

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Patch Changes
 
-- 06b1124: Fix: Content API invocations will have `includeRefs` set to `true` by default.
+- 06b1124: Fix: remove `enrich=true` default option passed to the API and instead use `includeRefs=true` as default
 - 409aec9: Feat: add `meta` type to custom components
 - 40d572d: Renders Symbol correctly when apiEndpoint is 'content'
 - 2fc9fc5: Fix: `onChange` functions passed to builder inputs can now receive async functions

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -182,18 +182,18 @@
   These events can be listened to for analytics or other custom behaviors:
 
   ```javascript
-  document.addEventListener('builder.variantLoaded', event => {
+  document.addEventListener("builder.variantLoaded", (event) => {
     // This will either be a variant object like { name: 'My Variant', query: [...], startDate: ..., endDate: ... }
     // or the string 'default'
-    console.log('Variant loaded:', event.detail.variant);
+    console.log("Variant loaded:", event.detail.variant);
     // This will be the content object like { name: 'My page', id: '...', ... }
-    console.log('Content:', event.detail.content);
+    console.log("Content:", event.detail.content);
     // Perform analytics or other actions
   });
 
-  document.addEventListener('builder.variantDisplayed', event => {
-    console.log('Variant displayed:', event.detail.variant);
-    console.log('Content:', event.detail.content);
+  document.addEventListener("builder.variantDisplayed", (event) => {
+    console.log("Variant displayed:", event.detail.variant);
+    console.log("Content:", event.detail.content);
     // Track impressions or perform other visibility-dependent actions
   });
   ```
@@ -238,7 +238,7 @@
 
   ```js
   userAttributes: {
-    stringWithStrs: ['a', 'c'];
+    stringWithStrs: ["a", "c"];
   }
   ```
 
@@ -254,7 +254,7 @@
 
   ```js
   userAttributes: {
-    stringWithNums: ['1', '2'];
+    stringWithNums: ["1", "2"];
   }
   ```
 
@@ -464,10 +464,10 @@
 In case you feel the need to use our older API Version `v1`, reach out to us at support@builder.io first. But you can override the default by setting `apiVersion` explicitly to `v1` as follows:
 
 ```js
-import { builder } from '@builder.io/react';
+import { builder } from "@builder.io/react";
 
-builder.init('YOUR_BUILDER_PUBLIC_KEY');
-builder.apiVersion = 'v1';
+builder.init("YOUR_BUILDER_PUBLIC_KEY");
+builder.apiVersion = "v1";
 ```
 
 More details on the Builder API Versions visit [this link](https://www.builder.io/c/docs/content-api-versions).
@@ -479,10 +479,10 @@ More details on the Builder API Versions visit [this link](https://www.builder.i
 You can set the apiVersion using `builder.init` or `builder.apiVersion`:
 
 ```js
-import { builder } from '@builder.io/react';
+import { builder } from "@builder.io/react";
 
-builder.init('YOUR_BUILDER_PUBLIC_KEY');
-builder.apiVersion = 'v3';
+builder.init("YOUR_BUILDER_PUBLIC_KEY");
+builder.apiVersion = "v3";
 ```
 
 ## 2.0.16

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Patch Changes
 
-- 06b1124: Fix: Content API invocations will have `includeRefs` set to `true` by default.
+- 06b1124: Fix: remove `enrich=true` default option passed to the API and instead use `includeRefs=true` as default
 - a8009ba: Fix: hydration errors in Next v15 while a user is editing
 - 409aec9: Feat: add `meta` type to custom components
 - 40d572d: Renders Symbol correctly when apiEndpoint is 'content'
@@ -182,18 +182,18 @@
   These events can be listened to for analytics or other custom behaviors:
 
   ```javascript
-  document.addEventListener("builder.variantLoaded", (event) => {
+  document.addEventListener('builder.variantLoaded', event => {
     // This will either be a variant object like { name: 'My Variant', query: [...], startDate: ..., endDate: ... }
     // or the string 'default'
-    console.log("Variant loaded:", event.detail.variant);
+    console.log('Variant loaded:', event.detail.variant);
     // This will be the content object like { name: 'My page', id: '...', ... }
-    console.log("Content:", event.detail.content);
+    console.log('Content:', event.detail.content);
     // Perform analytics or other actions
   });
 
-  document.addEventListener("builder.variantDisplayed", (event) => {
-    console.log("Variant displayed:", event.detail.variant);
-    console.log("Content:", event.detail.content);
+  document.addEventListener('builder.variantDisplayed', event => {
+    console.log('Variant displayed:', event.detail.variant);
+    console.log('Content:', event.detail.content);
     // Track impressions or perform other visibility-dependent actions
   });
   ```
@@ -238,7 +238,7 @@
 
   ```js
   userAttributes: {
-    stringWithStrs: ["a", "c"];
+    stringWithStrs: ['a', 'c'];
   }
   ```
 
@@ -254,7 +254,7 @@
 
   ```js
   userAttributes: {
-    stringWithNums: ["1", "2"];
+    stringWithNums: ['1', '2'];
   }
   ```
 
@@ -464,10 +464,10 @@
 In case you feel the need to use our older API Version `v1`, reach out to us at support@builder.io first. But you can override the default by setting `apiVersion` explicitly to `v1` as follows:
 
 ```js
-import { builder } from "@builder.io/react";
+import { builder } from '@builder.io/react';
 
-builder.init("YOUR_BUILDER_PUBLIC_KEY");
-builder.apiVersion = "v1";
+builder.init('YOUR_BUILDER_PUBLIC_KEY');
+builder.apiVersion = 'v1';
 ```
 
 More details on the Builder API Versions visit [this link](https://www.builder.io/c/docs/content-api-versions).
@@ -479,10 +479,10 @@ More details on the Builder API Versions visit [this link](https://www.builder.i
 You can set the apiVersion using `builder.init` or `builder.apiVersion`:
 
 ```js
-import { builder } from "@builder.io/react";
+import { builder } from '@builder.io/react';
 
-builder.init("YOUR_BUILDER_PUBLIC_KEY");
-builder.apiVersion = "v3";
+builder.init('YOUR_BUILDER_PUBLIC_KEY');
+builder.apiVersion = 'v3';
 ```
 
 ## 2.0.16


### PR DESCRIPTION
## Description

Updates the changelog to mention that we removed `enrich=true` default being passed to the API.

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
