### PR TITLE
fix[plugin][algolia]: ENG-8338 commit released algolia@0.0.9 plugin

### DIFF
--- a/plugins/algolia/package-lock.json
+++ b/plugins/algolia/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/plugin-algolia",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-algolia",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "MIT",
       "dependencies": {
         "@builder.io/mobx-state-tree": "^3.14.2",

--- a/plugins/algolia/package.json
+++ b/plugins/algolia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-algolia",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "",
   "keywords": [],
   "main": "dist/plugin.system.js",


### PR DESCRIPTION
## Description

This PR commits the file updates from release of @builder.io/plugin-algolia@0.0.9 plugin.

The 0.0.9 release has no additional changes. The 0.0.8 (link [here](https://cdn.jsdelivr.net/npm/@builder.io/plugin-algolia@0.0.8)) was generated in corrupt way as seen by a extra `owIf` object at the end of it.

I just used the same code src and published the 0.0.9 version (link [here](https://cdn.jsdelivr.net/npm/@builder.io/plugin-algolia@0.0.9)).
