### PR TITLE
remove Update Translation button that has not yet been implemented

### DIFF
--- a/plugins/phrase-conector/src/plugin.tsx
+++ b/plugins/phrase-conector/src/plugin.tsx
@@ -174,22 +174,23 @@ registerPlugin(
         }
       },
     });
-    registerContentAction({
-      label: 'Request an updated translation',
-      showIf(content, model) {
-        return (
-          content.published === 'published' &&
-          content.meta?.get('translationStatus') === 'pending' &&
-          content.meta.get('translationRevisionLatest') &&
-          content.meta.get('translationRevision') !== content.meta.get('translationRevisionLatest')
-        );
-      },
-      async onClick(content) {
-        appState.globalState.showGlobalBlockingLoading('Contacting Phrase ....');
-        // TODO
-        appState.globalState.hideGlobalBlockingLoading();
-      },
-    });
+    //TODO
+    // registerContentAction({
+    //   label: 'Request an updated translation',
+    //   showIf(content, model) {
+    //     return (
+    //       content.published === 'published' &&
+    //       content.meta?.get('translationStatus') === 'pending' &&
+    //       content.meta.get('translationRevisionLatest') &&
+    //       content.meta.get('translationRevision') !== content.meta.get('translationRevisionLatest')
+    //     );
+    //   },
+    //   async onClick(content) {
+    //     appState.globalState.showGlobalBlockingLoading('Contacting Phrase ....');
+    //     // TODO
+    //     appState.globalState.hideGlobalBlockingLoading();
+    //   },
+    // });
 
     registerContentAction({
       label: 'Apply Translation',


### PR DESCRIPTION

![Screenshot 2025-02-07 at 10 42 29 AM](https://github.com/user-attachments/assets/eed01d09-4a9d-48c0-bb3f-009befe66d64)
There is a section of Phrase plugin that will add a Request an updated translation when a user has changed content on their page, but the actual logic of the button has not been implemented. 

This will remove the button until such time that the logic is implemented 