### PR TITLE
fix[gen1+gen2][countdown]: ENG-9409 replace hardcoded COUNTDOWN_DATE with programmatic value

### DIFF
--- a/packages/sdks-tests/src/specs/countdown.ts
+++ b/packages/sdks-tests/src/specs/countdown.ts
@@ -1,4 +1,4 @@
-export const COUNTDOWN_DATE = 'Thu May 15 2025 01:00:00 GMT-0300 (Atlantic Daylight Time)';
+export const COUNTDOWN_DATE = new Date(Date.now() + 1000 * 60 * 60 * 24 * 10).toString();
 
 export const COUNTDOWN = {
   data: {


### PR DESCRIPTION
## Description

Hardcoded countdown time of 15 May 2025 started to fail after 15 May 2025. This led to GitHub checks failing - https://github.com/BuilderIO/builder/actions/runs/15051973960/job/42308753906?pr=4026

**JIRA Ticket**
https://builder-io.atlassian.net/browse/ENG-9409
