### PR TITLE
Live Previewing Data Model – Add Support for Latest subscribeToEditor() Change in React Gen2 Snippets

### DIFF
--- a/packages/sdks-tests/src/snippet-tests/live-previewing.spec.ts
+++ b/packages/sdks-tests/src/snippet-tests/live-previewing.spec.ts
@@ -22,7 +22,9 @@ test.describe('LivePreviewBlogData Component', () => {
     await expect(blogPreview).toContainText('Authored by: John Doe');
     await expect(blogPreview).toContainText('Handle: john_doe');
 
-    const expectedDate = new Date().toDateString();
+    const expectedDate = new Date().toDateString().split(' ').slice(0, 4).join(' ');
+
+    console.log('expectedDate', expectedDate);
 
     const actualText = await blogPreview.textContent();
 

--- a/packages/sdks-tests/src/snippet-tests/live-previewing.spec.ts
+++ b/packages/sdks-tests/src/snippet-tests/live-previewing.spec.ts
@@ -14,7 +14,6 @@ test.describe('LivePreviewBlogData Component', () => {
     test.skip(!['react'].includes(packageName));
 
     await page.goto('/live-preview');
-    await page.waitForLoadState('networkidle');
 
     const blogPreview = page.locator('.blog-data-preview');
     await expect(blogPreview).toBeVisible();
@@ -37,9 +36,8 @@ test.describe('LivePreviewBlogData Component', () => {
       );
 
       await launchEmbedderAndWaitForSdk({ path: '/live-preview', basePort, page, sdk });
-      await page.waitForLoadState('networkidle');
 
-      const initialContent = {
+      const INITIAL_CONTENT = {
         data: {
           title: 'Welcome to Builder.io',
           author: 'John Doe',
@@ -48,18 +46,18 @@ test.describe('LivePreviewBlogData Component', () => {
         },
       };
       await expect(
-        page.frameLocator('iframe').getByText(`Blog Title: ${initialContent.data.title}`)
+        page.frameLocator('iframe').getByText(`Blog Title: ${INITIAL_CONTENT.data.title}`)
       ).toBeVisible();
       await expect(
-        page.frameLocator('iframe').getByText(`Authored by: ${initialContent.data.author}`)
+        page.frameLocator('iframe').getByText(`Authored by: ${INITIAL_CONTENT.data.author}`)
       ).toBeVisible();
       await expect(
-        page.frameLocator('iframe').getByText(`Handle: ${initialContent.data.handle}`)
+        page.frameLocator('iframe').getByText(`Handle: ${INITIAL_CONTENT.data.handle}`)
       ).toBeVisible();
       await expect(
         page
           .frameLocator('iframe')
-          .getByText(`Published date: ${initialContent.data.publishedDate}`)
+          .getByText(`Published date: ${INITIAL_CONTENT.data.publishedDate}`)
       ).toBeVisible();
 
       const UPDATED_CONTENT = {
@@ -70,7 +68,6 @@ test.describe('LivePreviewBlogData Component', () => {
           publishedDate: `${new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}`,
         },
       };
-
 
       await sendPatchOrUpdateMessage({
         page,

--- a/packages/sdks-tests/src/snippet-tests/live-previewing.spec.ts
+++ b/packages/sdks-tests/src/snippet-tests/live-previewing.spec.ts
@@ -1,10 +1,6 @@
 import { expect } from '@playwright/test';
 import { test } from '../helpers/index.js';
-import {
-  launchEmbedderAndWaitForSdk,
-  sendContentUpdateMessage,
-  sendPatchOrUpdateMessage,
-} from '../helpers/visual-editor.js';
+import { launchEmbedderAndWaitForSdk, sendPatchOrUpdateMessage } from '../helpers/visual-editor.js';
 
 test.describe('LivePreviewBlogData Component', () => {
   test('should render the page without 404', async ({ page, packageName }) => {

--- a/packages/sdks-tests/src/snippet-tests/live-previewing.spec.ts
+++ b/packages/sdks-tests/src/snippet-tests/live-previewing.spec.ts
@@ -1,5 +1,10 @@
 import { expect } from '@playwright/test';
 import { test } from '../helpers/index.js';
+import {
+  launchEmbedderAndWaitForSdk,
+  sendContentUpdateMessage,
+  sendPatchOrUpdateMessage,
+} from '../helpers/visual-editor.js';
 
 test.describe('LivePreviewBlogData Component', () => {
   test('should render the page without 404', async ({ page, packageName }) => {
@@ -19,9 +24,56 @@ test.describe('LivePreviewBlogData Component', () => {
     await expect(blogPreview).toBeVisible();
 
     //assert the blog details coming from builder data model
-    await expect(blogPreview).toContainText('Blog Title: Welcome to Builder.io');
-    await expect(blogPreview).toContainText('Authored by: John Doe');
-    await expect(blogPreview).toContainText('Handle: john_doe');
-    await expect(blogPreview).toContainText('Published date: Tue Feb 11 2025');
+    await expect(blogPreview).toContainText('Blog Title: Welcome to Visual Copilot');
+    await expect(blogPreview).toContainText('Authored by: Jane Doe');
+    await expect(blogPreview).toContainText('Handle: jane_doe');
+    await expect(blogPreview).toContainText('Published date: Wed Feb 12 2025');
+  });
+
+  test.describe('Live Preview blog data - Visual Editor', () => {
+    test('enables live previewing and editing', async ({ page, basePort, sdk, packageName }) => {
+      test.skip(
+        packageName === 'nextjs-sdk-next-app' ||
+          packageName === 'gen1-next14-pages' ||
+          packageName === 'gen1-remix' ||
+          !['react'].includes(packageName),
+        'Skipping test: incompatible package or framework.'
+      );
+
+      // Launch the Visual Editor and wait for SDK
+      await launchEmbedderAndWaitForSdk({ path: '/live-preview', basePort, page, sdk });
+      await page.waitForLoadState('networkidle');
+
+      const NEW_CONTENT = {
+        data: {
+          title: 'Welcome to Builder.io',
+          author: 'John Doe',
+          handle: 'john_doe',
+          publishedDate: 'Tue Feb 11 2025',
+        },
+      };
+
+      await sendPatchOrUpdateMessage({
+        page,
+        content: NEW_CONTENT,
+        model: 'blog-data',
+        sdk,
+        updateFn: content => content,
+        path: '/live-preview',
+      });
+
+      await expect(
+        page.frameLocator('iframe').getByText(`Blog Title: ${NEW_CONTENT.data.title}`)
+      ).toBeVisible();
+      await expect(
+        page.frameLocator('iframe').getByText(`Authored by: ${NEW_CONTENT.data.author}`)
+      ).toBeVisible();
+      await expect(
+        page.frameLocator('iframe').getByText(`Handle: ${NEW_CONTENT.data.handle}`)
+      ).toBeVisible();
+      await expect(
+        page.frameLocator('iframe').getByText(`Published date: ${NEW_CONTENT.data.publishedDate}`)
+      ).toBeVisible();
+    });
   });
 });

--- a/packages/sdks-tests/src/snippet-tests/live-previewing.spec.ts
+++ b/packages/sdks-tests/src/snippet-tests/live-previewing.spec.ts
@@ -1,0 +1,31 @@
+import { expect } from '@playwright/test';
+import { test } from '../helpers/index.js';
+
+test.describe('LivePreviewBlogData Component', () => {
+  test('should render the page without 404', async ({ page, packageName }) => {
+    test.skip(!['react'].includes(packageName));
+
+    const response = await page.goto('/live-preview');
+    expect(response?.status()).toBeLessThan(400);
+  });
+
+  test('should display blog details correctly', async ({ page, packageName }) => {
+    test.skip(!['react'].includes(packageName));
+
+    await page.goto('/live-preview');
+    await page.waitForLoadState('networkidle');
+
+    const blogPreview = page.locator('.blog-data-preview');
+    await expect(blogPreview).toBeVisible();
+
+    await expect(blogPreview).toContainText('Blog Title: Welcome to Builder.io');
+    await expect(blogPreview).toContainText('Authored by: John Doe');
+    await expect(blogPreview).toContainText('Handle: john_doe');
+
+    const expectedDate = new Date().toDateString();
+
+    const actualText = await blogPreview.textContent();
+
+    expect(actualText).toContain(`Published date: ${expectedDate}`);
+  });
+});

--- a/packages/sdks-tests/src/snippet-tests/live-previewing.spec.ts
+++ b/packages/sdks-tests/src/snippet-tests/live-previewing.spec.ts
@@ -21,13 +21,6 @@ test.describe('LivePreviewBlogData Component', () => {
     await expect(blogPreview).toContainText('Blog Title: Welcome to Builder.io');
     await expect(blogPreview).toContainText('Authored by: John Doe');
     await expect(blogPreview).toContainText('Handle: john_doe');
-
-    const expectedDate = new Date().toDateString().split(' ').slice(0, 4).join(' ');
-
-    console.log('expectedDate', expectedDate);
-
-    const actualText = await blogPreview.textContent();
-
-    expect(actualText).toContain(`Published date: ${expectedDate}`);
+    await expect(blogPreview).toContainText('Published date: Tue Feb 11 2025');
   });
 });

--- a/packages/sdks-tests/src/snippet-tests/live-previewing.spec.ts
+++ b/packages/sdks-tests/src/snippet-tests/live-previewing.spec.ts
@@ -18,6 +18,7 @@ test.describe('LivePreviewBlogData Component', () => {
     const blogPreview = page.locator('.blog-data-preview');
     await expect(blogPreview).toBeVisible();
 
+    //assert the blog details coming from builder data model
     await expect(blogPreview).toContainText('Blog Title: Welcome to Builder.io');
     await expect(blogPreview).toContainText('Authored by: John Doe');
     await expect(blogPreview).toContainText('Handle: john_doe');

--- a/packages/sdks-tests/src/snippet-tests/live-previewing.spec.ts
+++ b/packages/sdks-tests/src/snippet-tests/live-previewing.spec.ts
@@ -20,10 +20,10 @@ test.describe('LivePreviewBlogData Component', () => {
     await expect(blogPreview).toBeVisible();
 
     //assert the blog details coming from builder data model
-    await expect(blogPreview).toContainText('Blog Title: Welcome to Visual Copilot');
-    await expect(blogPreview).toContainText('Authored by: Jane Doe');
-    await expect(blogPreview).toContainText('Handle: jane_doe');
-    await expect(blogPreview).toContainText('Published date: Wed Feb 12 2025');
+    await expect(blogPreview).toContainText('Blog Title: Welcome to Builder.io');
+    await expect(blogPreview).toContainText('Authored by: John Doe');
+    await expect(blogPreview).toContainText('Handle: john_doe');
+    await expect(blogPreview).toContainText('Published date: Tue Feb 11 2025');
   });
 
   test.describe('Live Preview blog data - Visual Editor', () => {
@@ -36,11 +36,10 @@ test.describe('LivePreviewBlogData Component', () => {
         'Skipping test: incompatible package or framework.'
       );
 
-      // Launch the Visual Editor and wait for SDK
       await launchEmbedderAndWaitForSdk({ path: '/live-preview', basePort, page, sdk });
       await page.waitForLoadState('networkidle');
 
-      const NEW_CONTENT = {
+      const initialContent = {
         data: {
           title: 'Welcome to Builder.io',
           author: 'John Doe',
@@ -48,10 +47,34 @@ test.describe('LivePreviewBlogData Component', () => {
           publishedDate: 'Tue Feb 11 2025',
         },
       };
+      await expect(
+        page.frameLocator('iframe').getByText(`Blog Title: ${initialContent.data.title}`)
+      ).toBeVisible();
+      await expect(
+        page.frameLocator('iframe').getByText(`Authored by: ${initialContent.data.author}`)
+      ).toBeVisible();
+      await expect(
+        page.frameLocator('iframe').getByText(`Handle: ${initialContent.data.handle}`)
+      ).toBeVisible();
+      await expect(
+        page
+          .frameLocator('iframe')
+          .getByText(`Published date: ${initialContent.data.publishedDate}`)
+      ).toBeVisible();
+
+      const UPDATED_CONTENT = {
+        data: {
+          title: 'Welcome to Visual Editor',
+          author: 'Jane Doe',
+          handle: 'jane_doe',
+          publishedDate: `${new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}`,
+        },
+      };
+
 
       await sendPatchOrUpdateMessage({
         page,
-        content: NEW_CONTENT,
+        content: UPDATED_CONTENT,
         model: 'blog-data',
         sdk,
         updateFn: content => content,
@@ -59,16 +82,18 @@ test.describe('LivePreviewBlogData Component', () => {
       });
 
       await expect(
-        page.frameLocator('iframe').getByText(`Blog Title: ${NEW_CONTENT.data.title}`)
+        page.frameLocator('iframe').getByText(`Blog Title: ${UPDATED_CONTENT.data.title}`)
       ).toBeVisible();
       await expect(
-        page.frameLocator('iframe').getByText(`Authored by: ${NEW_CONTENT.data.author}`)
+        page.frameLocator('iframe').getByText(`Authored by: ${UPDATED_CONTENT.data.author}`)
       ).toBeVisible();
       await expect(
-        page.frameLocator('iframe').getByText(`Handle: ${NEW_CONTENT.data.handle}`)
+        page.frameLocator('iframe').getByText(`Handle: ${UPDATED_CONTENT.data.handle}`)
       ).toBeVisible();
       await expect(
-        page.frameLocator('iframe').getByText(`Published date: ${NEW_CONTENT.data.publishedDate}`)
+        page
+          .frameLocator('iframe')
+          .getByText(`Published date: ${UPDATED_CONTENT.data.publishedDate}`)
       ).toBeVisible();
     });
   });

--- a/packages/sdks/snippets/react/src/main.tsx
+++ b/packages/sdks/snippets/react/src/main.tsx
@@ -6,6 +6,7 @@ import AdvancedChildRoute from './routes/custom-components/advanced-child.tsx';
 import CustomChildRoute from './routes/custom-components/custom-child.tsx';
 import EditableRegionRoute from './routes/custom-components/editable-region.tsx';
 import IntegratingPages from './routes/IntegratingPages.tsx';
+import LivePreviewBlogData from './routes/LivePreviewBlogData.js';
 
 const router = createBrowserRouter([
   {
@@ -23,6 +24,10 @@ const router = createBrowserRouter([
   {
     path: '/advanced-child',
     element: <AdvancedChildRoute />,
+  },
+  {
+    path: '/live-preview',
+    element: <LivePreviewBlogData />,
   },
   {
     path: '/*',

--- a/packages/sdks/snippets/react/src/routes/LivePreviewBlogData.tsx
+++ b/packages/sdks/snippets/react/src/routes/LivePreviewBlogData.tsx
@@ -1,6 +1,5 @@
 import {
   BuilderContent,
-  Content,
   fetchOneEntry,
   subscribeToEditor,
 } from '@builder.io/sdk-react';
@@ -17,6 +16,7 @@ function LivePreviewBlogData() {
     fetchOneEntry({
       model: 'blog-data',
       apiKey: 'ee9f13b4981e489a9a1209887695ef2b',
+
       userAttributes: {
         urlPath: slug,
       },
@@ -61,15 +61,6 @@ function LivePreviewBlogData() {
           Published date:{' '}
           {content?.data?.publishedDate.split(' ').slice(0, 4).join(' ')}
         </div>
-      </div>
-
-      {/* You can render builder content here and they must be published to be visible */}
-      <div className="builder-blocks">
-        <Content
-          model="page"
-          apiKey="ee9f13b4981e489a9a1209887695ef2b"
-          content={content}
-        />
       </div>
     </>
   );

--- a/packages/sdks/snippets/react/src/routes/LivePreviewBlogData.tsx
+++ b/packages/sdks/snippets/react/src/routes/LivePreviewBlogData.tsx
@@ -40,7 +40,6 @@ function LivePreviewBlogData() {
         setContent(content);
       },
     });
-
     //unsubscribe from live updates
     return () => {
       unsubscribe();

--- a/packages/sdks/snippets/react/src/routes/LivePreviewBlogData.tsx
+++ b/packages/sdks/snippets/react/src/routes/LivePreviewBlogData.tsx
@@ -1,0 +1,76 @@
+import {
+  BuilderContent,
+  Content,
+  fetchOneEntry,
+  subscribeToEditor,
+} from '@builder.io/sdk-react';
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router';
+
+function LivePreviewBlogData() {
+  const [content, setContent] = useState<BuilderContent | null>(null);
+  const [loading, setLoading] = useState(true);
+  const location = useLocation();
+  const slug = location.pathname;
+
+  useEffect(() => {
+    fetchOneEntry({
+      model: 'blog-data',
+      apiKey: 'ee9f13b4981e489a9a1209887695ef2b',
+      userAttributes: {
+        urlPath: slug,
+      },
+    })
+      .then((data) => {
+        setContent(data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        console.error(
+          'something went wrong while fetching Builder Content: ',
+          err
+        );
+      });
+
+    //subscribe to live updates
+    const unsubscribe = subscribeToEditor({
+      model: 'blog-data',
+      apiKey: 'ee9f13b4981e489a9a1209887695ef2b',
+      callback: (content) => {
+        setContent(content);
+      },
+    });
+
+    //unsubscribe from live updates
+    return () => {
+      unsubscribe();
+    };
+  }, [slug]);
+
+  if (!content && !loading) {
+    return <div>Loading Data...</div>;
+  }
+
+  return (
+    <>
+      {/* Live preview the blog data in the browser without publishing */}
+      <div className="blog-data-preview">
+        <div>Blog Title: {content?.data?.title}</div>
+        <div>Authored by: {content?.data?.author}</div>
+        <div>Handle: {content?.data?.handle}</div>
+        <div>Published date: {content?.data?.publishedDate}</div>
+      </div>
+
+      {/* You can render builder content here and they must be published to be visible */}
+      <div className="builder-blocks">
+        <Content
+          model="page"
+          apiKey="ee9f13b4981e489a9a1209887695ef2b"
+          content={content}
+        />
+      </div>
+    </>
+  );
+}
+
+export default LivePreviewBlogData;

--- a/packages/sdks/snippets/react/src/routes/LivePreviewBlogData.tsx
+++ b/packages/sdks/snippets/react/src/routes/LivePreviewBlogData.tsx
@@ -58,7 +58,10 @@ function LivePreviewBlogData() {
         <div>Blog Title: {content?.data?.title}</div>
         <div>Authored by: {content?.data?.author}</div>
         <div>Handle: {content?.data?.handle}</div>
-        <div>Published date: {content?.data?.publishedDate}</div>
+        <div>
+          Published date:{' '}
+          {content?.data?.publishedDate.split(' ').slice(0, 4).join(' ')}
+        </div>
       </div>
 
       {/* You can render builder content here and they must be published to be visible */}


### PR DESCRIPTION
## Description

As per the ticket [EDU-459](https://builder-io.atlassian.net/browse/EDU-459), this PR updates the React Gen2 code snippet to align with the latest breaking change to `subscribeToEditor()`. This ensures that the docs remain up to date and work without any issues. 

ENG changelog: https://github.com/BuilderIO/builder/blob/main/packages/sdks/output/react/CHANGELOG.md#400 

This PR adds the code for live previewing data models in the code snippets. I just wanted to let you know that more to come. 
@samijaber Please review it.


[EDU-459]: https://builder-io.atlassian.net/browse/EDU-459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ