### PR TITLE
fix: passing custom breakpoints down to symbol

### DIFF
--- a/.changeset/nervous-rabbits-sing.md
+++ b/.changeset/nervous-rabbits-sing.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/react": patch
+---
+
+fix passing down custom breakpoints to Symbol

--- a/packages/react/src/components/builder-block.component.tsx
+++ b/packages/react/src/components/builder-block.component.tsx
@@ -43,11 +43,7 @@ export function deepCloneWithConditions<T = any>(obj: T): T {
   for (const key in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, key)) {
       if (key === 'meta') {
-        clonedObj.meta = {
-          breakpoints: {
-            ...obj['meta'].breakpoints,
-          },
-        };
+        clonedObj.meta = obj['meta'];
       } else {
         clonedObj[key] = deepCloneWithConditions(obj[key]);
       }

--- a/packages/react/src/components/builder-block.component.tsx
+++ b/packages/react/src/components/builder-block.component.tsx
@@ -41,7 +41,7 @@ export function deepCloneWithConditions<T = any>(obj: T): T {
   const clonedObj: any = {};
 
   for (const key in obj) {
-    if (key !== 'meta' && Object.prototype.hasOwnProperty.call(obj, key)) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
       clonedObj[key] = deepCloneWithConditions(obj[key]);
     }
   }

--- a/packages/react/src/components/builder-block.component.tsx
+++ b/packages/react/src/components/builder-block.component.tsx
@@ -42,7 +42,15 @@ export function deepCloneWithConditions<T = any>(obj: T): T {
 
   for (const key in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, key)) {
-      clonedObj[key] = deepCloneWithConditions(obj[key]);
+      if (key === 'meta') {
+        clonedObj.meta = {
+          breakpoints: {
+            ...obj['meta'].breakpoints,
+          },
+        };
+      } else {
+        clonedObj[key] = deepCloneWithConditions(obj[key]);
+      }
     }
   }
 


### PR DESCRIPTION
## Description

when we passed content of symbol down - we do a deepClone and here we were skipping `meta` field that contains the breakpoints object

i think it's safe to clone meta field too?

Jira
https://builder-io.atlassian.net/browse/ENG-10131

loom:
https://www.loom.com/share/c31a74790c6d4aac9d9375dcf8a3ce69
