### PR TITLE
feat: optimize re-renders for builder-component

### DIFF
--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -568,12 +568,18 @@ export class BuilderComponent extends React.Component<
       case 'builder.resetState': {
         const { state, model } = info.data;
         if (model === this.name) {
+          // Suspend change tracking to batch all updates
+          onChange.suspend(this.rootState);
+
           for (const key in this.rootState) {
             // TODO: support nested functions (somehow)
             if (typeof this.rootState[key] !== 'function') {
               delete this.rootState[key];
             }
           }
+          // Resume change tracking
+          onChange.resume(this.rootState);
+
           Object.assign(this.rootState, state);
           this.setState({
             ...this.state,
@@ -586,9 +592,16 @@ export class BuilderComponent extends React.Component<
       case 'builder.resetSymbolState': {
         const { state, model, id } = info.data.state;
         if (this.props.builderBlock && this.props.builderBlock === id) {
+          // Suspend change tracking to batch all updates
+          onChange.suspend(this.rootState);
+
           for (const key in this.rootState) {
             delete this.rootState[key];
           }
+
+          // Resume change tracking
+          onChange.resume(this.rootState);
+
           Object.assign(this.rootState, state);
           this.setState({
             ...this.state,

--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -571,14 +571,17 @@ export class BuilderComponent extends React.Component<
           // Suspend change tracking to batch all updates
           onChange.suspend(this.rootState);
 
-          for (const key in this.rootState) {
-            // TODO: support nested functions (somehow)
-            if (typeof this.rootState[key] !== 'function') {
-              delete this.rootState[key];
+          try {
+            for (const key in this.rootState) {
+              // TODO: support nested functions (somehow)
+              if (typeof this.rootState[key] !== 'function') {
+                delete this.rootState[key];
+              }
             }
+          } finally {
+            // Resume change tracking - ensure this always runs even if deletion fails
+            onChange.resume(this.rootState);
           }
-          // Resume change tracking
-          onChange.resume(this.rootState);
 
           Object.assign(this.rootState, state);
           this.setState({
@@ -595,12 +598,14 @@ export class BuilderComponent extends React.Component<
           // Suspend change tracking to batch all updates
           onChange.suspend(this.rootState);
 
-          for (const key in this.rootState) {
-            delete this.rootState[key];
+          try {
+            for (const key in this.rootState) {
+              delete this.rootState[key];
+            }
+          } finally {
+            // Resume change tracking - ensure this always runs even if deletion fails
+            onChange.resume(this.rootState);
           }
-
-          // Resume change tracking
-          onChange.resume(this.rootState);
 
           Object.assign(this.rootState, state);
           this.setState({

--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -578,17 +578,18 @@ export class BuilderComponent extends React.Component<
                 delete this.rootState[key];
               }
             }
+
+            Object.assign(this.rootState, state);
+            this.setState({
+              ...this.state,
+              state: this.rootState,
+              updates: ((this.state && this.state.updates) || 0) + 1,
+            });
           } finally {
             // Resume change tracking - ensure this always runs even if deletion fails
             onChange.resume(this.rootState);
+            this.debouncedUpdateState();
           }
-
-          Object.assign(this.rootState, state);
-          this.setState({
-            ...this.state,
-            state: this.rootState,
-            updates: ((this.state && this.state.updates) || 0) + 1,
-          });
         }
         break;
       }
@@ -827,6 +828,8 @@ export class BuilderComponent extends React.Component<
 
     this.notifyStateChange();
   };
+
+  debouncedUpdateState = debounce(this.updateState, 1000);
 
   get isPreviewing() {
     return (


### PR DESCRIPTION
## Description

- prevent `updateState` calls whenever we call delete key on the `rootState` 

**Loom**
https://www.loom.com/share/4d19d3dacd14468aaa8f7e4a575fbe01

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `onChange.suspend/resume` and use them to batch `rootState` resets in `BuilderComponent`, reducing unnecessary re-renders.
> 
> - **State change tracking (`packages/react/lib/on-change.js`)**:
>   - Add `SUSPEND`/`RESUME` symbols and `isSuspended` flag.
>   - Expose `onChange.suspend(proxy)` and `onChange.resume(proxy)` APIs.
>   - `ignoreChange` now skips notifications while suspended; handler exposes suspend/resume at root.
> - **Builder component (`packages/react/src/components/builder-component.component.tsx`)**:
>   - Wrap `builder.resetState` and `builder.resetSymbolState` handlers with `onChange.suspend(this.rootState)`/`onChange.resume(this.rootState)` to batch deletions/assignments.
>   - After reset, call `debouncedUpdateState` (1s debounce) to coalesce updates.
>   - Add `debouncedUpdateState = debounce(this.updateState, 1000)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 316c80d6d4a51be6f70c90cf0f2a8e8850a1a6b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->