### PR TITLE
Chore/bump isolated vm

### DIFF
--- a/packages/react/CONTRIBUTING.md
+++ b/packages/react/CONTRIBUTING.md
@@ -8,9 +8,9 @@ These steps will guide you through contributing to this project:
 - Clone it and install dependencies
 
       		git clone https://github.com/YOUR-USERNAME/builder-react
-      		npm install
+      		yarn install
 
-Keep in mind that after running `npm install` the git repo is reset. So a good way to cope with this is to have a copy of the folder to push the changes, and the other to try them.
+Keep in mind that after running `yarn install` the git repo is reset. So a good way to cope with this is to have a copy of the folder to push the changes, and the other to try them.
 
 Make and commit your changes. Make sure the commands npm run build and npm run test:prod are working.
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -100,7 +100,7 @@
     "@builder.io/sdk": "workspace:*",
     "@emotion/core": "^10.0.17",
     "hash-sum": "^2.0.0",
-    "isolated-vm": "^5.0.0",
+    "isolated-vm": "^6.0.0",
     "preact": "^10.1.0"
   },
   "installConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6958,7 +6958,7 @@ __metadata:
     coveralls: ^3.0.0
     cross-env: ^5.0.1
     hash-sum: ^2.0.0
-    isolated-vm: ^5.0.0
+    isolated-vm: ^6.0.0
     jest: ^28.1.3
     jest-environment-jsdom: ^28.1.3
     node-fetch: ^2.6.1
@@ -40867,6 +40867,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isolated-vm@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "isolated-vm@npm:6.0.1"
+  dependencies:
+    node-gyp: latest
+    prebuild-install: ^7.1.3
+  checksum: ac8bb41270b8547ee2c20024327c6564dfffeca4dec5102bf8cf0f2eac94b46f5aef5e78bc207e2e055c4b2575a32156ad9f9716f406b5886120d393f3f86bea
+  languageName: node
+  linkType: hard
+
 "isomorphic-ws@npm:^5.0.0":
   version: 5.0.0
   resolution: "isomorphic-ws@npm:5.0.0"
@@ -47906,6 +47916,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"napi-build-utils@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "napi-build-utils@npm:2.0.0"
+  checksum: 532121efd2dd2272595580bca48859e404bdd4ed455a72a28432ba44868c38d0e64fac3026a8f82bf8563d2a18b32eb9a1d59e601a9da4e84ba4d45b922297f5
+  languageName: node
+  linkType: hard
+
 "napi-wasm@npm:^1.1.0":
   version: 1.1.0
   resolution: "napi-wasm@npm:1.1.0"
@@ -52567,6 +52584,28 @@ __metadata:
   bin:
     prebuild-install: bin.js
   checksum: dbf96d0146b6b5827fc8f67f72074d2e19c69628b9a7a0a17d0fad1bf37e9f06922896972e074197fc00a52eae912993e6ef5a0d471652f561df5cb516f3f467
+  languageName: node
+  linkType: hard
+
+"prebuild-install@npm:^7.1.3":
+  version: 7.1.3
+  resolution: "prebuild-install@npm:7.1.3"
+  dependencies:
+    detect-libc: ^2.0.0
+    expand-template: ^2.0.3
+    github-from-package: 0.0.0
+    minimist: ^1.2.3
+    mkdirp-classic: ^0.5.3
+    napi-build-utils: ^2.0.0
+    node-abi: ^3.3.0
+    pump: ^3.0.0
+    rc: ^1.2.7
+    simple-get: ^4.0.0
+    tar-fs: ^2.0.0
+    tunnel-agent: ^0.6.0
+  bin:
+    prebuild-install: bin.js
+  checksum: 300740ca415e9ddbf2bd363f1a6d2673cc11dd0665c5ec431bbb5bf024c2f13c56791fb939ce2b2a2c12f2d2a09c91316169e8063a80eb4482a44b8fe5b265e1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

https://github.com/BuilderIO/builder/issues/4137

Bump `isolated-vm` to version 6.x.x, which supports Node 24: https://github.com/laverdet/isolated-vm?tab=readme-ov-file. I took a look through the commits on that release and didn't see anything that looked like it would impact functionality. The tests in the React package seem to  all be borked on main so I can't confirm, took a stab at updating the contributing docs in there too to use `yarn` instead of `npm`.

I only did it in the React package since I don't want to get too far into the weeds and that's the one I use on my project.