### PR TITLE
fix[angular-gen2]: add `display: contents` to inlined script and inlined styles to not affect flex styles

### DIFF
--- a/.changeset/silly-pigs-confess.md
+++ b/.changeset/silly-pigs-confess.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/sdk-angular": patch
+---
+
+Fix: add `display: contents` to InlinedScript and InlinedStyles components so that they don't affect flex styles

--- a/packages/sdks/overrides/angular/src/components/inlined-script.ts
+++ b/packages/sdks/overrides/angular/src/components/inlined-script.ts
@@ -20,6 +20,13 @@ interface Props {
   template: ``,
   standalone: true,
   imports: [CommonModule],
+  styles: [
+    `
+      :host {
+        display: contents;
+      }
+    `,
+  ],
 })
 export default class InlinedScript {
   @Input() scriptStr!: Props['scriptStr'];

--- a/packages/sdks/overrides/angular/src/components/inlined-styles.ts
+++ b/packages/sdks/overrides/angular/src/components/inlined-styles.ts
@@ -14,6 +14,13 @@ interface Props {
   template: ``,
   standalone: true,
   imports: [CommonModule],
+  styles: [
+    `
+      :host {
+        display: contents;
+      }
+    `,
+  ],
 })
 export default class InlinedStyles {
   @Input() styles!: Props['styles'];


### PR DESCRIPTION
## Description

Fixes #3845

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
