### PR TITLE
Add targeting snippets

### DIFF
--- a/packages/sdks-tests/src/snippet-tests/targeted-page.spec.ts
+++ b/packages/sdks-tests/src/snippet-tests/targeted-page.spec.ts
@@ -1,0 +1,41 @@
+import { expect } from '@playwright/test';
+import { test } from '../helpers/index.js';
+
+test.describe('TargetedPage Component', () => {
+  test.beforeEach(async ({ page, packageName }) => {
+    test.skip(!['gen1-react', 'react'].includes(packageName));
+    await page.goto('/targeted-page');
+  });
+
+  test('should render the Desktop page if there is no targeting', async ({ page }) => {
+    await page.goto('/targeted-page');
+    expect(await page.locator('h2').innerText()).toContain('Desktop');
+  });
+
+  test('should render the Desktop page with appropriate targeting', async ({ page }) => {
+    await page.goto('/targeted-page?target=desktop');
+    expect(await page.locator('h2').innerText()).toContain('Desktop');
+  });
+
+  test('should render the Mobile page with appropriate targeting', async ({ page }) => {
+    await page.goto('/targeted-page?target=mobile');
+    expect(await page.locator('h2').innerText()).toContain('Mobile');
+  });
+
+  test("should render the Men's Fashion page with appropriate targeting", async ({ page }) => {
+    await page.goto('/targeted-page?target=mens-fashion');
+    expect(await page.locator('h2').innerText()).toContain("Men's Fashion");
+  });
+
+  test('should render the Recent Shopper page with appropriate targeting included in array', async ({
+    page,
+  }) => {
+    await page.goto('/targeted-page?target=multi-target');
+    expect(await page.locator('h2').innerText()).toContain('Recent Shopper');
+  });
+
+  test('should render the Logged In page with appropriate boolean targeting', async ({ page }) => {
+    await page.goto('/targeted-page?target=is-logged-in');
+    expect(await page.locator('h2').innerText()).toContain('Logged');
+  });
+});

--- a/packages/sdks/snippets/gen1-react/src/main.tsx
+++ b/packages/sdks/snippets/gen1-react/src/main.tsx
@@ -6,6 +6,7 @@ import AnnouncementBar from './routes/AnnouncementBar';
 import CustomChild from './routes/custom-child';
 import EditableRegion from './routes/editable-region';
 import IntegratingPages from './routes/IntegratingPages';
+import TargetedPage from './routes/targeted-page';
 
 const router = createBrowserRouter([
   {
@@ -23,6 +24,10 @@ const router = createBrowserRouter([
   {
     path: '/announcements/:id',
     element: <AnnouncementBar />,
+  },
+  {
+    path: '/targeted-page',
+    element: <TargetedPage />,
   },
   {
     path: '/*',

--- a/packages/sdks/snippets/gen1-react/src/routes/targeted-page/custom-targeting-multi-request.tsx
+++ b/packages/sdks/snippets/gen1-react/src/routes/targeted-page/custom-targeting-multi-request.tsx
@@ -1,0 +1,9 @@
+import { builder } from '@builder.io/react';
+
+export default ({ model, urlPath }: { model: string; urlPath: string }) =>
+  builder.get(model, {
+    userAttributes: {
+      audience: ['recent-shopper', 'womens-fashion'],
+      urlPath,
+    },
+  });

--- a/packages/sdks/snippets/gen1-react/src/routes/targeted-page/custom-targeting-request.tsx
+++ b/packages/sdks/snippets/gen1-react/src/routes/targeted-page/custom-targeting-request.tsx
@@ -1,0 +1,9 @@
+import { builder } from '@builder.io/react';
+
+export default ({ model, urlPath }: { model: string; urlPath: string }) =>
+  builder.get(model, {
+    userAttributes: {
+      audience: ['mens-fashion'],
+      urlPath,
+    },
+  });

--- a/packages/sdks/snippets/gen1-react/src/routes/targeted-page/desktop-request.tsx
+++ b/packages/sdks/snippets/gen1-react/src/routes/targeted-page/desktop-request.tsx
@@ -1,0 +1,9 @@
+import { builder } from '@builder.io/react';
+
+export default ({ model, urlPath }: { model: string; urlPath: string }) =>
+  builder.get(model, {
+    userAttributes: {
+      device: 'desktop',
+      urlPath,
+    },
+  });

--- a/packages/sdks/snippets/gen1-react/src/routes/targeted-page/index.tsx
+++ b/packages/sdks/snippets/gen1-react/src/routes/targeted-page/index.tsx
@@ -1,0 +1,58 @@
+import { BuilderComponent, builder, useIsPreviewing } from '@builder.io/react';
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import FourOhFour from '../../components/404';
+
+import customTargetingMultiRequest from './custom-targeting-multi-request';
+import customTargetingRequest from './custom-targeting-request';
+import desktopRequest from './desktop-request';
+import loggedInRequest from './is-logged-in-request';
+import mobileRequest from './mobile-request';
+import noTargetRequest from './no-target-request';
+
+const MODEL = 'targeted-page';
+builder.init('ee9f13b4981e489a9a1209887695ef2b');
+
+export default function TargetedPage() {
+  const isPreviewingInBuilder = useIsPreviewing();
+  const [notFound, setNotFound] = useState(false);
+  const [content, setContent] = useState();
+  const [searchParams] = useSearchParams();
+
+  const fnMap: { [key: string]: any } = {
+    desktop: desktopRequest,
+    mobile: mobileRequest,
+    'mens-fashion': customTargetingRequest,
+    'multi-target': customTargetingMultiRequest,
+    'is-logged-in': loggedInRequest,
+  };
+
+  useEffect(() => {
+    async function fetchContent() {
+      const options = { model: MODEL, urlPath: window.location.pathname };
+      const target: string = searchParams.get('target') || '';
+      const targetFn = target ? fnMap[target] : noTargetRequest;
+      const content = await targetFn(options);
+
+      setContent(content);
+      setNotFound(!content);
+
+      if (content?.data.title) {
+        document.title = content.data.title;
+      }
+    }
+    fetchContent();
+  }, [window.location.pathname]);
+
+  if (notFound && !isPreviewingInBuilder) {
+    return <FourOhFour />;
+  }
+
+  return (
+    <>
+      <h1>Targeting Snippet</h1>
+      <hr />
+      <BuilderComponent model={MODEL} content={content} />
+    </>
+  );
+}

--- a/packages/sdks/snippets/gen1-react/src/routes/targeted-page/is-logged-in-request.tsx
+++ b/packages/sdks/snippets/gen1-react/src/routes/targeted-page/is-logged-in-request.tsx
@@ -1,0 +1,9 @@
+import { builder } from '@builder.io/react';
+
+export default async ({ model, urlPath }: { model: string; urlPath: string }) =>
+  builder.get(model, {
+    userAttributes: {
+      isLoggedIn: true,
+      urlPath,
+    },
+  });

--- a/packages/sdks/snippets/gen1-react/src/routes/targeted-page/mobile-request.tsx
+++ b/packages/sdks/snippets/gen1-react/src/routes/targeted-page/mobile-request.tsx
@@ -1,0 +1,9 @@
+import { builder } from '@builder.io/react';
+
+export default async ({ model, urlPath }: { model: string; urlPath: string }) =>
+  builder.get(model, {
+    userAttributes: {
+      device: 'mobile',
+      urlPath,
+    },
+  });

--- a/packages/sdks/snippets/gen1-react/src/routes/targeted-page/no-target-request.tsx
+++ b/packages/sdks/snippets/gen1-react/src/routes/targeted-page/no-target-request.tsx
@@ -1,0 +1,6 @@
+import { builder } from '@builder.io/react';
+
+export default ({ model, urlPath }: { model: string; urlPath: string }) =>
+  builder.get(model, {
+    url: urlPath,
+  });

--- a/packages/sdks/snippets/react/src/main.tsx
+++ b/packages/sdks/snippets/react/src/main.tsx
@@ -7,6 +7,7 @@ import CustomChildRoute from './routes/custom-components/custom-child.tsx';
 import EditableRegionRoute from './routes/custom-components/editable-region.tsx';
 import IntegratingPages from './routes/IntegratingPages.tsx';
 import LivePreviewBlogData from './routes/LivePreviewBlogData.js';
+import TargetedPage from './routes/targeted-page/index.tsx';
 
 const router = createBrowserRouter([
   {
@@ -28,6 +29,10 @@ const router = createBrowserRouter([
   {
     path: '/live-preview',
     element: <LivePreviewBlogData />,
+  },
+  {
+    path: '/targeted-page',
+    element: <TargetedPage />,
   },
   {
     path: '/*',

--- a/packages/sdks/snippets/react/src/routes/targeted-page/custom-targeting-multi-request.tsx
+++ b/packages/sdks/snippets/react/src/routes/targeted-page/custom-targeting-multi-request.tsx
@@ -1,0 +1,15 @@
+import { fetchOneEntry, GetContentOptions } from '@builder.io/sdk-react';
+
+export default function request(
+  urlPath: string,
+  { apiKey, model }: GetContentOptions
+) {
+  return fetchOneEntry({
+    apiKey,
+    model,
+    userAttributes: {
+      audience: ['recent-shopper', 'womens-fashion'],
+      urlPath,
+    },
+  });
+}

--- a/packages/sdks/snippets/react/src/routes/targeted-page/custom-targeting-request.tsx
+++ b/packages/sdks/snippets/react/src/routes/targeted-page/custom-targeting-request.tsx
@@ -1,0 +1,15 @@
+import { fetchOneEntry, GetContentOptions } from '@builder.io/sdk-react';
+
+export default function request(
+  urlPath: string,
+  { apiKey, model }: GetContentOptions
+) {
+  return fetchOneEntry({
+    apiKey,
+    model,
+    userAttributes: {
+      audience: ['mens-fashion'],
+      urlPath,
+    },
+  });
+}

--- a/packages/sdks/snippets/react/src/routes/targeted-page/desktop-request.tsx
+++ b/packages/sdks/snippets/react/src/routes/targeted-page/desktop-request.tsx
@@ -1,0 +1,15 @@
+import { fetchOneEntry, GetContentOptions } from '@builder.io/sdk-react';
+
+export default function request(
+  urlPath: string,
+  { apiKey, model }: GetContentOptions
+) {
+  return fetchOneEntry({
+    apiKey,
+    model,
+    userAttributes: {
+      device: 'desktop',
+      urlPath,
+    },
+  });
+}

--- a/packages/sdks/snippets/react/src/routes/targeted-page/index.tsx
+++ b/packages/sdks/snippets/react/src/routes/targeted-page/index.tsx
@@ -1,0 +1,53 @@
+import { Content } from '@builder.io/sdk-react';
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import customTargetingMultiRequest from './custom-targeting-multi-request';
+import customTargetingRequest from './custom-targeting-request';
+import desktopRequest from './desktop-request';
+import loggedInRequest from './is-logged-in-request';
+import mobileRequest from './mobile-request';
+import noTargetRequest from './no-target-request';
+
+const MODEL = 'targeted-page';
+const BUILDER_API_KEY = 'ee9f13b4981e489a9a1209887695ef2b';
+
+export default function TargetedPage() {
+  const [content, setContent] = useState();
+  const [searchParams] = useSearchParams();
+
+  useEffect(() => {
+    const fnMap: { [key: string]: any } = {
+      desktop: desktopRequest,
+      mobile: mobileRequest,
+      'mens-fashion': customTargetingRequest,
+      'multi-target': customTargetingMultiRequest,
+      'is-logged-in': loggedInRequest,
+    };
+
+    async function fetchContent() {
+      const options = {
+        apiKey: BUILDER_API_KEY,
+        model: MODEL,
+      };
+      const target: string = searchParams.get('target') || '';
+      const targetFn = target ? fnMap[target] : noTargetRequest;
+      const content = await targetFn(window.location.pathname, options);
+
+      setContent(content);
+
+      if (content?.data.title) {
+        document.title = content.data.title;
+      }
+    }
+    fetchContent();
+  }, [searchParams]);
+
+  return (
+    <>
+      <h1>Targeting Snippet</h1>
+      <hr />
+      <Content apiKey={BUILDER_API_KEY} model={MODEL} content={content} />
+    </>
+  );
+}

--- a/packages/sdks/snippets/react/src/routes/targeted-page/is-logged-in-request.tsx
+++ b/packages/sdks/snippets/react/src/routes/targeted-page/is-logged-in-request.tsx
@@ -1,0 +1,15 @@
+import { fetchOneEntry, GetContentOptions } from '@builder.io/sdk-react';
+
+export default function request(
+  urlPath: string,
+  { apiKey, model }: GetContentOptions
+) {
+  return fetchOneEntry({
+    apiKey,
+    model,
+    userAttributes: {
+      isLoggedIn: true,
+      urlPath,
+    },
+  });
+}

--- a/packages/sdks/snippets/react/src/routes/targeted-page/mobile-request.tsx
+++ b/packages/sdks/snippets/react/src/routes/targeted-page/mobile-request.tsx
@@ -1,0 +1,15 @@
+import { fetchOneEntry, GetContentOptions } from '@builder.io/sdk-react';
+
+export default function request(
+  urlPath: string,
+  { apiKey, model }: GetContentOptions
+) {
+  return fetchOneEntry({
+    apiKey,
+    model,
+    userAttributes: {
+      device: 'mobile',
+      urlPath,
+    },
+  });
+}

--- a/packages/sdks/snippets/react/src/routes/targeted-page/no-target-request.tsx
+++ b/packages/sdks/snippets/react/src/routes/targeted-page/no-target-request.tsx
@@ -1,0 +1,15 @@
+import { fetchOneEntry, GetContentOptions } from '@builder.io/sdk-react';
+
+export default function request(
+  urlPath: string,
+  { apiKey, model }: GetContentOptions
+) {
+  return fetchOneEntry({
+    apiKey,
+    model,
+    userAttributes: {
+      device: 'desktop',
+      urlPath,
+    },
+  });
+}


### PR DESCRIPTION
## Description

Adds snippets to be used within the [Targeting Cheatsheet](https://www.builder.io/c/docs/targeting-cheatsheet) doc. The only files that will be linked within the docs are the non-index files within the `targeted-page/` directory.