### PR TITLE
bump[shopify-plugin]: ENG-7391 Upgrade Shopify Buy SDK to v3.0.0

### DIFF
--- a/plugins/shopify/package-lock.json
+++ b/plugins/shopify/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@builder.io/plugin-tools": "^0.0.3",
-        "shopify-buy": "^2.18.0"
+        "@types/shopify-buy": "^3.0.0",
+        "shopify-buy": "^3.0.4"
       },
       "devDependencies": {
         "@commitlint/cli": "^7.1.2",
@@ -21,7 +22,6 @@
         "@types/jest": "^23.3.2",
         "@types/node": "^10.17.5",
         "@types/react": "^16.9.11",
-        "@types/shopify-buy": "^2.17.0",
         "colors": "^1.3.2",
         "commitizen": "^3.0.0",
         "coveralls": "^3.0.2",
@@ -591,10 +591,10 @@
       }
     },
     "node_modules/@types/shopify-buy": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@types/shopify-buy/-/shopify-buy-2.17.4.tgz",
-      "integrity": "sha512-svTrPgQJaKcKv0yGAdQAsgHR8JF8qSWPQThPU+cawSq2+2Wj/ZD8AVXn3FenXwEVfhqGcRhZOKJJfSd7+gipYg==",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/shopify-buy/-/shopify-buy-3.0.0.tgz",
+      "integrity": "sha512-AoTGG9/cqNpnnXYsYK1Sb8iAmQ9DqJ4gqLGXnx8PdiuOdCuKSNY8lqk8j+qe73jMsvdLhgRYRJP/OxR4+6Or6A==",
+      "license": "MIT"
     },
     "node_modules/ajv": {
       "version": "6.11.0",
@@ -4578,9 +4578,10 @@
       }
     },
     "node_modules/shopify-buy": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/shopify-buy/-/shopify-buy-2.22.0.tgz",
-      "integrity": "sha512-Y7FXmgX+By5VjF449oGj6+f8wBEKSupeAS/7bz9MXnvFmhT4C3ka/mzTjVDZTmq0arJdx3EyxUgpaWez3ztoKg=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/shopify-buy/-/shopify-buy-3.0.4.tgz",
+      "integrity": "sha512-lDdX/43rAAs/3bQFbqTNrS4d50WDpqY60KvEEVTKyJXrQ+ZXX45ok3vC0iOisEyDAWN2/2HYXc3Iu45Rxkd4+w==",
+      "license": "MIT"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -5852,10 +5853,9 @@
       }
     },
     "@types/shopify-buy": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@types/shopify-buy/-/shopify-buy-2.17.4.tgz",
-      "integrity": "sha512-svTrPgQJaKcKv0yGAdQAsgHR8JF8qSWPQThPU+cawSq2+2Wj/ZD8AVXn3FenXwEVfhqGcRhZOKJJfSd7+gipYg==",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/shopify-buy/-/shopify-buy-3.0.0.tgz",
+      "integrity": "sha512-AoTGG9/cqNpnnXYsYK1Sb8iAmQ9DqJ4gqLGXnx8PdiuOdCuKSNY8lqk8j+qe73jMsvdLhgRYRJP/OxR4+6Or6A=="
     },
     "ajv": {
       "version": "6.11.0",
@@ -9025,9 +9025,9 @@
       "dev": true
     },
     "shopify-buy": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/shopify-buy/-/shopify-buy-2.22.0.tgz",
-      "integrity": "sha512-Y7FXmgX+By5VjF449oGj6+f8wBEKSupeAS/7bz9MXnvFmhT4C3ka/mzTjVDZTmq0arJdx3EyxUgpaWez3ztoKg=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/shopify-buy/-/shopify-buy-3.0.4.tgz",
+      "integrity": "sha512-lDdX/43rAAs/3bQFbqTNrS4d50WDpqY60KvEEVTKyJXrQ+ZXX45ok3vC0iOisEyDAWN2/2HYXc3Iu45Rxkd4+w=="
     },
     "signal-exit": {
       "version": "3.0.7",

--- a/plugins/shopify/package.json
+++ b/plugins/shopify/package.json
@@ -80,7 +80,7 @@
     "@types/jest": "^23.3.2",
     "@types/node": "^10.17.5",
     "@types/react": "^16.9.11",
-    "@types/shopify-buy": "^2.17.0",
+    "@types/shopify-buy": "^3.0.0",
     "colors": "^1.3.2",
     "commitizen": "^3.0.0",
     "coveralls": "^3.0.2",
@@ -101,6 +101,6 @@
   },
   "dependencies": {
     "@builder.io/plugin-tools": "^0.0.3",
-    "shopify-buy": "^2.18.0"
+    "shopify-buy": "^3.0.4"
   }
 }

--- a/plugins/shopify/src/plugin.ts
+++ b/plugins/shopify/src/plugin.ts
@@ -1,6 +1,6 @@
 import { registerCommercePlugin } from '@builder.io/plugin-tools';
 
-import Client from 'shopify-buy';
+import Client from 'shopify-buy'
 import pkg from '../package.json';
 import appState from '@builder.io/app-context';
 import { getDataConfig } from './data-plugin';

--- a/plugins/shopify/src/plugin.ts
+++ b/plugins/shopify/src/plugin.ts
@@ -1,6 +1,6 @@
 import { registerCommercePlugin } from '@builder.io/plugin-tools';
 
-import Client from 'shopify-buy'
+import Client from 'shopify-buy';
 import pkg from '../package.json';
 import appState from '@builder.io/app-context';
 import { getDataConfig } from './data-plugin';


### PR DESCRIPTION
## Description

This PR upgrades the `shopify-buy` SDK from `^2.17.0` to `^3.0.0` to ensure compatibility with Shopify's latest API changes and prevent deprecation errors.

_JIRA_
https://builder-io.atlassian.net/browse/ENG-7391
