### PR TITLE
Make state values available in eval context SSR

### DIFF
--- a/packages/react/src/functions/try-eval.tsx
+++ b/packages/react/src/functions/try-eval.tsx
@@ -56,6 +56,29 @@ export const tryEval = (str?: string, data: any = {}, errors?: Error[]): any => 
       // for the server build
       const ivm = safeDynamicRequire('isolated-vm');
       const context = getIsolateContext();
+
+      Object.keys(data).forEach(key => {
+        switch (key) {
+          case 'state':
+          case 'global':
+          case 'log':
+            console.warn(`Not setting state.${key} as global ${key} in isolated vm`);
+            break;
+          default:
+            if (data[key] === undefined) {
+              return;
+            }
+            try {
+              if (typeof data[key] === 'object' && data[key] !== null) {
+                context.global.setSync(key, new ivm.ExternalCopy(data[key]).copyInto());
+              } else {
+                context.global.setSync(key, data[key]);
+              }
+            } catch (error) {
+              console.warn(`Could not set ${key} for isolated-vm:`, error);
+            }
+        }
+      });
       const fnString = makeFn(str!, useReturn, ['state']);
       const resultStr = context.evalClosureSync(fnString, [new ivm.Reference(data || {})]);
       try {


### PR DESCRIPTION
## Description

In client side evaluations state values are available without needing the `state.` prefix. Now this should work in SSR as well.

I also prevented shadowing of some special globals that we set ourselves and don't want to override.