### PR TITLE
fix[react-gen1]: handle `fetchPriority` vs `fetchpriority` in different react versions

### DIFF
--- a/.changeset/thirty-cougars-repair.md
+++ b/.changeset/thirty-cougars-repair.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/react': patch
+---
+
+fix: handle `fetchpriority` casing in different react versions

--- a/packages/react/src/blocks/Image.tsx
+++ b/packages/react/src/blocks/Image.tsx
@@ -263,10 +263,14 @@ class ImageComponent extends React.Component<any, { imageLoaded: boolean; load: 
     return this.props.image || this.props.src;
   }
 
+  get loadEagerly() {
+    return this.props.builderBlock?.id.startsWith('builder-pixel-') || this.props.highPriority;
+  }
+
   get fetchPriorityProp() {
     const propNameToUse = isNewReact ? 'fetchPriority' : 'fetchpriority';
     return {
-      [propNameToUse]: this.props.highPriority ? 'high' : 'auto',
+      [propNameToUse]: this.loadEagerly ? 'high' : 'auto',
     };
   }
 
@@ -310,8 +314,6 @@ class ImageComponent extends React.Component<any, { imageLoaded: boolean; load: 
       srcset = this.getSrcSet();
     }
 
-    const isPixel = builderBlock?.id.startsWith('builder-pixel-');
-    const eagerLoad = isPixel || this.props.highPriority;
     const { fitContent } = this.props;
 
     return (
@@ -361,7 +363,7 @@ class ImageComponent extends React.Component<any, { imageLoaded: boolean; load: 
                   },
                 }),
               }}
-              loading={eagerLoad ? 'eager' : 'lazy'}
+              loading={this.loadEagerly ? 'eager' : 'lazy'}
               {...this.fetchPriorityProp}
               className={'builder-image' + (this.props.className ? ' ' + this.props.className : '')}
               src={this.image}

--- a/packages/react/src/blocks/Image.tsx
+++ b/packages/react/src/blocks/Image.tsx
@@ -10,6 +10,8 @@ import { throttle } from '../functions/throttle';
 import { Breakpoints, getSizesForBreakpoints } from '../constants/device-sizes.constant';
 import { IMAGE_FILE_TYPES } from 'src/constants/file-types.constant';
 
+const isNewReact = 'use' in React;
+
 // Taken from (and modified) the shopify theme script repo
 // https://github.com/Shopify/theme-scripts/blob/bcfb471f2a57d439e2f964a1bb65b67708cc90c3/packages/theme-images/images.js#L59
 function removeProtocol(path: string) {
@@ -261,6 +263,13 @@ class ImageComponent extends React.Component<any, { imageLoaded: boolean; load: 
     return this.props.image || this.props.src;
   }
 
+  get fetchPriorityProp() {
+    const propNameToUse = isNewReact ? 'fetchPriority' : 'fetchpriority';
+    return {
+      [propNameToUse]: this.props.highPriority ? 'high' : 'auto',
+    };
+  }
+
   getSrcSet(): string | undefined {
     const url = this.image;
     if (!url || typeof url !== 'string') {
@@ -353,7 +362,7 @@ class ImageComponent extends React.Component<any, { imageLoaded: boolean; load: 
                 }),
               }}
               loading={eagerLoad ? 'eager' : 'lazy'}
-              fetchPriority={eagerLoad ? 'high' : 'auto'}
+              {...this.fetchPriorityProp}
               className={'builder-image' + (this.props.className ? ' ' + this.props.className : '')}
               src={this.image}
               {...(!amp && {


### PR DESCRIPTION
## Description

Handles fetch priority casing based on React versions

> In a previous PR, https://github.com/vercel/next.js/pull/47302, detection for fetchPriority assumed that https://github.com/facebook/react/pull/25927 would land in react@18.3.0 because that was the react@canary version at the time. However, it didn't land in react@18.3.0 and it is expected to land in react@19.0.0 due to the breaking change.
This means that users upgrading to react@18.3.0 will see a warning.

Inspiration from:
https://github.com/facebook/react/issues/28946
https://github.com/vercel/next.js/pull/65235
https://github.com/ascorbic/unpic-img/pull/644

_Screenshot_
If relevant, add a screenshot or two of the changes you made.
