### PR TITLE
feat[pluginTools][builderRequest]: ENG-8621 ensure BuilderRequest can define POST requests as well with request-body

### DIFF
--- a/packages/plugin-tools/README.md
+++ b/packages/plugin-tools/README.md
@@ -275,7 +275,7 @@ registerDataPlugin(
                   query: params,
                   data: {
                     query: "{ query($id: String!) { spaces(id: $id) { id name } }",
-                    variables: { id: options.graphQLRequestBody.spaceId },
+                    variables: { id: options.spaceId },
                   },
                 },
               };

--- a/packages/plugin-tools/src/data.ts
+++ b/packages/plugin-tools/src/data.ts
@@ -2,6 +2,7 @@ import { Builder } from '@builder.io/sdk';
 import { Input } from '@builder.io/sdk';
 import appState from '@builder.io/app-context';
 import { ReactNode } from 'react';
+import { BuilderRequest } from './interfaces/builder-request';
 
 interface OnSaveActions {
   updateSettings(partal: Record<string, any>): Promise<void>;
@@ -24,7 +25,7 @@ export type ResourceType = {
   icon?: string;
   description?: string;
   inputs?: () => Partial<Input>[];
-  toUrl: (options: Record<string, any>) => string | Promise<string>;
+  toUrl: (options: Record<string, any>) => string | Promise<string> | Promise<BuilderRequest>;
   canPickEntries?: boolean;
 };
 

--- a/packages/plugin-tools/src/data.ts
+++ b/packages/plugin-tools/src/data.ts
@@ -25,7 +25,7 @@ export type ResourceType = {
   icon?: string;
   description?: string;
   inputs?: () => Partial<Input>[];
-  toUrl: (options: Record<string, any>) => string | Promise<string> | Promise<BuilderRequest>;
+  toUrl: (options: Record<string, any>) => string | BuilderRequest | Promise<string> | Promise<BuilderRequest>;
   canPickEntries?: boolean;
 };
 

--- a/packages/plugin-tools/src/interfaces/builder-request.ts
+++ b/packages/plugin-tools/src/interfaces/builder-request.ts
@@ -5,7 +5,7 @@ export interface BuilderRequest {
     query?: { [key: string]: string };
     headers?: { [key: string]: string };
     method?: 'GET' | 'POST';
-    data?: any;
+    body?: any;
   };
   options?: { [key: string]: any };
   bindings?: { [key: string]: string };

--- a/packages/plugin-tools/src/interfaces/builder-request.ts
+++ b/packages/plugin-tools/src/interfaces/builder-request.ts
@@ -4,7 +4,8 @@ export interface BuilderRequest {
     url: string;
     query?: { [key: string]: string };
     headers?: { [key: string]: string };
-    method?: string;
+    method?: 'GET' | 'POST';
+    data?: any;
   };
   options?: { [key: string]: any };
   bindings?: { [key: string]: string };

--- a/packages/plugin-tools/src/interfaces/builder-request.ts
+++ b/packages/plugin-tools/src/interfaces/builder-request.ts
@@ -4,7 +4,7 @@ export interface BuilderRequest {
     url: string;
     query?: { [key: string]: string };
     headers?: { [key: string]: string };
-    method?: 'GET' | 'POST';
+    method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
     body?: any;
   };
   options?: { [key: string]: any };


### PR DESCRIPTION
## Description

Ensure BuilderRequest can define POST requests as well with request-body

**Dependent PRs for same feature**

1. Content API https://github.com/BuilderIO/builder-internal/pull/8046
2. Web-App https://github.com/BuilderIO/builder-internal/pull/8056

**Jira Ticket**
https://builder-io.atlassian.net/browse/ENG-8621

**Loom**

**Tasks**
- [ ] Add Loom for testing
- [x]  Add dependent Content API and Web-App PRs to this description
- [x] Replace `data` with `body` in web-app and API (Reference to code-review comment: [here](https://github.com/BuilderIO/builder/pull/3945#discussion_r1981273680))