### PR TITLE
fix[utils][packageJson]: SUPP-1396 manual upgrade to package.json

### DIFF
--- a/packages/utils/package-lock.json
+++ b/packages/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/utils",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/utils",
-      "version": "1.1.23",
+      "version": "1.1.24",
       "dependencies": {
         "@types/lodash": "^4.14.182",
         "lodash": "^4.17.21",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/utils",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "description": "Utils for working with Builder.io content",
   "main": "./dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Description

As the utils have been manually upgraded https://www.npmjs.com/package/@builder.io/utils/v/1.1.24?activeTab=readme
This PR ensures the repo has the latest version in package.json

**Dependent PR**
https://github.com/BuilderIO/builder/pull/4122

**Link to JIRA ticket**
https://builder-io.atlassian.net/browse/SUPP-1396