### PR TITLE
fix[gen1][react]: ENG-9493 change to release:dev script

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,7 +36,7 @@
     "release:minor": "yarn build && yarn version minor && yarn npm publish",
     "release:patch": "yarn build && yarn version patch && yarn npm publish",
     "release:nightly": "yarn build && yarn version prerelease && yarn npm publish --tag nightly",
-    "release:dev": "yarn build && yarn version prerelease && yarn npm publish --tag dev",
+    "release:dev": "yarn version prerelease && yarn pack && tar -zxvf package.tgz && cp package/package.json ./package.json && rm -rf package package.tgz && yarn build && yarn npm publish --tag dev",
     "fix-core-version": "bash ./scripts/fix-core-version.sh",
     "ci:test": "yarn test",
     "ci:build": "yarn build"


### PR DESCRIPTION
## Description

Releasing dev version of SDK to NPM does not work as expected

**Screenshot**
| Before | After |
| --- | --- |
| <img width="400" alt="Screenshot 2025-05-30 at 2 13 29 PM" src="https://github.com/user-attachments/assets/a7b7df09-6c20-4f64-8e9e-af4a1c4220dc" /> | <img width="400" alt="Screenshot 2025-05-30 at 2 13 48 PM" src="https://github.com/user-attachments/assets/ed27c7b9-4d62-45a8-b9b8-be53d397f6c8" /> |
