### PR TITLE
fix[gen1+gen2][httpRequests]: ENG-9525 handleRequest for GET method should not pass body to fetch()

### DIFF
--- a/.changeset/modern-nails-doubt.md
+++ b/.changeset/modern-nails-doubt.md
@@ -1,0 +1,11 @@
+---
+"@builder.io/react": patch
+"@builder.io/sdk-angular": patch
+"@builder.io/sdk-react-nextjs": patch
+"@builder.io/sdk-qwik": patch
+"@builder.io/sdk-react": patch
+"@builder.io/sdk-react-native": patch
+"@builder.io/sdk-solid": patch
+---
+
+Fix: Corrected the implementaion of http requests with GET method

--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -1282,7 +1282,7 @@ export class BuilderComponent extends React.Component<
         const result = await fetch(url, {
           method,
           headers,
-          body,
+          body: method === 'GET' ? undefined : body,
         });
         json = await result.json();
       } catch (err) {

--- a/packages/sdks-tests/src/e2e-tests/http-requests-get-api.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/http-requests-get-api.spec.ts
@@ -1,0 +1,120 @@
+import { expect } from '@playwright/test';
+import { excludeTestFor, test } from '../helpers/index.js';
+import { launchEmbedderAndWaitForSdk } from '../helpers/visual-editor.js';
+
+const countriesResponse = {
+  data: {
+    countries: [
+      {
+        name: 'Andorra',
+      },
+      {
+        name: 'United Arab Emirates',
+      },
+      {
+        name: 'Afghanistan',
+      },
+      {
+        name: 'Antigua and Barbuda',
+      },
+      {
+        name: 'Anguilla',
+      },
+      {
+        name: 'Albania',
+      },
+      {
+        name: 'Armenia',
+      },
+    ],
+  },
+};
+
+test.describe.only('HTTP Requests GET API', () => {
+  test('call GET API only once - in page', async ({ page, packageName, sdk }) => {
+    test.fail(
+      packageName === 'nextjs-sdk-next-app',
+      'editor tests not supported in nextjs-sdk-next-app'
+    );
+    test.fail(
+      excludeTestFor({ qwik: true }, sdk),
+      'error setting httpRequest response or making API call altogether.'
+    );
+    test.skip(excludeTestFor({ vue: true }, sdk), 'Vue flakiness issues');
+
+    let x = 0;
+
+    const urlMatch = /^https:\/\/cdn\.builder\.io\/api\/v2\/admin$/;
+
+    await page.route(urlMatch, route => {
+      if (route.request().method() === 'GET') {
+        x++;
+
+        if (x > 10) {
+          throw new Error('Too many GET API requests.');
+        }
+        return route.fulfill({
+          status: 200,
+          json: countriesResponse,
+        });
+      }
+    });
+
+    await page.goto('/http-requests-get-api', { waitUntil: 'networkidle' });
+    for (const country of countriesResponse.data.countries) {
+      await expect(page.locator('body').getByText(country.name, { exact: true })).toBeVisible();
+    }
+    expect(x).toBe(1);
+  });
+
+  test('call GET API only once - in editor', async ({ page, basePort, packageName, sdk }) => {
+    test.skip(
+      packageName === 'react-native-74' || packageName === 'react-native-76-fabric',
+      'editor tests not supported in react-native'
+    );
+    test.skip(
+      packageName === 'nextjs-sdk-next-app',
+      'editor tests not supported in nextjs-sdk-next-app'
+    );
+    test.fail(
+      excludeTestFor({ qwik: true }, sdk),
+      'error setting httpRequest response or making API call altogether.'
+    );
+    test.skip(excludeTestFor({ vue: true }, sdk), 'Vue flakiness issues');
+
+    let x = 0;
+
+    const urlMatch = /^https:\/\/cdn\.builder\.io\/api\/v2\/admin$/;
+
+    await page.route(urlMatch, route => {
+      if (route.request().method() === 'GET') {
+        x++;
+
+        if (x > 10) {
+          throw new Error('Too many proxy API requests.');
+        }
+
+        return route.fulfill({
+          status: 200,
+          json: countriesResponse,
+        });
+      }
+    });
+
+    await launchEmbedderAndWaitForSdk({
+      page,
+      basePort,
+      path: '/http-requests-get-api',
+      sdk,
+      gotoOptions: { waitUntil: 'networkidle' },
+    });
+
+    for (const country of countriesResponse.data.countries) {
+      await expect(
+        page.frameLocator('iframe').getByText(country.name, { exact: true })
+      ).toBeVisible();
+    }
+
+    expect(x).toBe(1);
+  });
+});

--- a/packages/sdks-tests/src/e2e-tests/http-requests-get-api.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/http-requests-get-api.spec.ts
@@ -30,7 +30,7 @@ const countriesResponse = {
   },
 };
 
-test.describe.only('HTTP Requests GET API', () => {
+test.describe('HTTP Requests GET API', () => {
   test('call GET API only once - in page', async ({ page, packageName, sdk }) => {
     test.fail(
       packageName === 'nextjs-sdk-next-app',

--- a/packages/sdks-tests/src/specs/http-requests-get-api.ts
+++ b/packages/sdks-tests/src/specs/http-requests-get-api.ts
@@ -1,0 +1,92 @@
+export const HTTP_REQUESTS_GET_API_CONTENT = {
+  createdBy: 'OcOewqA7uqVVlVfqY453F8vgcc33',
+  createdDate: 1644861373771,
+  data: {
+    inputs: [],
+    title: 'Home',
+    blocks: [
+      {
+        '@type': '@builder.io/sdk:Element',
+        '@version': 2,
+        bindings: {
+          'component.options.text': 'state.countriesItem.name',
+        },
+        code: {
+          bindings: {
+            'component.options.text': 'state.countriesItem.name',
+          },
+        },
+        repeat: {
+          collection: 'state.someOtherRequest.data.countries',
+        },
+        id: 'builder-7e214686e245495aa8a4b67fc13bc746',
+        meta: {
+          bindingActions: {
+            _newProperty: null,
+            component: {
+              options: {
+                text: null,
+              },
+            },
+          },
+        },
+        component: {
+          name: 'Text',
+          options: {
+            text: 'Enter some text...',
+          },
+        },
+        responsiveStyles: {
+          large: {
+            display: 'flex',
+            flexDirection: 'column',
+            position: 'relative',
+            flexShrink: '0',
+            boxSizing: 'border-box',
+            marginTop: '20px',
+            lineHeight: 'normal',
+            height: 'auto',
+          },
+        },
+      },
+    ],
+    url: '/',
+    httpRequests: {
+      someOtherRequest: {
+        '@type': '@builder.io/core:Request',
+        request: {
+          url: 'https://cdn.builder.io/api/v2/admin',
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: '',
+        },
+      },
+    },
+    state: {
+      deviceSize: 'large',
+      location: { pathname: '/', path: [''], query: {} },
+    },
+  },
+  id: '037948e52eaf4743afed464f02c70da4',
+  lastUpdatedBy: 'OcOewqA7uqVVlVfqY453F8vgcc33',
+  modelId: '240a12053d674735ac2a384dcdc561b5',
+  name: 'Home',
+  published: 'published',
+  query: [
+    {
+      '@type': '@builder.io/core:Query',
+      operator: 'is',
+      property: 'urlPath',
+      value: '/',
+    },
+  ],
+  testRatio: 1,
+  variations: {},
+  lastUpdated: 1658242555536,
+  screenshot:
+    'https://cdn.builder.io/api/v1/image/assets%2Ff1a790f8c3204b3b8c5c1795aeac4660%2F34622bca1dd941968b25341a40be51f7',
+  firstPublished: 1644861541599,
+  rev: 'ooerksctkc',
+};

--- a/packages/sdks-tests/src/specs/index.ts
+++ b/packages/sdks-tests/src/specs/index.ts
@@ -96,6 +96,7 @@ import { COLUMNS_VERTICAL_CENTERING } from './columns-vertical-centering.js';
 import { SECTION_CHILDREN } from './section-children.js';
 import { MAIN_CONTENT as SYMBOL_UPDATE_ENTRIES } from './get-content-symbol-update-entry.js';
 import { HTTP_REQUESTS_POST_API_CONTENT } from './http-requests-post-api.js';
+import { HTTP_REQUESTS_GET_API_CONTENT } from './http-requests-get-api.js';
 
 function isBrowser(): boolean {
   return typeof window !== 'undefined' && typeof document !== 'undefined';
@@ -152,6 +153,7 @@ export const PAGES: Record<string, Page> = {
   '/ab-test-interactive': { content: AB_TEST_INTERACTIVE },
   '/http-requests': { content: HTTP_REQUESTS },
   '/http-requests-post-api': { content: HTTP_REQUESTS_POST_API_CONTENT },
+  '/http-requests-get-api': { content: HTTP_REQUESTS_GET_API_CONTENT },
   '/symbol-ab-test': { content: symbolAbTest },
   '/custom-breakpoints': { content: customBreakpoints },
   '/reactive-state': { content: REACTIVE_STATE_CONTENT },

--- a/packages/sdks/src/components/content/components/enable-editor.lite.tsx
+++ b/packages/sdks/src/components/content/components/enable-editor.lite.tsx
@@ -246,7 +246,10 @@ export default function EnableEditor(props: BuilderEditorProps) {
           fetch(fetchRequestObj.url, {
             method: fetchRequestObj.method,
             headers: fetchRequestObj.headers,
-            body: fetchRequestObj.body,
+            body:
+              fetchRequestObj.method === 'GET'
+                ? undefined
+                : fetchRequestObj.body,
           })
             .then((response) => response.json())
             .then((json) => {


### PR DESCRIPTION
## Description

`handleRequest` for `GET` method should not pass body to `fetch()`

**Root cause**
https://github.com/BuilderIO/builder/pull/4064

**JIRA ticket**
https://builder-io.atlassian.net/browse/ENG-9525

**Loom**
https://www.loom.com/share/f1c275055f0f4660bfbfbb4105dab24e