### PR TITLE
fix[reactSdk][gen1]: ENG-7900 Dynamic Symbol in Visual Editor loads the wrong Symbol type

### DIFF
--- a/.changeset/famous-camels-breathe.md
+++ b/.changeset/famous-camels-breathe.md
@@ -2,4 +2,4 @@
 "@builder.io/react": patch
 ---
 
-Fixed issue with dynamic symbols not rendering properly on visual editor
+Fix: Dynamic symbols not rendering properly in Visual Editor.

--- a/.changeset/famous-camels-breathe.md
+++ b/.changeset/famous-camels-breathe.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/react": patch
+---
+
+Fixed issue with dynamic symbols not rendering properly on visual editor

--- a/packages/react/src/blocks/Symbol.tsx
+++ b/packages/react/src/blocks/Symbol.tsx
@@ -112,7 +112,7 @@ class SymbolComponent extends React.Component<PropsWithChildren<SymbolProps>> {
       showPlaceholder = false;
     }
 
-    let key = dynamic ? undefined : [model, entry].join(':');
+    let key = dynamic ? this.props.builderBlock?.id : [model, entry].join(':');
     const dataString = data && size(data) && hash(data);
 
     if (key && dataString && dataString.length < 300) {


### PR DESCRIPTION
## Description

- When 2 or more dynamic symbols are used in a content, it was showing the same preview for all the symbols on initial load in the content editor
- For dynamic symbols we were passing the React key as `undefined` hence on initial render all the symbol blocks had the same key, now we are setting the key as the block id.
- This issue is only on the gen 1 react sdk.

**Jira Ticket**
https://builder-io.atlassian.net/browse/ENG-7900

**Loom**
https://www.loom.com/share/831e4bc4816845269769b323b5696765
