### PR TITLE
[gen2][videoCompoent]: Removing the z-index from video component

### DIFF
--- a/packages/sdks/src/blocks/video/video.lite.tsx
+++ b/packages/sdks/src/blocks/video/video.lite.tsx
@@ -38,7 +38,6 @@ export default function Video(props: VideoProps) {
           objectPosition: props.position,
           // Hack to get object fit to work as expected and
           // not have the video overflow
-          zIndex: 2,
           borderRadius: '1px',
           ...(props.aspectRatio
             ? {


### PR DESCRIPTION
Same changes applied to gen2 as this PR: https://github.com/BuilderIO/builder/pull/3876

## Description
Removed the z-index property on Video Component, as it hides the child elements.


## Jira Ticket
https://builder-io.atlassian.net/browse/ENG-8012

_Loom_
https://www.loom.com/share/2d70f09c03444f37aacea83789508923

