### PR TITLE
fix[gen2][fetchOneEntry]: ENG-9110 make fetchOneEntry() handle options.locale just like builder.get() handles options.locale

### DIFF
--- a/packages/core/src/builder.class.test.ts
+++ b/packages/core/src/builder.class.test.ts
@@ -1195,6 +1195,20 @@ describe('get', () => {
       { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } }
     );
   });
+
+  test('hits content API with locale=fr added to the locale query param and the userAttributes.locale param', async () => {
+    const expectedModel = 'page';
+    const expectedLocale = 'en-IN';
+
+    builder.apiEndpoint = 'content';
+    await builder.get(expectedModel, { locale: expectedLocale });
+
+    expect(builder['makeFetchApiCall']).toBeCalledTimes(1);
+    expect(builder['makeFetchApiCall']).toBeCalledWith(
+      `https://cdn.builder.io/api/v3/content/page?omit=meta.componentsUsed&apiKey=${API_KEY}&locale=${expectedLocale}&noTraverse=false&userAttributes=%7B%22locale%22%3A%22${expectedLocale}%22%7D&includeRefs=true&model=%22${expectedModel}%22`,
+      { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } }
+    );
+  });
 });
 
 describe('getAll', () => {
@@ -1261,6 +1275,20 @@ describe('getAll', () => {
     expect(builder['makeFetchApiCall']).toBeCalledTimes(1);
     expect(builder['makeFetchApiCall']).toBeCalledWith(
       `https://cdn.builder.io/api/v3/content/${expectedModel}?omit=meta.componentsUsed&apiKey=${API_KEY}&noTraverse=true&userAttributes=%7B%22urlPath%22%3A%22%2F%22%2C%22host%22%3A%22localhost%22%2C%22device%22%3A%22desktop%22%7D&includeRefs=false&limit=30&model=%22${expectedModel}%22`,
+      { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } }
+    );
+  });
+
+  test('hits content API with locale=fr added to the locale query param and NOT the userAttributes.locale param', async () => {
+    const expectedModel = 'page';
+    const expectedLocale = 'en-IN';
+
+    builder.apiEndpoint = 'content';
+    await builder.getAll(expectedModel, { locale: expectedLocale });
+
+    expect(builder['makeFetchApiCall']).toBeCalledTimes(1);
+    expect(builder['makeFetchApiCall']).toBeCalledWith(
+      `https://cdn.builder.io/api/v3/content/page?omit=meta.componentsUsed&apiKey=${API_KEY}&locale=${expectedLocale}&noTraverse=true&userAttributes=%7B%22urlPath%22%3A%22%2F%22%2C%22host%22%3A%22localhost%22%2C%22device%22%3A%22desktop%22%7D&includeRefs=true&limit=30&model=%22${expectedModel}%22`,
       { headers: { Authorization: `Bearer ${AUTH_TOKEN}` } }
     );
   });

--- a/packages/sdks/src/functions/get-content/__snapshots__/generate-content-url.test.ts.snap
+++ b/packages/sdks/src/functions/get-content/__snapshots__/generate-content-url.test.ts.snap
@@ -2,9 +2,9 @@
 
 exports[`Generate Content URL > Handles overrides correctly 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed&cachebust=true&noCache=true&overrides.037948e52eaf4743afed464f02c70da4=037948e52eaf4743afed464f02c70da4&overrides.page=037948e52eaf4743afed464f02c70da4&overrides.page%3A%2F=037948e52eaf4743afed464f02c70da4&preview=page&query.id=%22c1b81bab59704599b997574eb0736def%22"`;
 
-exports[`Generate Content URL > add options.locale in userAttributes when no locale attribute set 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&locale=en-US&omit=meta.componentsUsed&userAttributes=%7B%22locale%22%3A%22en-US%22%7D"`;
+exports[`Generate Content URL > does not add options.locale in userAttributes when no locale attribute set 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed&userAttributes=%7B%22locale%22%3A%22en-US%22%7D"`;
 
-exports[`Generate Content URL > add userAttributes.locale when top-level locale option exist 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&locale=en-US&omit=meta.componentsUsed&userAttributes=%7B%22locale%22%3A%22en-US%22%7D"`;
+exports[`Generate Content URL > does not add userAttributes.locale when top-level locale option exist 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&locale=en-US&omit=meta.componentsUsed"`;
 
 exports[`Generate Content URL > generate content url when given invalid values of offset, includeUnpublished, cacheSeconds, staleCacheSeconds 1`] = `"https://cdn.builder.io/api/v3/content/page?apiKey=YJIGb4i01jvw0SRdL5Bt&limit=30&noTraverse=true&includeRefs=true&omit=meta.componentsUsed&includeUnpublished=false"`;
 

--- a/packages/sdks/src/functions/get-content/generate-content-url.test.ts
+++ b/packages/sdks/src/functions/get-content/generate-content-url.test.ts
@@ -237,7 +237,7 @@ describe('Generate Content URL', () => {
     expect(output).toMatchSnapshot();
   });
 
-  test('add userAttributes.locale when top-level locale option exist', () => {
+  test('does not add userAttributes.locale when top-level locale option exist', () => {
     const output = generateContentUrl({
       apiKey: testKey,
       model: testModel,
@@ -246,7 +246,7 @@ describe('Generate Content URL', () => {
     expect(output).toMatchSnapshot();
   });
 
-  test('add options.locale in userAttributes when no locale attribute set', () => {
+  test('does not add options.locale in userAttributes when no locale attribute set', () => {
     const output = generateContentUrl({
       apiKey: testKey,
       model: testModel,

--- a/packages/sdks/src/functions/get-content/generate-content-url.ts
+++ b/packages/sdks/src/functions/get-content/generate-content-url.ts
@@ -52,17 +52,12 @@ export const generateContentUrl = (options: GetContentOptions): URL => {
   url.searchParams.set('limit', String(limit));
   url.searchParams.set('noTraverse', String(noTraverse));
   url.searchParams.set('includeRefs', String(true));
+  if (locale) {
+    url.searchParams.set('locale', locale);
+  }
 
-  const finalLocale = locale || userAttributes?.locale;
   let finalUserAttributes: Record<string, any> = userAttributes || {};
 
-  if (finalLocale) {
-    url.searchParams.set('locale', finalLocale);
-    finalUserAttributes = {
-      locale: finalLocale,
-      ...finalUserAttributes,
-    };
-  }
   if (enrich) url.searchParams.set('enrich', String(enrich));
 
   url.searchParams.set('omit', omit ?? 'meta.componentsUsed');

--- a/packages/sdks/src/functions/get-content/index.ts
+++ b/packages/sdks/src/functions/get-content/index.ts
@@ -20,6 +20,16 @@ const checkContentHasResults = (
 export async function fetchOneEntry(
   options: GetContentOptions
 ): Promise<BuilderContent | null> {
+  const finalLocale = options.locale || options.userAttributes?.locale;
+
+  if (finalLocale) {
+    options.locale = finalLocale;
+    options.userAttributes = {
+      locale: finalLocale,
+      ...options.userAttributes,
+    };
+  }
+
   const allContent = await fetchEntries({ ...options, limit: 1 });
 
   if (allContent) {


### PR DESCRIPTION
## Description

 FetchEntries - includes extra userAttribute: {locale: value} along with the locale payload

`builder.getAll()` hits the Content API without the addition of `locale` to `userAttributes`. See here: https://www.loom.com/share/7117e8725b69400f98e02d823a901b7a

The change in this [PR](https://github.com/BuilderIO/builder/pull/3719)  was added to ensure `locale` is added to `userAttributes` for `builder.get()` and not `builder.getAll()`

However, to ensure the same outcome In Gen2 SDK the [change](https://github.com/BuilderIO/builder/pull/3719/files#diff-b4fb78a40f76e70808858993da491c522b4f567feefeb6c01b0ab5defac58569) of adding `locale` to `userAttributes` is added in `packages/sdks/src/functions/get-content/generate-content-url.ts` which is used in **BOTH** `fetchOneEntry()` and `fetchEntries()`.

**PR that caused the bug**
https://github.com/BuilderIO/builder/pull/3719

**Link to JIRA ticket**
https://builder-io.atlassian.net/browse/ENG-9110


