### PR TITLE
feat[TextEditor]: Handling <p> and <br> tags in text editor

### DIFF
--- a/packages/react/src/blocks/Text.tsx
+++ b/packages/react/src/blocks/Text.tsx
@@ -22,7 +22,38 @@ class TextComponent extends React.Component<TextProps> {
     if (this.textRef && !/{{([^}]+)}}/.test(this.props.text)) {
       this.textRef.innerHTML = this.props.text;
     }
+
+    if (this.textRef) {
+      this.textRef.addEventListener('keydown', this.handleKeyDown);
+    }
   }
+
+  handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      event.preventDefault(); // Prevent default Enter behavior
+
+      const selection = window.getSelection();
+      if (!selection || !selection.rangeCount) return;
+
+      const range = selection.getRangeAt(0);
+      const newNode = document.createElement(event.shiftKey ? 'br' : 'p');
+
+      if (!event.shiftKey) {
+        // For <p> tags, add a line break to avoid collapsing
+        newNode.innerHTML = '<br>';
+      }
+
+      // Insert the new element at the caret position
+      range.deleteContents();
+      range.insertNode(newNode);
+
+      // Move caret after the newly inserted element
+      range.setStartAfter(newNode);
+      range.setEndAfter(newNode);
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }
+  };
 
   evalExpression(expression: string, state: any) {
     // Don't interpolate when inline editing


### PR DESCRIPTION
## Description

Issue: https://www.loom.com/share/778be6445389441db7188e83bdc752cb

**Current behavior:**
Pressing Enter creates a line break (<br> tag) without spacing (aka without creating new <p> tags)
Shift+Enter has no different effect than Enter

**Expected behavior:**
Pressing Enter should create a new paragraph (P tag) which will give it the expected amount of spacing
Shift+Enter should create a line break (BR tag) without spacing

**Solution Loom**
https://www.loom.com/share/a29637870e84432daa4493af6bed6181

