### PR TITLE
feat[AngularGen2][edgeExports]: ENG-8567 Add angular edge exports

### DIFF
--- a/.changeset/gentle-bears-learn.md
+++ b/.changeset/gentle-bears-learn.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/sdk-angular": patch
+---
+
+feat: Add edge exports to angular SDK

--- a/packages/sdks/output/angular/package.json
+++ b/packages/sdks/output/angular/package.json
@@ -8,9 +8,10 @@
     "release": "npm publish",
     "build-inline-fns": "yarn g:build-inline-fns",
     "generate-dynamic-renderer": "node ./scripts/generate-dynamic-renderer.mjs",
-    "build": "yarn g:nx run-many -p @builder.io/sdk-angular -t build:node build:browser --parallel=false",
+    "build": "yarn g:nx run-many -p @builder.io/sdk-angular -t build:node build:browser build:edge --parallel=false",
     "build:node": "cross-env SDK_ENV=node node ./scripts/multi-build.mjs",
-    "build:browser": "cross-env SDK_ENV=browser node ./scripts/multi-build.mjs"
+    "build:browser": "cross-env SDK_ENV=browser node ./scripts/multi-build.mjs",
+    "build:edge": "cross-env SDK_ENV=edge node ./scripts/multi-build.mjs"
   },
   "dependencies": {
     "isolated-vm": "^5.0.0",

--- a/packages/sdks/output/angular/package.json
+++ b/packages/sdks/output/angular/package.json
@@ -94,7 +94,31 @@
         "types": "./lib/browser/index.d.ts",
         "default": "./lib/browser/fesm2022/builder.io-sdk-angular.mjs"
       },
+      "edge": {
+        "esm2022": "./lib/edge/esm2022/builder.io-sdk-angular.mjs",
+        "esm": "./lib/edge/esm2022/builder.io-sdk-angular.mjs",
+        "types": "./lib/edge/index.d.ts",
+        "default": "./lib/edge/fesm2022/builder.io-sdk-angular.mjs"
+      },
+      "edge-routine": {
+        "esm2022": "./lib/edge/esm2022/builder.io-sdk-angular.mjs",
+        "esm": "./lib/edge/esm2022/builder.io-sdk-angular.mjs",
+        "types": "./lib/edge/index.d.ts",
+        "default": "./lib/edge/fesm2022/builder.io-sdk-angular.mjs"
+      },
+      "netlify": {
+        "esm2022": "./lib/edge/esm2022/builder.io-sdk-angular.mjs",
+        "esm": "./lib/edge/esm2022/builder.io-sdk-angular.mjs",
+        "types": "./lib/edge/index.d.ts",
+        "default": "./lib/edge/fesm2022/builder.io-sdk-angular.mjs"
+      },
       "types": "./lib/node/index.d.ts"
+    },
+    "./bundle/edge": {
+      "esm2022": "./lib/edge/esm2022/builder.io-sdk-angular.mjs",
+      "esm": "./lib/edge/esm2022/builder.io-sdk-angular.mjs",
+      "types": "./lib/edge/index.d.ts",
+      "default": "./lib/edge/fesm2022/builder.io-sdk-angular.mjs"
     }
   },
   "main": "lib/node/fesm2022/builder.io-sdk-angular.mjs",


### PR DESCRIPTION
## Description
To solve the unsafe-eval issue while evaluating bindings, we want to provide the customers with edge build option.

https://builder-io.atlassian.net/browse/ENG-8567
https://builder-io.atlassian.net/browse/SUPP-1035


Testing
Tested the Angular Gen2 edge exports by running on local and pointing all exports to edge
https://www.loom.com/share/b628a812d39b41269c2a073e51d9d2cc

