### PR TITLE
[shopify][Plugin]: Increasing limit for storefront shopify products api

### DIFF
--- a/plugins/shopify/package-lock.json
+++ b/plugins/shopify/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/plugin-shopify",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-shopify",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@builder.io/plugin-tools": "^0.0.3",

--- a/plugins/shopify/package.json
+++ b/plugins/shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-shopify",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "",
   "keywords": [],
   "main": "dist/plugin.system.js",

--- a/plugins/shopify/src/plugin.ts
+++ b/plugins/shopify/src/plugin.ts
@@ -86,6 +86,7 @@ registerCommercePlugin(
           return client.collection.fetchQuery({
             query: search ? `title:*${search}*` : '',
             sortKey: 'TITLE',
+            first: 250
           });
         },
 

--- a/plugins/shopify/src/plugin.ts
+++ b/plugins/shopify/src/plugin.ts
@@ -51,6 +51,7 @@ registerCommercePlugin(
             (await client.product.fetchQuery({
               query: search ? `title:*${search}*` : '',
               sortKey: 'TITLE',
+              first: 250
             })) || [];
           return sources.map((src: any) => {
             return {


### PR DESCRIPTION
## Description
This api is by default having a limit of 20 products, increasing it to a maximum of 250. 
