### PR TITLE
Fix: NextJS SDK: reduce network roundtrips for visual editing

### DIFF
--- a/.changeset/funny-planes-itch.md
+++ b/.changeset/funny-planes-itch.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/sdk-react-nextjs": patch
+---
+
+Fix: reduce network roundtrips for updates when visually editing

--- a/packages/sdks/output/nextjs/module-augmentations.d.ts
+++ b/packages/sdks/output/nextjs/module-augmentations.d.ts
@@ -4,3 +4,7 @@
 declare module 'next/navigation' {
   export * from 'next/navigation.js';
 }
+
+declare module 'next/cache' {
+  export * from 'next/cache.js';
+}

--- a/packages/sdks/output/nextjs/vite.config.ts
+++ b/packages/sdks/output/nextjs/vite.config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
         'node:module',
         'isolated-vm',
         'next/navigation',
+        'next/cache',
       ],
       output: {
         globals: {

--- a/packages/sdks/overrides/rsc/src/helpers/preview-lru-cache/set.ts
+++ b/packages/sdks/overrides/rsc/src/helpers/preview-lru-cache/set.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { revalidatePath } from 'next/cache';
 import type { BuilderContent } from '../../types/builder-content.js';
 import { init } from './init.js';
 import type { GlobalWCache } from './types.js';
@@ -7,13 +8,15 @@ import type { GlobalWCache } from './types.js';
 export async function postPreviewContent({
   key,
   value,
+  url,
 }: {
   key: string;
   value: BuilderContent;
+  url: string;
 }) {
   init();
 
   (globalThis as GlobalWCache)._BUILDER_PREVIEW_LRU_CACHE.set(key, value);
 
-  return { [key]: value };
+  revalidatePath(url);
 }

--- a/packages/sdks/src/components/content/components/enable-editor.lite.tsx
+++ b/packages/sdks/src/components/content/components/enable-editor.lite.tsx
@@ -107,10 +107,7 @@ export default function EnableEditor(props: BuilderEditorProps) {
           postPreviewContent({
             value: newContentValue,
             key: newContentValue.id!,
-          }).then(() => {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            router.refresh();
+            url: window.location.pathname,
           });
         },
         default: () => {

--- a/packages/sdks/src/helpers/preview-lru-cache/set.ts
+++ b/packages/sdks/src/helpers/preview-lru-cache/set.ts
@@ -1,10 +1,8 @@
 import type { BuilderContent } from '../../types/builder-content.js';
-export async function postPreviewContent({
-  key,
-  value,
-}: {
+export async function postPreviewContent(_opts: {
   key: string;
   value: BuilderContent;
+  url: string;
 }) {
-  return { [key]: value };
+  return null;
 }


### PR DESCRIPTION
## Description

https://www.loom.com/share/f1c0c50adb4c4566a00caeedd40f8fc5

- replace `router.refresh()` with `revalidateTag()` to avoid a redundant network->client->network roundtrip
- you have to specify the path, so i decided to restrict it to the current `location.url.pathname` to reduce its impact as much as possible


before:
- client: receives new data from editor
- client: POSTs new content to server action
- server: stores new content in cache
- client: calls `router.refresh()`
- server: re-renders page


after
- client: receives new data from editor
- client: POSTs new content to server action
- server: stores new content in cache and calls `revalidateTag()`, which re-renders the page