### PR TITLE
add missing `customComponents` prop to page content in nextjs-app-dir-v2 example

### DIFF
--- a/examples/nextjs-app-dir-v2/src/app/[[...slug]]/page.tsx
+++ b/examples/nextjs-app-dir-v2/src/app/[[...slug]]/page.tsx
@@ -1,5 +1,7 @@
 import { Content, fetchOneEntry, isEditing, isPreviewing } from '@builder.io/sdk-react';
 
+import { customComponents } from '../components/register';
+
 const BUILDER_PUBLIC_API_KEY = 'f1a790f8c3204b3b8c5c1795aeac4660';
 
 interface PageProps {
@@ -32,5 +34,5 @@ export default async function Page(props: PageProps) {
       </>
     );
   }
-  return <Content content={content} apiKey={BUILDER_PUBLIC_API_KEY} model={'page'} />;
+  return <Content content={content} apiKey={BUILDER_PUBLIC_API_KEY} model={'page'} customComponents={customComponents} />;
 }


### PR DESCRIPTION
## Description

The `nextjs-app-dir-v2` example has a registry module but doesn't pass the custom components to the `Content` component so they never show in the Builder UI which caught me out. 

This adds the `customComponent` prop to the `Content`, allowing custom component to now render in the Builder UI.
