### PR TITLE
bug[reactSDK][videoComponent]: Removing z-index from video component

### DIFF
--- a/.changeset/popular-rocks-grow.md
+++ b/.changeset/popular-rocks-grow.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/react": patch
+---
+
+Fix: Removed z-index from video component as its hiding the child elements

--- a/packages/react/src/blocks/Video.tsx
+++ b/packages/react/src/blocks/Video.tsx
@@ -132,7 +132,6 @@ class VideoComponent extends React.Component<
             height: '100%',
             objectFit: this.props.fit,
             objectPosition: this.props.position,
-            zIndex: 2,
             // Hack to get object fit to work as expected and not have the video
             // overflow
             borderRadius: 1,

--- a/packages/sdks-tests/src/e2e-tests/blocks.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/blocks.spec.ts
@@ -244,28 +244,24 @@ test.describe('Blocks', () => {
         {
           width: '152px',
           'object-fit': 'cover',
-          'z-index': '2',
           'border-radius': '1px',
           position: 'absolute',
         },
         {
           width: '1249px',
           'object-fit': 'contain',
-          'z-index': '2',
           'border-radius': '1px',
           position: 'absolute',
         },
         {
           width: '744px',
           'object-fit': 'cover',
-          'z-index': '2',
           'border-radius': '1px',
           position: 'absolute',
         },
         {
           width: '152px',
           'object-fit': 'cover',
-          'z-index': '2',
           'border-radius': '1px',
           position: 'absolute',
         },


### PR DESCRIPTION
## Description
Removed the z-index property on Video Component, as it hides the child elements.


## Jira Ticket
https://builder-io.atlassian.net/browse/ENG-8012

_Loom_
https://www.loom.com/share/2d70f09c03444f37aacea83789508923

