### PR TITLE
bump[shopify-plugin]: Upgrade @builder.io/plugin-shopify SDK to v1.0.6

### DIFF
--- a/plugins/shopify/package-lock.json
+++ b/plugins/shopify/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/plugin-shopify",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-shopify",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "@builder.io/plugin-tools": "^0.0.3",

--- a/plugins/shopify/package.json
+++ b/plugins/shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-shopify",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "keywords": [],
   "main": "dist/plugin.system.js",


### PR DESCRIPTION
## Description

Bumping `@builder.io/plugin-shopify` after publishing to `npm`
