### PR TITLE
Add integrating pages snippets for Angular SSR

### DIFF
--- a/packages/sdks-tests/src/snippet-tests/landing-page.spec.ts
+++ b/packages/sdks-tests/src/snippet-tests/landing-page.spec.ts
@@ -1,0 +1,13 @@
+import { findTextInPage, test } from '../helpers/index.js';
+
+test.describe('Landing Page for Angular', () => {
+  test.beforeEach(async ({ page, packageName }) => {
+    test.skip(!['angular-17-ssr'].includes(packageName));
+    // Navigate to the product editorial page
+    await page.goto('/landing-page-integrating-pages');
+  });
+
+  test('loads landing-page', async ({ page }) => {
+    await findTextInPage({ page, text: 'Landing page' });
+  });
+});

--- a/packages/sdks/snippets/angular-17-ssr/.eslintrc.js
+++ b/packages/sdks/snippets/angular-17-ssr/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    '@typescript-eslint/consistent-type-imports': 'off',
+  },
+};

--- a/packages/sdks/snippets/angular-17-ssr/src/app/app.routes.ts
+++ b/packages/sdks/snippets/angular-17-ssr/src/app/app.routes.ts
@@ -7,6 +7,8 @@ import { CustomChildComponent } from './custom-child/custom-child.component';
 import { EditableRegionComponent } from './editable-regions/editable-regions.component';
 import { HeroComponent } from './hero/hero.component';
 import { HomepageComponent } from './home/homepage.component';
+import { LandingPageComponent } from './landing-page/landing-page.component';
+import { landingPageResolver } from './landing-page/landing-page.resolver';
 import { LivePreviewComponent } from './live-preview/live-preview.component';
 import { NavBarComponent } from './nav-bar/nav-bar.component';
 import { ProductDetailsComponent } from './product-details/product-details.component';
@@ -18,6 +20,11 @@ export const routes: Routes = [
   { path: 'products/:id', component: ProductEditorialComponent },
   { path: 'product/category/jacket', component: ProductDetailsComponent },
   { path: 'landing-page', component: NavBarComponent },
+  {
+    path: 'landing-page-integrating-pages',
+    component: LandingPageComponent,
+    resolve: { content: landingPageResolver },
+  },
   {
     path: 'custom-child',
     component: CustomChildComponent,

--- a/packages/sdks/snippets/angular-17-ssr/src/app/landing-page/landing-page.component.html
+++ b/packages/sdks/snippets/angular-17-ssr/src/app/landing-page/landing-page.component.html
@@ -1,0 +1,12 @@
+<!-- app/landing-page.component.html -->
+<ng-container *ngIf="content; else notFound">
+  <builder-content
+    [model]="model"
+    [content]="content"
+    [apiKey]="apiKey"
+  ></builder-content>
+</ng-container>
+
+<ng-template #notFound>
+  <div>404 - Content not found</div>
+</ng-template>

--- a/packages/sdks/snippets/angular-17-ssr/src/app/landing-page/landing-page.component.ts
+++ b/packages/sdks/snippets/angular-17-ssr/src/app/landing-page/landing-page.component.ts
@@ -1,0 +1,26 @@
+// app/landing-page/landing-page.component.ts
+
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Content, type BuilderContent } from '@builder.io/sdk-angular';
+
+@Component({
+  selector: 'app-landing-page',
+  standalone: true,
+  imports: [Content, CommonModule],
+  templateUrl: './landing-page.component.html',
+})
+export class LandingPageComponent {
+  apiKey = 'ee9f13b4981e489a9a1209887695ef2b';
+  model = 'page';
+  content: BuilderContent | null = null;
+
+  constructor(private activatedRoute: ActivatedRoute) {}
+
+  ngOnInit() {
+    this.activatedRoute.data.subscribe((data: any) => {
+      this.content = data.content;
+    });
+  }
+}

--- a/packages/sdks/snippets/angular-17-ssr/src/app/landing-page/landing-page.resolver.ts
+++ b/packages/sdks/snippets/angular-17-ssr/src/app/landing-page/landing-page.resolver.ts
@@ -1,0 +1,18 @@
+import type { ActivatedRouteSnapshot, ResolveFn } from '@angular/router';
+import { fetchOneEntry, getBuilderSearchParams } from '@builder.io/sdk-angular';
+
+export const landingPageResolver: ResolveFn<any> = (
+  route: ActivatedRouteSnapshot
+) => {
+  const urlPath = `/${route.url.join('/')}`;
+  const searchParams = getBuilderSearchParams(route.queryParams);
+
+  return fetchOneEntry({
+    apiKey: 'ee9f13b4981e489a9a1209887695ef2b',
+    model: 'page',
+    userAttributes: {
+      urlPath,
+    },
+    options: searchParams,
+  });
+};


### PR DESCRIPTION
## Description

PR is in response to [this ticket](https://builder-io.atlassian.net/browse/EDU-714?atlOrigin=eyJpIjoiODQ0N2EzNjI5OTI5NGM3ZjgyMGM1ZTg1MWIyZTYwZDQiLCJwIjoiaiJ9). Our [Integrating Pages doc](https://www.builder.io/c/docs/integrating-builder-pages) has code snippets for Angular SSR, but those snippets are not in the repository. This PR adds them to the repository with a single test.
