### PR TITLE
fix[gen1][react]: ENG-8739 change to makeFn() for handling errors when serialising functions

### DIFF
--- a/packages/react/src/functions/string-to-function.ts
+++ b/packages/react/src/functions/string-to-function.ts
@@ -209,7 +209,12 @@ export const makeFn = (code: string, useReturn: boolean, args?: string[]) => {
             }
             const val = obj.getSync(key);
             if (typeof val?.copySync === 'function') {
+              try {
                 return JSON.parse(stringify(val));
+              } catch (e) {
+               log('Error:', e);
+                return refToProxy(val);
+              }
             }
             return val;
         },


### PR DESCRIPTION
## Description

Changed makeFn() for handling errors when serialising functions

**PR that caused the hydration error**
https://github.com/BuilderIO/builder/pull/3396

**Screenshot**
| Before | After |
| ---- | --- |
| <img width="400" alt="Screenshot 2025-04-30 at 11 19 52 AM" src="https://github.com/user-attachments/assets/114408c1-5948-4a41-9b2d-ce9daaab2e6d" /> | <img width="400" alt="Screenshot 2025-04-30 at 11 19 14 AM" src="https://github.com/user-attachments/assets/5293d771-47c8-4b7b-8c9c-64bc3530452a" /> |

**Loom**
https://www.loom.com/share/8b961a80726d4fe4ad8bdf52e389f72a