### PR TITLE
fix[qwik-sdk]: ENG-6695 visual editor hangs if editable area (<Content />) is not in the iframe viewport

### DIFF
--- a/.changeset/nice-planets-roll.md
+++ b/.changeset/nice-planets-roll.md
@@ -2,5 +2,4 @@
 "@builder.io/sdk-qwik": patch
 ---
 
-- Fix: Content editor hangs if not in the iframe viewport
-- Chore: Added test case to trigger event when content component is not in the viewport
+Fix: Content editor hangs if not in the iframe viewport.

--- a/.changeset/nice-planets-roll.md
+++ b/.changeset/nice-planets-roll.md
@@ -1,0 +1,6 @@
+---
+"@builder.io/sdk-qwik": patch
+---
+
+- Fix: Content editor hangs if not in the iframe viewport
+- Chore: Added test case to trigger event when content component is not in the viewport

--- a/packages/sdks-tests/src/e2e-tests/editing.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/editing.spec.ts
@@ -18,7 +18,13 @@ import { ADD_A_TEXT_BLOCK } from '../specs/duplicated-content-using-nested-symbo
 import { EDITING_STYLES } from '../specs/editing-styles.js';
 import { ACCORDION_WITH_NO_DETAIL } from '../specs/accordion.js';
 
-const editorTests = ({ noTrustedHosts }: { noTrustedHosts: boolean }) => {
+const editorTests = ({
+  noTrustedHosts,
+  editorIsInViewPort,
+}: {
+  noTrustedHosts: boolean;
+  editorIsInViewPort?: boolean;
+}) => {
   test('correctly updates Text block', async ({ page, basePort, packageName, sdk }) => {
     test.skip(
       packageName === 'nextjs-sdk-next-app' ||
@@ -27,8 +33,16 @@ const editorTests = ({ noTrustedHosts }: { noTrustedHosts: boolean }) => {
         packageName === 'gen1-remix'
     );
 
+    if (!editorIsInViewPort) {
+      test.skip(sdk !== 'qwik', 'This is Qwik only test');
+    }
+
     await launchEmbedderAndWaitForSdk({
-      path: noTrustedHosts ? '/no-trusted-hosts' : '/editing',
+      path: noTrustedHosts
+        ? '/no-trusted-hosts'
+        : editorIsInViewPort
+          ? '/editing'
+          : '/editing-with-top-padding',
       basePort,
       page,
       sdk,
@@ -82,7 +96,7 @@ const editorTests = ({ noTrustedHosts }: { noTrustedHosts: boolean }) => {
 };
 
 test.describe('Visual Editing', () => {
-  editorTests({ noTrustedHosts: false });
+  editorTests({ noTrustedHosts: false, editorIsInViewPort: false });
   test('correctly updates Box -> Columns when used Inner Layout > Columns option', async ({
     page,
     packageName,

--- a/packages/sdks-tests/src/specs/index.ts
+++ b/packages/sdks-tests/src/specs/index.ts
@@ -106,6 +106,7 @@ type Page = {
 export const PAGES: Record<string, Page> = {
   '/': { content: HOMEPAGE },
   '/editing': { content: HOMEPAGE, isGen1VisualEditingTest: true },
+  '/editing-with-top-padding': { content: HOMEPAGE, isGen1VisualEditingTest: true },
   '/api-version-v3': { content: CONTENT_WITHOUT_SYMBOLS },
   '/api-version-default': { content: CONTENT_WITHOUT_SYMBOLS },
   '/can-track-false': { content: HOMEPAGE },
@@ -355,6 +356,11 @@ export const getProps = async (args: {
     case '/localization-subfields':
       extraProps = {
         locale: 'hi-IN',
+      };
+      break;
+    case '/editing-with-top-padding':
+      extraProps = {
+        addTopPadding: true,
       };
       break;
     default:

--- a/packages/sdks/e2e/qwik-city/src/routes/[...index]/index.tsx
+++ b/packages/sdks/e2e/qwik-city/src/routes/[...index]/index.tsx
@@ -61,6 +61,9 @@ export default component$(() => {
   const contentProps = useBuilderContentLoader();
   return (
     <>
+      {contentProps.value.addTopPadding && (
+        <div style={{ marginTop: '2000px' }} class="builder-margin-element" />
+      )}
       {contentProps.value ? (
         <Content
           {...(contentProps.value as any)}

--- a/packages/sdks/mitosis.config.cjs
+++ b/packages/sdks/mitosis.config.cjs
@@ -107,104 +107,18 @@ const IMPORT_USE_ON_DOCUMENT_PLUGIN = () => ({
       return json;
     },
   },
-});
-
-const REPLACE_USE_ON_WITH_USE_ON_DOCUMENT_PLUGIN = () => ({
   code: {
     post: (code, json) => {
-      if (json.name === 'EnableEditor') {
-        code = code.replace(
-          `
-  useOn(
-    "qvisible",
-    $((event, element) => {
-      if (isBrowser()) {
-        if (isEditing() && !props.isNestedRender) {
-          if (element) {
-            element.dispatchEvent(new CustomEvent("initeditingbldr"));
-          }
-        }
-        const shouldTrackImpression =
-          element.attributes.getNamedItem("shouldTrack")?.value === "true";
-        if (shouldTrackImpression) {
-          const variationId =
-            element.attributes.getNamedItem("variationId")?.value;
-          const contentId = element.attributes.getNamedItem("contentId")?.value;
-          const apiKeyProp = element.attributes.getNamedItem("apiKey")?.value;
-          _track({
-            apiHost: props.apiHost,
-            type: "impression",
-            canTrack: true,
-            contentId,
-            apiKey: apiKeyProp!,
-            variationId: variationId !== contentId ? variationId : undefined,
-          });
-        }
-
-        /**
-         * Override normal content in preview mode.
-         * We ignore this when editing, since the edited content is already being sent from the editor via post messages.
-         */
-        if (isPreviewing() && !isEditing()) {
-          if (element) {
-            element.dispatchEvent(new CustomEvent("initpreviewingbldr"));
-          }
-        }
+      if (json.name === 'EnableEditor'){
+        code = code.replace(`useOn(
+    "qvisible"`, `useOnDocument(
+    "readystatechange"`)
       }
-    }) as Parameters<typeof useOn>[1]
-  );
-  `,
-          `
-  useOnDocument(
-    "readystatechange",
-    $((event) => {
-      if (document.readyState === "complete" && typeof window !== "undefined") {
-        const element = document.querySelector("div");
-  
-        if (element) {
-          if (isEditing() && !props.isNestedRender) {
-            element.dispatchEvent(new CustomEvent("initeditingbldr"));
-          }
-  
-          const shouldTrackImpression =
-            element.attributes.getNamedItem("shouldTrack")?.value === "true";
-          if (shouldTrackImpression) {
-            const variationId =
-              element.attributes.getNamedItem("variationId")?.value;
-            const contentId = element.attributes.getNamedItem("contexntId")?.value;
-            const apiKeyProp = element.attributes.getNamedItem("apiKey")?.value;
-  
-            _track({
-              apiHost: props.apiHost,
-              type: "impression",
-              canTrack: true,
-              contentId,
-              apiKey: apiKeyProp!,
-              variationId: variationId !== contentId ? variationId : undefined,
-            });
-          }
-  
-          if (isPreviewing() && !isEditing()) {
-            element.dispatchEvent(new CustomEvent("initpreviewingbldr"));
-          }
-        }
-      }
-    })
-  );
-  `
-        );
-        code = code.replaceAll('useOn(', 'useOnDocument(');
-
-        code = code.replaceAll(
-          'as Parameters<typeof useOn>[1]',
-          'as Parameters<typeof useOnDocument>[1]'
-        );
-      }
-
-      return code;
-    },
-  },
+      return code
+    }
+  }
 });
+
 const REMOVE_MAGIC_PLUGIN = () => ({
   json: {
     post: (json) => {
@@ -1220,7 +1134,7 @@ module.exports = {
       typescript: true,
       plugins: [
         FETCHPRIORITY_CAMELCASE_PLUGIN,
-        REPLACE_USE_ON_WITH_USE_ON_DOCUMENT_PLUGIN,
+        // REPLACE_USE_ON_WITH_USE_ON_DOCUMENT_PLUGIN,
         IMPORT_USE_ON_DOCUMENT_PLUGIN,
         /**
          * cleanup `onMount` hooks

--- a/packages/sdks/mitosis.config.cjs
+++ b/packages/sdks/mitosis.config.cjs
@@ -95,6 +95,116 @@ ${restOfCode.join('\n').replace(/<(\/?)Text(.*?)>/g, '<$1BaseText$2>')}
   },
 });
 
+const IMPORT_USE_ON_DOCUMENT_PLUGIN = () => ({
+  json: {
+    post: (json) => {
+      if (json.name !== 'EnableEditor') return;
+      json.imports.push({
+        imports: { useOnDocument: 'useOnDocument' },
+        path: '@builder.io/qwik',
+      });
+
+      return json;
+    },
+  },
+});
+
+const REPLACE_USE_ON_WITH_USE_ON_DOCUMENT_PLUGIN = () => ({
+  code: {
+    post: (code, json) => {
+      if (json.name === 'EnableEditor') {
+        code = code.replace(
+          `
+  useOn(
+    "qvisible",
+    $((event, element) => {
+      if (isBrowser()) {
+        if (isEditing() && !props.isNestedRender) {
+          if (element) {
+            element.dispatchEvent(new CustomEvent("initeditingbldr"));
+          }
+        }
+        const shouldTrackImpression =
+          element.attributes.getNamedItem("shouldTrack")?.value === "true";
+        if (shouldTrackImpression) {
+          const variationId =
+            element.attributes.getNamedItem("variationId")?.value;
+          const contentId = element.attributes.getNamedItem("contentId")?.value;
+          const apiKeyProp = element.attributes.getNamedItem("apiKey")?.value;
+          _track({
+            apiHost: props.apiHost,
+            type: "impression",
+            canTrack: true,
+            contentId,
+            apiKey: apiKeyProp!,
+            variationId: variationId !== contentId ? variationId : undefined,
+          });
+        }
+
+        /**
+         * Override normal content in preview mode.
+         * We ignore this when editing, since the edited content is already being sent from the editor via post messages.
+         */
+        if (isPreviewing() && !isEditing()) {
+          if (element) {
+            element.dispatchEvent(new CustomEvent("initpreviewingbldr"));
+          }
+        }
+      }
+    }) as Parameters<typeof useOn>[1]
+  );
+  `,
+          `
+  useOnDocument(
+    "readystatechange",
+    $((event) => {
+      if (document.readyState === "complete" && typeof window !== "undefined") {
+        const element = document.querySelector("div");
+  
+        if (element) {
+          if (isEditing() && !props.isNestedRender) {
+            element.dispatchEvent(new CustomEvent("initeditingbldr"));
+          }
+  
+          const shouldTrackImpression =
+            element.attributes.getNamedItem("shouldTrack")?.value === "true";
+          if (shouldTrackImpression) {
+            const variationId =
+              element.attributes.getNamedItem("variationId")?.value;
+            const contentId = element.attributes.getNamedItem("contexntId")?.value;
+            const apiKeyProp = element.attributes.getNamedItem("apiKey")?.value;
+  
+            _track({
+              apiHost: props.apiHost,
+              type: "impression",
+              canTrack: true,
+              contentId,
+              apiKey: apiKeyProp!,
+              variationId: variationId !== contentId ? variationId : undefined,
+            });
+          }
+  
+          if (isPreviewing() && !isEditing()) {
+            element.dispatchEvent(new CustomEvent("initpreviewingbldr"));
+          }
+        }
+      }
+    })
+  );
+  `
+        );
+        code = code.replaceAll('useOn(', 'useOnDocument(');
+
+        code = code.replaceAll(
+          'as Parameters<typeof useOn>[1]',
+          'as Parameters<typeof useOnDocument>[1]'
+        );
+      }
+
+      return code;
+    },
+  },
+});
 const REMOVE_MAGIC_PLUGIN = () => ({
   json: {
     post: (json) => {
@@ -1110,6 +1220,8 @@ module.exports = {
       typescript: true,
       plugins: [
         FETCHPRIORITY_CAMELCASE_PLUGIN,
+        REPLACE_USE_ON_WITH_USE_ON_DOCUMENT_PLUGIN,
+        IMPORT_USE_ON_DOCUMENT_PLUGIN,
         /**
          * cleanup `onMount` hooks
          * - rmv unnecessary ones

--- a/packages/sdks/mitosis.config.cjs
+++ b/packages/sdks/mitosis.config.cjs
@@ -95,33 +95,6 @@ ${restOfCode.join('\n').replace(/<(\/?)Text(.*?)>/g, '<$1BaseText$2>')}
   },
 });
 
-const IMPORT_USE_ON_DOCUMENT_PLUGIN = () => ({
-  json: {
-    post: (json) => {
-      if (json.name !== 'EnableEditor') return;
-      json.imports.push({
-        imports: { useOnDocument: 'useOnDocument' },
-        path: '@builder.io/qwik',
-      });
-
-      return json;
-    },
-  },
-  code: {
-    post: (code, json) => {
-      if (json.name === 'EnableEditor') {
-        code = code.replace(
-          `useOn(
-    "qvisible"`,
-          `useOnDocument(
-    "readystatechange"`
-        );
-      }
-      return code;
-    },
-  },
-});
-
 const REMOVE_MAGIC_PLUGIN = () => ({
   json: {
     post: (json) => {
@@ -1137,7 +1110,6 @@ module.exports = {
       typescript: true,
       plugins: [
         FETCHPRIORITY_CAMELCASE_PLUGIN,
-        IMPORT_USE_ON_DOCUMENT_PLUGIN,
         /**
          * cleanup `onMount` hooks
          * - rmv unnecessary ones
@@ -1160,13 +1132,35 @@ module.exports = {
                   json.hooks.onEvent.push({
                     code: hook.code.replaceAll('elementRef', 'element'),
                     eventArgName: 'event',
-                    eventName: 'qvisible',
+                    eventName: 'readystatechange',
                     isRoot: true,
                     refName: 'element',
                     elementArgName: 'element',
                   });
                 });
               }
+            },
+            post: (json) => {
+              if (json.name !== 'EnableEditor') return;
+              json.imports.push({
+                imports: { useOnDocument: 'useOnDocument' },
+                path: '@builder.io/qwik',
+              });
+              return json;
+            },
+          },
+          code: {
+            post: (code, json) => {
+              if (json.name === 'EnableEditor') {
+                code = code.replaceAll(
+                  `useOn(
+    "readystatechange"`,
+                  `useOnDocument(
+    "readystatechange"`
+                );
+                console.log('use on document', code)
+              }
+              return code;
             },
           },
         }),

--- a/packages/sdks/mitosis.config.cjs
+++ b/packages/sdks/mitosis.config.cjs
@@ -1158,7 +1158,6 @@ module.exports = {
                   `useOnDocument(
     "readystatechange"`
                 );
-                console.log('use on document', code)
               }
               return code;
             },

--- a/packages/sdks/mitosis.config.cjs
+++ b/packages/sdks/mitosis.config.cjs
@@ -109,14 +109,17 @@ const IMPORT_USE_ON_DOCUMENT_PLUGIN = () => ({
   },
   code: {
     post: (code, json) => {
-      if (json.name === 'EnableEditor'){
-        code = code.replace(`useOn(
-    "qvisible"`, `useOnDocument(
-    "readystatechange"`)
+      if (json.name === 'EnableEditor') {
+        code = code.replace(
+          `useOn(
+    "qvisible"`,
+          `useOnDocument(
+    "readystatechange"`
+        );
       }
-      return code
-    }
-  }
+      return code;
+    },
+  },
 });
 
 const REMOVE_MAGIC_PLUGIN = () => ({
@@ -1134,7 +1137,6 @@ module.exports = {
       typescript: true,
       plugins: [
         FETCHPRIORITY_CAMELCASE_PLUGIN,
-        // REPLACE_USE_ON_WITH_USE_ON_DOCUMENT_PLUGIN,
         IMPORT_USE_ON_DOCUMENT_PLUGIN,
         /**
          * cleanup `onMount` hooks


### PR DESCRIPTION
## Description
The `CustomEvent` `"initeditingbldr"` was not triggering as expected by ensuring proper event dispatch timing and listener registration. The `useOnDocument("readystatechange")` handler was updated to dispatch the event only after the DOM is fully loaded (`document.readyState === "complete"`)

**JIRA**:
https://builder-io.atlassian.net/browse/ENG-6695

**Loom**
https://www.loom.com/share/0ab5296adbe24bb2b22319f0588f0bbf?sid=4e4b4066-4b18-459e-bc62-7dae1e45c1f9