### PR TITLE
fix[dynamic-renderer]: ENG-8440 Button links cannot be used in Angular Gen 2 SDK

### DIFF
--- a/.changeset/loud-jars-sleep.md
+++ b/.changeset/loud-jars-sleep.md
@@ -2,4 +2,4 @@
 "@builder.io/sdk-angular": patch
 ---
 
-Resolved assertion error encountered when dynamically switching components
+Fix: crashes when visually editing blocks (encountered when SDK dynamically switched HTML elements)

--- a/.changeset/loud-jars-sleep.md
+++ b/.changeset/loud-jars-sleep.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/sdk-angular": patch
+---
+
+Resolved assertion error encountered when dynamically switching components

--- a/packages/sdks-tests/src/e2e-tests/dynamic-button.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/dynamic-button.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '../helpers/visual-editor.js';
 import { DYNAMIC_BUTTON } from '../specs/dynamic-button.js';
 
-test.describe.only('Dynamic Button', () => {
+test.describe('Dynamic Button', () => {
   test('should render a button', async ({ page, sdk, basePort }) => {
     test.skip(sdk !== 'angular');
 

--- a/packages/sdks-tests/src/e2e-tests/dynamic-button.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/dynamic-button.spec.ts
@@ -1,0 +1,55 @@
+import { expect } from '@playwright/test';
+import { test } from '../helpers/index.js';
+import {
+  cloneContent,
+  launchEmbedderAndWaitForSdk,
+  sendContentUpdateMessage,
+} from '../helpers/visual-editor.js';
+import { DYNAMIC_BUTTON } from '../specs/dynamic-button.js';
+
+test.describe.only('Dynamic Button', () => {
+  test('should render a button', async ({ page, sdk, basePort }) => {
+    test.skip(sdk !== 'angular');
+
+    await launchEmbedderAndWaitForSdk({
+      path: '/dynamic-button',
+      basePort,
+      page,
+      sdk,
+    });
+
+    const buttonLocator = page
+      .frameLocator('iframe')
+      .locator('[builder-id="builder-b53d1cc2bcbb481b869207fdd97ee1db"]');
+    await expect(buttonLocator).toHaveText('Click me!');
+    const newContent = cloneContent(DYNAMIC_BUTTON);
+
+    //simulating typing in the link field
+    newContent.data.blocks[0].component.options.link = '#';
+    await sendContentUpdateMessage({
+      page,
+      newContent,
+      model: 'page',
+    });
+
+    newContent.data.blocks[0].component.options.link = '#g';
+    await sendContentUpdateMessage({
+      page,
+      newContent,
+      model: 'page',
+    });
+
+    newContent.data.blocks[0].component.options.link = '#go';
+    await sendContentUpdateMessage({
+      page,
+      newContent,
+      model: 'page',
+    });
+
+    const updatedButtonLocator = page
+      .frameLocator('iframe')
+      .locator('[builder-id="builder-b53d1cc2bcbb481b869207fdd97ee1db"]');
+
+    await expect(updatedButtonLocator).toBeVisible();
+  });
+});

--- a/packages/sdks-tests/src/e2e-tests/dynamic-button.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/dynamic-button.spec.ts
@@ -3,12 +3,13 @@ import { checkIsRN, test } from '../helpers/index.js';
 import {
   cloneContent,
   launchEmbedderAndWaitForSdk,
-  sendContentUpdateMessage,
+  sendPatchOrUpdateMessage,
 } from '../helpers/visual-editor.js';
 import { DYNAMIC_BUTTON } from '../specs/dynamic-button.js';
 
 test.describe('Dynamic Button', () => {
   test('should render a button', async ({ page, sdk, basePort, packageName }) => {
+    test.fail(sdk === 'svelte', 'Not showing the href attribute in Svelte');
     test.skip(
       packageName === 'nextjs-sdk-next-app' ||
         packageName === 'gen1-next14-pages' ||
@@ -31,25 +32,31 @@ test.describe('Dynamic Button', () => {
     const newContent = cloneContent(DYNAMIC_BUTTON);
 
     // simulating typing in the link field
-    newContent.data.blocks[0].component.options.link = '#';
-    await sendContentUpdateMessage({
+    await sendPatchOrUpdateMessage({
       page,
-      newContent,
+      content: cloneContent(DYNAMIC_BUTTON),
       model: 'page',
+      sdk,
+      updateFn: () => '#',
+      path: '/data/blocks/0/component/options/link',
     });
 
-    newContent.data.blocks[0].component.options.link = '#g';
-    await sendContentUpdateMessage({
+    await sendPatchOrUpdateMessage({
       page,
-      newContent,
+      content: newContent,
       model: 'page',
+      sdk,
+      updateFn: () => '#g',
+      path: '/data/blocks/0/component/options/link',
     });
 
-    newContent.data.blocks[0].component.options.link = '#go';
-    await sendContentUpdateMessage({
+    await sendPatchOrUpdateMessage({
       page,
-      newContent,
+      content: newContent,
       model: 'page',
+      sdk,
+      updateFn: () => '#go',
+      path: '/data/blocks/0/component/options/link',
     });
 
     const updatedButtonLocator = checkIsRN(sdk) ? page.frameLocator('iframe').locator('a') : page

--- a/packages/sdks-tests/src/e2e-tests/dynamic-button.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/dynamic-button.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { test } from '../helpers/index.js';
+import { checkIsRN, test } from '../helpers/index.js';
 import {
   cloneContent,
   launchEmbedderAndWaitForSdk,
@@ -9,7 +9,6 @@ import { DYNAMIC_BUTTON } from '../specs/dynamic-button.js';
 
 test.describe('Dynamic Button', () => {
   test('should render a button', async ({ page, sdk, basePort }) => {
-    test.skip(sdk !== 'angular');
 
     await launchEmbedderAndWaitForSdk({
       path: '/dynamic-button',
@@ -18,9 +17,10 @@ test.describe('Dynamic Button', () => {
       sdk,
     });
 
-    const buttonLocator = page
-      .frameLocator('iframe')
-      .locator('[builder-id="builder-b53d1cc2bcbb481b869207fdd97ee1db"]');
+    const buttonLocator = checkIsRN(sdk) ? page.frameLocator('iframe').locator('button') : page
+    .frameLocator('iframe')
+    .locator('[builder-id="builder-b53d1cc2bcbb481b869207fdd97ee1db"]');
+    
     await expect(buttonLocator).toHaveText('Click me!');
     const newContent = cloneContent(DYNAMIC_BUTTON);
 
@@ -46,10 +46,12 @@ test.describe('Dynamic Button', () => {
       model: 'page',
     });
 
-    const updatedButtonLocator = page
+    const updatedButtonLocator = checkIsRN(sdk) ? page.frameLocator('iframe').locator('a') : page
       .frameLocator('iframe')
       .locator('[builder-id="builder-b53d1cc2bcbb481b869207fdd97ee1db"]');
 
     await expect(updatedButtonLocator).toBeVisible();
+    
+    await expect(updatedButtonLocator).toHaveAttribute('href', '#go');
   });
 });

--- a/packages/sdks-tests/src/e2e-tests/dynamic-button.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/dynamic-button.spec.ts
@@ -8,8 +8,14 @@ import {
 import { DYNAMIC_BUTTON } from '../specs/dynamic-button.js';
 
 test.describe('Dynamic Button', () => {
-  test('should render a button', async ({ page, sdk, basePort }) => {
-
+  test('should render a button', async ({ page, sdk, basePort, packageName }) => {
+    test.skip(
+      packageName === 'nextjs-sdk-next-app' ||
+        packageName === 'gen1-next14-pages' ||
+        packageName === 'gen1-next15-app' ||
+        packageName === 'gen1-remix' ||
+        packageName === 'gen1-react'
+    );
     await launchEmbedderAndWaitForSdk({
       path: '/dynamic-button',
       basePort,
@@ -24,7 +30,7 @@ test.describe('Dynamic Button', () => {
     await expect(buttonLocator).toHaveText('Click me!');
     const newContent = cloneContent(DYNAMIC_BUTTON);
 
-    //simulating typing in the link field
+    // simulating typing in the link field
     newContent.data.blocks[0].component.options.link = '#';
     await sendContentUpdateMessage({
       page,

--- a/packages/sdks-tests/src/e2e-tests/dynamic-button.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/dynamic-button.spec.ts
@@ -9,13 +9,13 @@ import { DYNAMIC_BUTTON } from '../specs/dynamic-button.js';
 
 test.describe('Dynamic Button', () => {
   test('should render a button', async ({ page, sdk, basePort, packageName }) => {
-    test.fail(sdk === 'svelte', 'Not showing the href attribute in Svelte');
+
+    test.fail(sdk === 'svelte' || sdk === 'oldReact', 'Not showing the href attribute in Svelte');
     test.skip(
       packageName === 'nextjs-sdk-next-app' ||
         packageName === 'gen1-next14-pages' ||
         packageName === 'gen1-next15-app' ||
-        packageName === 'gen1-remix' ||
-        packageName === 'gen1-react'
+        packageName === 'gen1-remix'
     );
     await launchEmbedderAndWaitForSdk({
       path: '/dynamic-button',

--- a/packages/sdks-tests/src/specs/dynamic-button.ts
+++ b/packages/sdks-tests/src/specs/dynamic-button.ts
@@ -1,0 +1,40 @@
+export const DYNAMIC_BUTTON = {
+  data: {
+    title: 'angular-sdk-test',
+    themeId: false,
+    blocks: [
+      {
+        '@type': '@builder.io/sdk:Element',
+        '@version': 2,
+        id: 'builder-b53d1cc2bcbb481b869207fdd97ee1db',
+        component: {
+          name: 'Core:Button',
+          options: {
+            text: 'Click me!',
+            openLinkInNewTab: false,
+          },
+        },
+        responsiveStyles: {
+          large: {
+            display: 'flex',
+            flexDirection: 'column',
+            position: 'relative',
+            flexShrink: '0',
+            boxSizing: 'border-box',
+            marginTop: '20px',
+            appearance: 'none',
+            paddingTop: '15px',
+            paddingBottom: '15px',
+            paddingLeft: '25px',
+            paddingRight: '25px',
+            backgroundColor: 'black',
+            color: 'white',
+            borderRadius: '4px',
+            textAlign: 'center',
+            cursor: 'pointer',
+          },
+        },
+      },
+    ],
+  },
+};

--- a/packages/sdks-tests/src/specs/dynamic-button.ts
+++ b/packages/sdks-tests/src/specs/dynamic-button.ts
@@ -1,6 +1,6 @@
 export const DYNAMIC_BUTTON = {
   data: {
-    title: 'angular-sdk-test',
+    title: 'dynamic-button-sdk-test',
     themeId: false,
     blocks: [
       {

--- a/packages/sdks-tests/src/specs/index.ts
+++ b/packages/sdks-tests/src/specs/index.ts
@@ -87,7 +87,7 @@ import { VIDEO_LAZY_LOAD } from './video-lazy-load.js';
 import { COLUMNS_VERTICAL_CENTER_FLEX } from './columns-vertical-center-flex.js';
 import { DYNAMIC_ELEMENT } from './dynamic-element.js';
 import { CUSTOM_CODE_DOM_UPDATE } from './custom-code-dom-update.js';
-
+import { DYNAMIC_BUTTON } from './dynamic-button.js';
 function isBrowser(): boolean {
   return typeof window !== 'undefined' && typeof document !== 'undefined';
 }
@@ -279,6 +279,7 @@ export const PAGES: Record<string, Page> = {
   '/can-track-false-pre-init': { content: HOMEPAGE, target: 'gen1' },
   '/dynamic-element': { content: DYNAMIC_ELEMENT },
   '/custom-code-dom-update': { content: CUSTOM_CODE_DOM_UPDATE },
+  '/dynamic-button': { content: DYNAMIC_BUTTON },
 } as const;
 
 export type Path = keyof typeof PAGES;

--- a/packages/sdks/output/angular/scripts/generate-dynamic-renderer.mjs
+++ b/packages/sdks/output/angular/scripts/generate-dynamic-renderer.mjs
@@ -129,7 +129,7 @@ const generateComponents = () => {
       <ng-container *ngIf="useTypeOf(TagName) === 'string'">
         <ng-container
           *ngComponentOutlet="
-            TagName;
+            getComponentType(TagName);
             inputs: {
               attributes: attributes,
               actionAttributes: actionAttributes
@@ -185,13 +185,17 @@ export default class DynamicRenderer {
 
   constructor(private vcRef: ViewContainerRef) {}
 
+  private tagComponentMap: { [key: string]: any } = {
+    ${htmlElements.map((el) => `'${el}': Dynamic${capitalize(el)}`).join(',\n    ')}
+  };
+
+  getComponentType(tagName: string): any {
+    return this.tagComponentMap[tagName] || null;
+  }
+
   ngOnInit() {
-    if (typeof this.TagName === 'string') {
-      switch (this.TagName) {
-        ${htmlElements.map((el) => `case '${el}': this.TagName = Dynamic${capitalize(el)}; break;`).join('\n        ')}
-        default:
-          break;
-      }
+    if (typeof this.TagName === 'string' && this.tagComponentMap[this.TagName]) {
+      this.TagName = this.tagComponentMap[this.TagName];
     }
     this.myContent = [this.vcRef.createEmbeddedView(this.tagnameTemplateRef).rootNodes];
   }


### PR DESCRIPTION
## Description

This PR replaces the switch-case logic with a Map for dynamically selecting components in `dynamic-renderer`. The previous approach caused an assertion error when users typed.

_Loom_
https://www.loom.com/share/1229e7974db44743921df588ca1bd1bb?sid=ea3ccc9c-41de-4efe-b499-f61ca9244cbd