### PR TITLE
WIP. feat[RSC]: [ENG-8936] Add `LiveEdit` support for client-side updates using `BuilderContext.Provider`

### DIFF
--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -770,6 +770,11 @@ export interface Component {
   models?: readonly string[];
 
   /**
+   * Whether the component is a React Server Component
+   */
+  isRSC?: boolean;
+
+  /**
    * Specify restrictions direct children must match
    */
   childRequirements?: {

--- a/packages/sdks/src/blocks/text/component-info.ts
+++ b/packages/sdks/src/blocks/text/component-info.ts
@@ -11,8 +11,6 @@ export const componentInfo: ComponentInfo = {
       : {},
   name: 'Text',
   static: true,
-  isRSC: true,
-
   image:
     'https://firebasestorage.googleapis.com/v0/b/builder-3b0a2.appspot.com/o/images%2Fbaseline-text_fields-24px%20(1).svg?alt=media&token=12177b73-0ee3-42ca-98c6-0dd003de1929',
   inputs: [

--- a/packages/sdks/src/components/block/components/interactive-element.lite.tsx
+++ b/packages/sdks/src/components/block/components/interactive-element.lite.tsx
@@ -9,6 +9,7 @@ import {
 import type { BuilderContextInterface } from '../../../context/types.js';
 import { getBlockActions } from '../../../functions/get-block-actions.js';
 import { getBlockProperties } from '../../../functions/get-block-properties.js';
+import { isEditing } from '../../../server-index.js';
 import type { BuilderBlock } from '../../../types/builder-block.js';
 import type { Dictionary } from '../../../types/typescript.js';
 import Awaiter from '../../awaiter.lite.jsx';
@@ -84,12 +85,21 @@ export default function InteractiveElement(props: InteractiveElementProps) {
     <Show
       when={props.Wrapper.load}
       else={
-        <props.Wrapper
-          {...state.targetWrapperProps}
-          attributes={state.attributes}
+        <Show
+          when={isEditing()}
+          else={
+            <props.Wrapper
+              {...props.wrapperProps}
+              attributes={state.attributes}
+            >
+              {props.children}
+            </props.Wrapper>
+          }
         >
-          {props.children}
-        </props.Wrapper>
+          <div>
+            <p>This is a placeholder for the interactive element.</p>
+          </div>
+        </Show>
       }
     >
       <Awaiter

--- a/packages/sdks/src/components/block/components/interactive-element.lite.tsx
+++ b/packages/sdks/src/components/block/components/interactive-element.lite.tsx
@@ -13,6 +13,7 @@ import { isEditing } from '../../../server-index.js';
 import type { BuilderBlock } from '../../../types/builder-block.js';
 import type { Dictionary } from '../../../types/typescript.js';
 import Awaiter from '../../awaiter.lite.jsx';
+import LiveEdit from '../../live-edit.lite.jsx';
 
 export type InteractiveElementProps = {
   Wrapper: any;
@@ -96,9 +97,9 @@ export default function InteractiveElement(props: InteractiveElementProps) {
             </props.Wrapper>
           }
         >
-          <div>
-            <p>This is a placeholder for the interactive element.</p>
-          </div>
+          <LiveEdit component={props.Wrapper} id={props.block.id || ''}>
+            {props.children}
+          </LiveEdit>
         </Show>
       }
     >

--- a/packages/sdks/src/components/content/content.lite.tsx
+++ b/packages/sdks/src/components/content/content.lite.tsx
@@ -202,6 +202,7 @@ export default function ContentComponent(props: ContentProps) {
         },
         // eslint-disable-next-line object-shorthand
         solid: { setBuilderContextSignal: setBuilderContextSignal },
+        rsc: { setBuilderContextSignal: state.contentSetState },
         default: {},
       })}
     >

--- a/packages/sdks/src/components/live-edit.lite.tsx
+++ b/packages/sdks/src/components/live-edit.lite.tsx
@@ -1,0 +1,48 @@
+import { useContext, useStore } from "@builder.io/mitosis";
+import type { BuilderBlock, BuilderContent } from "../server-index.js";
+import { BuilderContext } from "../context/index.js";
+
+type LiveEditProps = {
+  children: any;
+  id: string;
+  component: any;
+};
+
+
+export default function LiveEdit(props: LiveEditProps) {
+  const context = useContext(BuilderContext);
+
+  const state = useStore({
+  /**
+   * Recursively searches for a block by ID.
+   *
+   * @param blocks The blocks to search through.
+   * @param id The ID of the block to search for.
+   * @returns The block if found, otherwise null.
+   */
+    _findBlockById(blocks: BuilderBlock[] | undefined, id: string): BuilderBlock | null {
+        if (!blocks) return null;
+        for (const block of blocks) {
+          if (block.id === id) return block;
+  
+          if (block.children) {
+            const child = this._findBlockById(block.children, id);
+            if (child) return child;
+          }
+        }
+        return null;
+    },
+    findBlockById(content: BuilderContent, id: string){
+        return this._findBlockById(content.data?.blocks, id);
+    },
+    get block() {
+        return this.findBlockById(context.value.content!, props.id);
+    },
+    get options() {
+        return this.block?.component?.options || {};
+    },
+  })
+
+
+  return <props.component {...props} {...state.options} />;
+}

--- a/packages/sdks/src/helpers/subscribe-to-editor.ts
+++ b/packages/sdks/src/helpers/subscribe-to-editor.ts
@@ -7,11 +7,13 @@ import type { BuilderContent } from '../types/builder-content.js';
 import type { Dictionary } from '../types/typescript.js';
 import { logger } from './logger.js';
 
+export type EditType = 'client' | 'server' | undefined;
+
 type ContentListener = Required<
   Pick<ContentProps, 'model' | 'trustedHosts'>
 > & {
   callbacks: {
-    contentUpdate: (updatedContent: BuilderContent) => void;
+    contentUpdate: (updatedContent: BuilderContent, editType?: EditType) => void;
     stateUpdate: (newState: Dictionary<string>) => void;
     animation: (updatedContent: BuilderAnimation) => void;
     configureSdk: (updatedContent: any) => void;
@@ -58,9 +60,9 @@ export const createEditorListener = ({
             messageContent.modelName;
 
           const contentData = messageContent.data;
-
+          const editType = messageContent.editType;
           if (key === model) {
-            callbacks.contentUpdate(contentData);
+            callbacks.contentUpdate(contentData, editType);
           }
           break;
         }


### PR DESCRIPTION
**Description:**  
This PR introduces client-side live editing support by extending the existing context and rendering logic in the SDK.

**What changes were made:**  
- Added a new `BuilderContext.Provider` inside `EnableEditor` to consume a derived state from the `builderContextSignal` prop in `Content`.
- Introduced a `LiveEdit` wrapper component that:
  - Finds a block by ID from the current context content.
  - Applies updated component options dynamically to render changes in real time.
- Updated `InteractiveElement` to conditionally render `LiveEdit` when in editing mode.
- Implemented logic to differentiate between `editType: 'server'` and `editType: 'client'`:
  - For `'server'`, retain existing behavior—push updates to LRU cache and re-render on the server.
  - For `'client'`, trigger a context update that re-renders `LiveEdit` components on the client side.

**Why these changes were made:**  
To support hybrid editing in the SDK where developers can opt into either server-side or client-side editing behavior, depending on the use case.

**Additional context:**  
- These changes are foundational for enabling smoother, near-instant updates during visual editing sessions—especially when using `editType: 'client'`.
- These changes will also require handling on `builder-internal`

_Screenshot_
OTW
