### PR TITLE
chore: bump commercelayer plugin version to 0.0.4

### DIFF
--- a/plugins/commercelayer/package-lock.json
+++ b/plugins/commercelayer/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "@builder.io/plugin-commercelayer",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-commercelayer",
-      "version": "0.0.1",
+      "version": "0.0.4",
+      "license": "MIT",
       "dependencies": {
         "@builder.io/plugin-tools": "^0.0.6"
       },
@@ -16,11 +17,15 @@
         "@rollup/plugin-replace": "^5.0.5",
         "@rollup/plugin-typescript": "^11.1.6",
         "@types/node": "^20.11.19",
+        "rimraf": "^2.6.2",
         "rollup": "^4.12.0",
         "rollup-plugin-esbuild": "^6.1.1",
         "rollup-plugin-serve": "^1.1.1",
         "tsx": "^4.7.1",
         "typescript": "^5.2.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@builder.io/plugin-tools": {
@@ -901,6 +906,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -985,6 +1015,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1023,6 +1060,28 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -1035,6 +1094,25 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
@@ -1088,12 +1166,35 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/opener": {
       "version": "1.5.2",
@@ -1103,6 +1204,16 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-parse": {
@@ -1170,6 +1281,20 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/rollup": {
@@ -1769,6 +1894,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     }
   }
 }

--- a/plugins/commercelayer/package.json
+++ b/plugins/commercelayer/package.json
@@ -1,14 +1,39 @@
 {
   "name": "@builder.io/plugin-commercelayer",
-  "private": true,
-  "version": "0.0.1",
-  "type": "module",
+  "version": "0.0.4",
+  "description": "Commerce Layer plugin for Builder.io",
+  "keywords": [],
   "main": "dist/plugin.system.js",
   "unpkg": "dist/plugin.system.js",
+  "files": [
+    "dist"
+  ],
+  "author": "Ahmed Felfel <ahmed@builder.io>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BuilderIO/builder"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=6.0.0"
+  },
+  "type": "module",
   "types": "dist/index.d.ts",
   "scripts": {
+    "lint": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",
+    "prebuild": "rimraf dist",
     "build": "rollup -c rollup.config.ts --configPlugin @rollup/plugin-typescript",
-    "start": "SERVE=true rollup -c rollup.config.ts --configPlugin @rollup/plugin-typescript -w"
+    "start": "SERVE=true rollup -c rollup.config.ts --configPlugin @rollup/plugin-typescript -w",
+    "release:dev": "npm run build && npm version prerelease --no-git-tag-version && npm publish --tag dev",
+    "release:patch": "npm run build && npm version patch --no-git-tag-version && npm publish",
+    "test": "jest --coverage",
+    "test:watch": "jest --coverage --watch",
+    "test:prod": "npm run lint && npm run test -- --no-cache",
+    "report-coverage": "cat ./coverage/lcov.info | coveralls",
+    "commit": "git-cz",
+    "semantic-release": "semantic-release",
+    "semantic-release-prepare": "ts-node tools/semantic-release-prepare",
+    "travis-deploy-once": "travis-deploy-once"
   },
   "devDependencies": {
     "@rollup/plugin-json": "^6.1.0",
@@ -20,7 +45,8 @@
     "rollup-plugin-esbuild": "^6.1.1",
     "rollup-plugin-serve": "^1.1.1",
     "tsx": "^4.7.1",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "rimraf": "^2.6.2"
   },
   "dependencies": {
     "@builder.io/plugin-tools": "^0.0.6"


### PR DESCRIPTION
This pull request includes updates to the `@builder.io/plugin-commercelayer` package, including version updates, new dependencies, and additional scripts. The changes aim to enhance the plugin's functionality and ensure compatibility with the latest tools.

Key changes include:

### Version and Metadata Updates:
* Updated the version from `0.0.1` to `0.0.4` and added a description, author, and repository information in `package.json`.
* Added a license field and specified the required Node.js version in `package.json`.

### Dependencies:
* Added new dependencies such as `rimraf`, `balanced-match`, `brace-expansion`, `concat-map`, `fs.realpath`, `glob`, `inflight`, `inherits`, `minimatch`, `once`, `path-is-absolute`, and `wrappy` in `package-lock.json`. [[1]](diffhunk://#diff-ddf9c2805aef4a99cf30b7913efd40210329100d5fbea275044891b7e190d49bR20-R28) [[2]](diffhunk://#diff-ddf9c2805aef4a99cf30b7913efd40210329100d5fbea275044891b7e190d49bR909-R933) [[3]](diffhunk://#diff-ddf9c2805aef4a99cf30b7913efd40210329100d5fbea275044891b7e190d49bR1018-R1024) [[4]](diffhunk://#diff-ddf9c2805aef4a99cf30b7913efd40210329100d5fbea275044891b7e190d49bR1063-R1084) [[5]](diffhunk://#diff-ddf9c2805aef4a99cf30b7913efd40210329100d5fbea275044891b7e190d49bR1098-R1116) [[6]](diffhunk://#diff-ddf9c2805aef4a99cf30b7913efd40210329100d5fbea275044891b7e190d49bR1169-R1198) [[7]](diffhunk://#diff-ddf9c2805aef4a99cf30b7913efd40210329100d5fbea275044891b7e190d49bR1209-R1218) [[8]](diffhunk://#diff-ddf9c2805aef4a99cf30b7913efd40210329100d5fbea275044891b7e190d49bR1897-R1903)

### Scripts:
* Added new scripts for linting, building, releasing, testing, and semantic release in `package.json`.