### PR TITLE
fix[react]: ENG-8091 add check around builder block id

### DIFF
--- a/.changeset/stupid-keys-camp.md
+++ b/.changeset/stupid-keys-camp.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/react": patch
+---
+
+fix: add builder block id only if its present

--- a/packages/react/src/components/builder-block.component.tsx
+++ b/packages/react/src/components/builder-block.component.tsx
@@ -664,12 +664,12 @@ export class BuilderBlock extends React.Component<
     );
   }
 
-  get id() {
+  get id(): string {
     const { block } = this;
-    if (!block.id!.startsWith('builder')) {
+    if (!block.id?.startsWith('builder')) {
       return 'builder-' + block.id;
     }
-    return block.id!;
+    return block.id || '';
   }
 
   contents(state: BuilderBlockState) {

--- a/packages/react/src/components/builder-block.component.tsx
+++ b/packages/react/src/components/builder-block.component.tsx
@@ -666,7 +666,7 @@ export class BuilderBlock extends React.Component<
 
   get id(): string {
     const { block } = this;
-    if (!block.id?.startsWith('builder')) {
+    if (block.id && !block.id.startsWith('builder')) {
       return 'builder-' + block.id;
     }
     return block.id || '';


### PR DESCRIPTION
## Description

We are getting block errors whenever we try to access `startsWith` method without checking if parent `id` field is there or not. This PR adds checks around that.
