### PR TITLE
#4124: Fixed initial Nuxt 3 SSR builder render issue by passing route…

### DIFF
--- a/examples/vue/nuxt-3-catchall/pages/[...app].vue
+++ b/examples/vue/nuxt-3-catchall/pages/[...app].vue
@@ -2,7 +2,7 @@
   <div id="home">
     <div>Hello world from your Vue project. Below is Builder Content:</div>
 
-    <div v-if="content || isPreviewing()">
+    <div v-if="canShowContent">
       <div>
         page title:
         {{ content?.data?.title || 'Unpublished' }}
@@ -20,7 +20,7 @@
 
 <script setup>
 import { Content, fetchOneEntry, isPreviewing } from '@builder.io/sdk-vue';
-
+import { ref } from 'vue';
 import HelloWorldComponent from '../components/HelloWorld.vue';
 
 // Register your Builder components
@@ -41,7 +41,7 @@ const REGISTERED_COMPONENTS = [
 
 // TODO: enter your public API key
 const BUILDER_PUBLIC_API_KEY = 'f1a790f8c3204b3b8c5c1795aeac4660'; // ggignore
-
+const canShowContent = ref(false);
 const route = useRoute();
 
 // fetch builder content data
@@ -54,4 +54,5 @@ const { data: content } = await useAsyncData(`builderData-page-${route.path}`, (
     },
   })
 );
+canShowContent.value = content.value ? true : isPreviewing(route.query);
 </script>

--- a/examples/vue/nuxt-3/app.vue
+++ b/examples/vue/nuxt-3/app.vue
@@ -2,7 +2,7 @@
   <div id="home">
     <div>Hello world from your Vue project. Below is Builder Content:</div>
 
-    <div v-if="content || isPreviewing()">
+    <div v-if="canShowContent">
       <div>
         page title:
         {{ content?.data?.title || 'Unpublished' }}
@@ -20,7 +20,7 @@
 
 <script setup>
 import { Content, fetchOneEntry, isPreviewing } from '@builder.io/sdk-vue';
-
+import { ref } from 'vue';
 import HelloWorldComponent from './components/HelloWorld.vue';
 
 // Register your Builder components
@@ -41,7 +41,7 @@ const REGISTERED_COMPONENTS = [
 
 // TODO: enter your public API key
 const BUILDER_PUBLIC_API_KEY = 'f1a790f8c3204b3b8c5c1795aeac4660'; // ggignore
-
+const canShowContent = ref(false);
 const route = useRoute();
 
 // fetch builder content data
@@ -54,4 +54,5 @@ const { data: content } = await useAsyncData(`builderData-page-${route.path}`, (
     },
   })
 );
+canShowContent.value = content.value ? true : isPreviewing(route.query);
 </script>


### PR DESCRIPTION
The Nuxt 3 and Nuxt 3 catch all solutions ([here](https://github.com/BuilderIO/builder/blob/main/examples/vue/nuxt-3-catchall/pages/%5B...app%5D.vue#L5) and [here](https://github.com/BuilderIO/builder/blob/main/examples/vue/nuxt-3/app.vue#L5)) do not work out of the box for SSR because preview query parameters are not passed to isPreviewing().

To reproduce:

Implement one of the Nuxt 3 examples above in an SSR Nuxt 3 app.
Attempt to access a page through the builder.io preview environment
Result: It'll say "Content not found" or you'll get the error pop-up that something is not configured correctly.

Fun note: If you update your app locally, HMR triggers a client update which then DOES trigger a working client call with fetchOneEntry - enabling the preview environment to work. The initial impression is a flaky builder preview environment that sometimes works and sometimes does not (no good!).
