### PR TITLE
Return sku code in the content with Commercelayer Plugin

### DIFF
--- a/plugins/commercelayer/src/plugin.ts
+++ b/plugins/commercelayer/src/plugin.ts
@@ -1,5 +1,5 @@
-import { registerCommercePlugin, BuilderRequest, CommerceAPIOperations } from '@builder.io/plugin-tools'
 import appState from '@builder.io/app-context'
+import { BuilderRequest, CommerceAPIOperations, registerCommercePlugin, Resource } from '@builder.io/plugin-tools'
 import pkg from '../package.json'
 import { authenticateClient, getOrganizationInfo, getProduct, searchProducts, getProductByHandle, transformProduct } from './service'
 
@@ -44,7 +44,7 @@ registerCommercePlugin(
             const products = await searchProducts(search, auth.accessToken, baseEndpoint)
             return products.map(transformProduct)
           },
-          getRequestObject(id: string): BuilderRequest {
+          getRequestObject(id: string, resource: Resource): BuilderRequest {
             return {
               '@type': '@builder.io/core:Request',
               request: {
@@ -56,6 +56,7 @@ registerCommercePlugin(
               },
               options: {
                 product: id,
+                code: resource.handle,
                 pluginId: pkg.name
               }
             }


### PR DESCRIPTION
## Description

The commercelayer plugin only returns the sku id when the content is fetched with the Content API. This is not very useful as the id of the SKU is not very useful in Commercelayer.
Ideally, one should be able to get the SKU code from the Content API.

This PR adds the SKU code in the response of the Content API for the Content Type Commercelayer product.

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
