### PR TITLE
fix[gen1][core]: ENG-9321 only serialize fn if not plugin and not onSave()

### DIFF
--- a/.changeset/fair-dryers-report.md
+++ b/.changeset/fair-dryers-report.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/sdk": patch
+---
+
+Fix: Functions in plugins will be selectively serialized


### PR DESCRIPTION
## Description

JTI is having an issue when trying to save the Magento plugin 

**Root cause of the regression**
https://github.com/BuilderIO/builder/pull/3492

**JIRA ticket**
https://builder-io.atlassian.net/browse/ENG-9321

**Loom**
https://www.loom.com/share/738964aade954c5ab15c60b0f0703248