### PR TITLE
Support Svelte 5 in Svelte SDK

### DIFF
--- a/examples/svelte/svelte-vite/package.json
+++ b/examples/svelte/svelte-vite/package.json
@@ -16,7 +16,7 @@
     "eslint-config-prettier": "^8.3.0",
     "prettier": "^2.5.1",
     "prettier-plugin-svelte": "^2.5.0",
-    "svelte": "^4.2.7",
+    "svelte": "^5.0.0",
     "svelte-eslint-parser": "0.33.1",
     "typescript": "~4.6.2",
     "vite": "^4.5.12"

--- a/examples/svelte/sveltekit/package.json
+++ b/examples/svelte/sveltekit/package.json
@@ -14,7 +14,7 @@
 		"@sveltejs/adapter-vercel": "^4.0.5",
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",
-		"svelte": "^4.2.7",
+		"svelte": "^5.0.0",
 		"svelte-check": "^3.6.0",
 		"tslib": "^2.4.1",
 		"typescript": "^5.0.0",

--- a/packages/sdks/e2e/svelte/package.json
+++ b/packages/sdks/e2e/svelte/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^2.0.3",
     "@tsconfig/svelte": "^4.0.1",
-    "svelte": "^3.57.0",
+    "svelte": "^5.0.0",
     "svelte-check": "^3.4.6",
     "tslib": "^2.5.0",
     "typescript": "^5.1.6",

--- a/packages/sdks/e2e/svelte/package.json
+++ b/packages/sdks/e2e/svelte/package.json
@@ -14,12 +14,12 @@
     "@sdk/tests": "workspace:*"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^2.0.3",
+    "@sveltejs/vite-plugin-svelte": "^4.0.0",
     "@tsconfig/svelte": "^4.0.1",
     "svelte": "^5.0.0",
-    "svelte-check": "^3.4.6",
+    "svelte-check": "^4.0.0",
     "tslib": "^2.5.0",
-    "typescript": "^5.1.6",
-    "vite": "^4.5.11"
+    "typescript": "^5.5.0",
+    "vite": "^5.4.4"
   }
 }

--- a/packages/sdks/e2e/svelte/src/App.svelte
+++ b/packages/sdks/e2e/svelte/src/App.svelte
@@ -42,7 +42,7 @@
     ],
   };
 
-  let props = undefined;
+  let props = $state(undefined);
   const fetch = async () => {
     props = await getProps({ _processContentResult });
     props.customComponents = [builderBlockWithClassNameCustomComponent];

--- a/packages/sdks/e2e/svelte/src/BuilderBlockWithClassName.svelte
+++ b/packages/sdks/e2e/svelte/src/BuilderBlockWithClassName.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
   import { Blocks } from '@builder.io/sdk-svelte';
 
-  export let builderBlock: any;
-  export let content: any;
+  interface Props {
+    builderBlock: any;
+    content: any;
+  }
+
+  let { builderBlock, content }: Props = $props();
 </script>
 
 <div>

--- a/packages/sdks/e2e/svelte/src/main.ts
+++ b/packages/sdks/e2e/svelte/src/main.ts
@@ -1,6 +1,7 @@
 import App from './App.svelte';
+import { mount } from "svelte";
 
-const app = new App({
+const app = mount(App, {
   target: document.getElementById('app'),
 });
 

--- a/packages/sdks/e2e/sveltekit/package.json
+++ b/packages/sdks/e2e/sveltekit/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@sveltejs/adapter-auto": "^3.2.5",
     "@sveltejs/kit": "^2.8.3",
-    "svelte": "^4.2.19",
+    "svelte": "^5.0.0",
     "svelte-check": "^4.0.5",
     "tslib": "^2.4.1",
     "typescript": "^5.1.6",

--- a/packages/sdks/e2e/sveltekit/package.json
+++ b/packages/sdks/e2e/sveltekit/package.json
@@ -19,7 +19,7 @@
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.5",
     "tslib": "^2.4.1",
-    "typescript": "^5.1.6",
+    "typescript": "^5.5.0",
     "vite": "^5.4.9"
   },
   "nx": {

--- a/packages/sdks/e2e/sveltekit/src/components/BuilderBlockWithClassName.svelte
+++ b/packages/sdks/e2e/sveltekit/src/components/BuilderBlockWithClassName.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
   import { Blocks } from '@builder.io/sdk-svelte';
 
-  export let builderBlock: any;
-  export let content: any;
+  interface Props {
+    builderBlock: any;
+    content: any;
+  }
+
+  let { builderBlock, content }: Props = $props();
 </script>
 
 <div>

--- a/packages/sdks/e2e/sveltekit/src/routes/[...catchall]/+page.svelte
+++ b/packages/sdks/e2e/sveltekit/src/routes/[...catchall]/+page.svelte
@@ -10,8 +10,13 @@
     }
   }
 
-  // this data comes from the function in `+page.server.ts`, which runs on the server only
-  export let data;
+  
+  interface Props {
+    // this data comes from the function in `+page.server.ts`, which runs on the server only
+    data: any;
+  }
+
+  let { data }: Props = $props();
   const builderBlockWithClassNameCustomComponent = {
     name: 'BuilderBlockWithClassName',
     component: BuilderBlockWithClassName,

--- a/packages/sdks/output/svelte/package.json
+++ b/packages/sdks/output/svelte/package.json
@@ -93,6 +93,6 @@
     }
   },
   "peerDependencies": {
-    "svelte": "^4.1.2"
+    "svelte": "^5.0.0"
   }
 }

--- a/packages/sdks/output/svelte/package.json
+++ b/packages/sdks/output/svelte/package.json
@@ -55,7 +55,7 @@
     "@sveltejs/adapter-auto": "^2.1.0",
     "@sveltejs/kit": "^1.22.4",
     "@sveltejs/package": "^2.2.0",
-    "svelte": "^4.1.2",
+    "svelte": "^5.43.6",
     "svelte-check": "^3.4.6",
     "svelte-preprocess": "^5.0.4",
     "tslib": "^2.3.1",

--- a/packages/sdks/output/svelte/package.json
+++ b/packages/sdks/output/svelte/package.json
@@ -55,7 +55,7 @@
     "@sveltejs/adapter-auto": "^2.1.0",
     "@sveltejs/kit": "^1.22.4",
     "@sveltejs/package": "^2.2.0",
-    "svelte": "^5.43.6",
+    "svelte": "^5.0.0",
     "svelte-check": "^3.4.6",
     "svelte-preprocess": "^5.0.4",
     "tslib": "^2.3.1",

--- a/packages/sdks/snippets/svelte/package.json
+++ b/packages/sdks/snippets/svelte/package.json
@@ -16,12 +16,12 @@
     "svelte-routing": "^2.13.0"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^3.0.2",
+    "@sveltejs/vite-plugin-svelte": "^4.0.0",
     "@tsconfig/svelte": "^5.0.2",
     "svelte": "^5.0.0",
-    "svelte-check": "^3.6.7",
+    "svelte-check": "^4.0.0",
     "tslib": "^2.6.2",
-    "typescript": "^5.2.2",
-    "vite": "^5.2.0"
+    "typescript": "^5.5.0",
+    "vite": "^5.4.4"
   }
 }

--- a/packages/sdks/snippets/svelte/package.json
+++ b/packages/sdks/snippets/svelte/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^3.0.2",
     "@tsconfig/svelte": "^5.0.2",
-    "svelte": "^4.2.12",
+    "svelte": "^5.0.0",
     "svelte-check": "^3.6.7",
     "tslib": "^2.6.2",
     "typescript": "^5.2.2",

--- a/packages/sdks/snippets/svelte/src/App.svelte
+++ b/packages/sdks/snippets/svelte/src/App.svelte
@@ -15,7 +15,11 @@
   import Hero from './components/blueprints/Hero.svelte';
   import Homepage from './components/blueprints/Homepage.svelte';
   import NavLinks from './components/blueprints/navlinks/NavLinks.svelte';
-  export let url = '';
+  interface Props {
+    url?: string;
+  }
+
+  let { url = '' }: Props = $props();
 </script>
 
 <svelte:head>

--- a/packages/sdks/snippets/svelte/src/components/AnnouncementBar.svelte
+++ b/packages/sdks/snippets/svelte/src/components/AnnouncementBar.svelte
@@ -13,8 +13,8 @@
   let apiKey = 'ee9f13b4981e489a9a1209887695ef2b';
   let model = 'announcement-bar';
 
-  let announcementBar: BuilderContent | null = null;
-  let canShowContent = false;
+  let announcementBar: BuilderContent | null = $state(null);
+  let canShowContent = $state(false);
 
   async function fetchContent() {
     announcementBar = await fetchOneEntry({

--- a/packages/sdks/snippets/svelte/src/components/CatchAll.svelte
+++ b/packages/sdks/snippets/svelte/src/components/CatchAll.svelte
@@ -12,8 +12,8 @@
   let apiKey = 'ee9f13b4981e489a9a1209887695ef2b';
   let model = 'page';
 
-  let content: BuilderContent | null = null;
-  let canShowContent = false;
+  let content: BuilderContent | null = $state(null);
+  let canShowContent = $state(false);
 
   async function fetchContent() {
     content = await fetchOneEntry({

--- a/packages/sdks/snippets/svelte/src/components/LivePreview.svelte
+++ b/packages/sdks/snippets/svelte/src/components/LivePreview.svelte
@@ -7,11 +7,11 @@
   } from '@builder.io/sdk-svelte';
   import type { BuilderContent } from '@builder.io/sdk-svelte';
 
-  let content: BuilderContent | null = null;
-  let isLoading = true;
+  let content: BuilderContent | null = $state(null);
+  let isLoading = $state(true);
 
   let urlPath = window.location.pathname;
-  let canShowContent = false;
+  let canShowContent = $state(false);
 
   async function fetchContent() {
     content = await fetchOneEntry({

--- a/packages/sdks/snippets/svelte/src/components/advanced-child/AdvancedChild.svelte
+++ b/packages/sdks/snippets/svelte/src/components/advanced-child/AdvancedChild.svelte
@@ -4,8 +4,8 @@
   import type { BuilderContent } from '@builder.io/sdk-svelte';
   import { CustomTabsInfo } from './CustomTabsInfo';
 
-  let loading = true;
-  let content: BuilderContent | null;
+  let loading = $state(true);
+  let content: BuilderContent | null = $state();
 
   let model = 'advanced-child';
   let apiKey = 'ee9f13b4981e489a9a1209887695ef2b';

--- a/packages/sdks/snippets/svelte/src/components/advanced-child/CustomTabs.svelte
+++ b/packages/sdks/snippets/svelte/src/components/advanced-child/CustomTabs.svelte
@@ -1,16 +1,20 @@
 <script lang="ts">
   import { Blocks, type BuilderBlock } from '@builder.io/sdk-svelte';
 
-  export let builderBlock: BuilderBlock;
-  export let tabList: Array<{ tabName: string; blocks: BuilderBlock[] }>;
+  interface Props {
+    builderBlock: BuilderBlock;
+    tabList: Array<{ tabName: string; blocks: BuilderBlock[] }>;
+  }
 
-  let activeTab = 0;
+  let { builderBlock, tabList }: Props = $props();
+
+  let activeTab = $state(0);
 </script>
 
 {#if tabList.length}
   <div class="dynamics-slots">
     {#each tabList as tab, index}
-      <button on:click={() => (activeTab = index)}>
+      <button onclick={() => (activeTab = index)}>
         {tab.tabName}
       </button>
     {/each}

--- a/packages/sdks/snippets/svelte/src/components/blueprints/BlogArticle.svelte
+++ b/packages/sdks/snippets/svelte/src/components/blueprints/BlogArticle.svelte
@@ -7,8 +7,12 @@
     type BuilderContent,
   } from '@builder.io/sdk-svelte';
 
-  export let handle: string;
-  let article: BuilderContent | null;
+  interface Props {
+    handle: string;
+  }
+
+  let { handle }: Props = $props();
+  let article: BuilderContent | null = $state();
   const model = 'blog-article';
   const apiKey = 'ee9f13b4981e489a9a1209887695ef2b';
 

--- a/packages/sdks/snippets/svelte/src/components/blueprints/Hero.svelte
+++ b/packages/sdks/snippets/svelte/src/components/blueprints/Hero.svelte
@@ -7,7 +7,7 @@
     type BuilderContent,
     isPreviewing,
   } from '@builder.io/sdk-svelte';
-  let productHero: BuilderContent | null = null;
+  let productHero: BuilderContent | null = $state(null);
 
   const MODEL = 'collection-hero';
   const API_KEY = 'ee9f13b4981e489a9a1209887695ef2b';

--- a/packages/sdks/snippets/svelte/src/components/blueprints/Homepage.svelte
+++ b/packages/sdks/snippets/svelte/src/components/blueprints/Homepage.svelte
@@ -7,7 +7,7 @@
     isPreviewing,
   } from '@builder.io/sdk-svelte';
 
-  let content: BuilderContent | null = null;
+  let content: BuilderContent | null = $state(null);
 
   const model = 'homepage';
   const apiKey = 'ee9f13b4981e489a9a1209887695ef2b';

--- a/packages/sdks/snippets/svelte/src/components/blueprints/ProductDetails.svelte
+++ b/packages/sdks/snippets/svelte/src/components/blueprints/ProductDetails.svelte
@@ -2,8 +2,12 @@
   import { onMount } from 'svelte';
   import { fetchOneEntry, type BuilderContent } from '@builder.io/sdk-svelte';
 
-  export let handle: string;
-  let productDetails: BuilderContent | null = null;
+  interface Props {
+    handle: string;
+  }
+
+  let { handle }: Props = $props();
+  let productDetails: BuilderContent | null = $state(null);
 
   onMount(() => {
     fetchOneEntry({

--- a/packages/sdks/snippets/svelte/src/components/blueprints/navlinks/NavBar.svelte
+++ b/packages/sdks/snippets/svelte/src/components/blueprints/navlinks/NavBar.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import type { BuilderContent } from '@builder.io/sdk-svelte';
-  export let links: BuilderContent;
+  interface Props {
+    links: BuilderContent;
+  }
+
+  let { links }: Props = $props();
 </script>
 
 {#if links.data?.links}

--- a/packages/sdks/snippets/svelte/src/components/blueprints/navlinks/NavLinks.svelte
+++ b/packages/sdks/snippets/svelte/src/components/blueprints/navlinks/NavLinks.svelte
@@ -4,7 +4,7 @@
   import { fetchOneEntry } from '@builder.io/sdk-svelte';
   import type { BuilderContent } from '@builder.io/sdk-svelte';
 
-  let links: BuilderContent | null = null;
+  let links: BuilderContent | null = $state(null);
 
   onMount(() => {
     fetchOneEntry({

--- a/packages/sdks/snippets/svelte/src/components/blueprints/product-editorial/ProductEditorial.svelte
+++ b/packages/sdks/snippets/svelte/src/components/blueprints/product-editorial/ProductEditorial.svelte
@@ -12,9 +12,13 @@
 
   const API_KEY = 'ee9f13b4981e489a9a1209887695ef2b';
   const modelName = 'product-editorial';
-  export let handle: string;
-  let product: any = null;
-  let editorial: BuilderContent | null = null;
+  interface Props {
+    handle: string;
+  }
+
+  let { handle }: Props = $props();
+  let product: any = $state(null);
+  let editorial: BuilderContent | null = $state(null);
 
   onMount(() => {
     fetch(`https://fakestoreapi.com/products/${handle}`)

--- a/packages/sdks/snippets/svelte/src/components/blueprints/product-editorial/ProductInfo.svelte
+++ b/packages/sdks/snippets/svelte/src/components/blueprints/product-editorial/ProductInfo.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  export let product: {
+  interface Props {
+    product: {
     id: number;
     title: string;
     price: number;
@@ -8,6 +9,9 @@
     image: string;
     rating: { rate: number; count: number };
   } | null;
+  }
+
+  let { product }: Props = $props();
 </script>
 
 {#if product}

--- a/packages/sdks/snippets/svelte/src/components/custom-child/CustomChild.svelte
+++ b/packages/sdks/snippets/svelte/src/components/custom-child/CustomChild.svelte
@@ -4,8 +4,8 @@
   import type { BuilderContent } from '@builder.io/sdk-svelte';
   import { customHeroInfo } from './CustomHeroInfo';
 
-  let loading = true;
-  let content: BuilderContent | null;
+  let loading = $state(true);
+  let content: BuilderContent | null = $state();
 
   let model = 'custom-child';
   let apiKey = 'ee9f13b4981e489a9a1209887695ef2b';

--- a/packages/sdks/snippets/svelte/src/components/custom-child/CustomHero.svelte
+++ b/packages/sdks/snippets/svelte/src/components/custom-child/CustomHero.svelte
@@ -1,5 +1,13 @@
+<script lang="ts">
+  interface Props {
+    children?: import('svelte').Snippet;
+  }
+
+  let { children }: Props = $props();
+</script>
+
 <section>
   <div>This is text from your component</div>
   <!-- The slot will render any child blocks from Builder -->
-  <slot />
+  {@render children?.()}
 </section>

--- a/packages/sdks/snippets/svelte/src/components/editable-regions/CustomColumns.svelte
+++ b/packages/sdks/snippets/svelte/src/components/editable-regions/CustomColumns.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
   import { Blocks, type BuilderBlock } from '@builder.io/sdk-svelte';
 
-  export let column1: BuilderBlock[];
-  export let column2: BuilderBlock[];
-  export let builderBlock: BuilderBlock;
+  interface Props {
+    column1: BuilderBlock[];
+    column2: BuilderBlock[];
+    builderBlock: BuilderBlock;
+  }
+
+  let { column1, column2, builderBlock }: Props = $props();
 </script>
 
 <!-- Left Column -->

--- a/packages/sdks/snippets/svelte/src/components/editable-regions/EditableRegions.svelte
+++ b/packages/sdks/snippets/svelte/src/components/editable-regions/EditableRegions.svelte
@@ -4,8 +4,8 @@
   import type { BuilderContent } from '@builder.io/sdk-svelte';
   import { CustomColumnsInfo } from './CustomColumnsInfo';
 
-  let loading = true;
-  let content: BuilderContent | null;
+  let loading = $state(true);
+  let content: BuilderContent | null = $state();
 
   let model = 'editable-regions';
   let apiKey = 'ee9f13b4981e489a9a1209887695ef2b';

--- a/packages/sdks/snippets/svelte/src/main.ts
+++ b/packages/sdks/snippets/svelte/src/main.ts
@@ -1,6 +1,7 @@
 import App from './App.svelte';
+import { mount } from "svelte";
 
-const app = new App({
+const app = mount(App, {
   target: document.getElementById('app')!,
 });
 

--- a/packages/sdks/snippets/sveltekit/package.json
+++ b/packages/sdks/snippets/sveltekit/package.json
@@ -16,13 +16,13 @@
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^3.0.0",
-    "@sveltejs/kit": "^2.0.0",
-    "@sveltejs/vite-plugin-svelte": "^3.0.0",
+    "@sveltejs/kit": "^2.5.27",
+    "@sveltejs/vite-plugin-svelte": "^4.0.0",
     "svelte": "^5.0.0",
-    "svelte-check": "^3.6.0",
+    "svelte-check": "^4.0.0",
     "tslib": "^2.4.1",
-    "typescript": "^5.0.0",
-    "vite": "^5.0.3"
+    "typescript": "^5.5.0",
+    "vite": "^5.4.4"
   },
   "type": "module",
   "nx": {

--- a/packages/sdks/snippets/sveltekit/package.json
+++ b/packages/sdks/snippets/sveltekit/package.json
@@ -18,7 +18,7 @@
     "@sveltejs/adapter-auto": "^3.0.0",
     "@sveltejs/kit": "^2.0.0",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
-    "svelte": "^4.2.7",
+    "svelte": "^5.0.0",
     "svelte-check": "^3.6.0",
     "tslib": "^2.4.1",
     "typescript": "^5.0.0",

--- a/packages/sdks/snippets/sveltekit/src/routes/[...catchall]/+page.svelte
+++ b/packages/sdks/snippets/sveltekit/src/routes/[...catchall]/+page.svelte
@@ -1,14 +1,19 @@
 <!-- Quickstart snippet -->
 <!-- snippets/sveltekit/src/routes/[...catchall]/+page.svelte -->
-<script>
+<script lang="ts">
   import { isPreviewing, Content } from '@builder.io/sdk-svelte';
 
   // TODO: use your own API key
   const apiKey = 'ee9f13b4981e489a9a1209887695ef2b';
   const model = 'page';
 
-  // this data comes from the function in `+page.server.js`, which runs on the server only
-  export let data;
+  
+  interface Props {
+    // this data comes from the function in `+page.server.js`, which runs on the server only
+    data: any;
+  }
+
+  let { data }: Props = $props();
 
   // show unpublished content when in preview mode.
   const canShowContent = data.content || isPreviewing(data.searchParams);

--- a/packages/sdks/snippets/sveltekit/src/routes/advanced-child/+page.svelte
+++ b/packages/sdks/snippets/sveltekit/src/routes/advanced-child/+page.svelte
@@ -3,7 +3,11 @@
   import type { PageData } from './$types';
   import { CustomTabsInfo } from './CustomTabsInfo';
 
-  export let data: PageData;
+  interface Props {
+    data: PageData;
+  }
+
+  let { data }: Props = $props();
 </script>
 
 {#if !data.data && !isPreviewing(data.searchParams)}

--- a/packages/sdks/snippets/sveltekit/src/routes/advanced-child/CustomTabs.svelte
+++ b/packages/sdks/snippets/sveltekit/src/routes/advanced-child/CustomTabs.svelte
@@ -1,16 +1,20 @@
 <script lang="ts">
   import { Blocks, type BuilderBlock } from '@builder.io/sdk-svelte';
 
-  export let builderBlock: BuilderBlock;
-  export let tabList: Array<{ tabName: string; blocks: BuilderBlock[] }>;
+  interface Props {
+    builderBlock: BuilderBlock;
+    tabList: Array<{ tabName: string; blocks: BuilderBlock[] }>;
+  }
 
-  let activeTab = 0;
+  let { builderBlock, tabList }: Props = $props();
+
+  let activeTab = $state(0);
 </script>
 
 {#if tabList.length}
   <div class="dynamics-slots">
     {#each tabList as tab, index}
-      <button on:click={() => (activeTab = index)}>
+      <button onclick={() => (activeTab = index)}>
         {tab.tabName}
       </button>
     {/each}

--- a/packages/sdks/snippets/sveltekit/src/routes/announcements/[...catchall]/+page.svelte
+++ b/packages/sdks/snippets/sveltekit/src/routes/announcements/[...catchall]/+page.svelte
@@ -2,13 +2,13 @@
 <!-- https://www.builder.io/c/blueprints/announcement-bar -->
 <!-- src/routes/announcements/[...catchall]/+page.svelte -->
 
-<script>
+<script lang="ts">
   import { isPreviewing, Content } from '@builder.io/sdk-svelte';
 
   const apiKey = 'ee9f13b4981e489a9a1209887695ef2b';
   const model = 'announcement-bar';
 
-  export let data;
+  let { data } = $props();
 
   const canShowContent = data.content || isPreviewing(data.searchParams);
 </script>

--- a/packages/sdks/snippets/sveltekit/src/routes/blogs/[handle]/+page.svelte
+++ b/packages/sdks/snippets/sveltekit/src/routes/blogs/[handle]/+page.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import type { PageData } from './$types';
   import { Content, isPreviewing } from '@builder.io/sdk-svelte';
-  export let data: PageData;
+  interface Props {
+    data: PageData;
+  }
+
+  let { data }: Props = $props();
   const { article } = data;
   const model = 'blog-article';
   const apiKey = 'ee9f13b4981e489a9a1209887695ef2b';

--- a/packages/sdks/snippets/sveltekit/src/routes/custom-child/+page.svelte
+++ b/packages/sdks/snippets/sveltekit/src/routes/custom-child/+page.svelte
@@ -3,7 +3,11 @@
   import type { PageData } from './$types';
   import { customHeroInfo } from './CustomHeroInfo';
 
-  export let data: PageData;
+  interface Props {
+    data: PageData;
+  }
+
+  let { data }: Props = $props();
 </script>
 
 {#if !data.data && !isPreviewing(data.searchParams)}

--- a/packages/sdks/snippets/sveltekit/src/routes/custom-child/CustomHero.svelte
+++ b/packages/sdks/snippets/sveltekit/src/routes/custom-child/CustomHero.svelte
@@ -1,5 +1,13 @@
+<script lang="ts">
+  interface Props {
+    children?: import('svelte').Snippet;
+  }
+
+  let { children }: Props = $props();
+</script>
+
 <section>
   <div>This is text from your component</div>
   <!-- The slot will render any child blocks from Builder -->
-  <slot />
+  {@render children?.()}
 </section>

--- a/packages/sdks/snippets/sveltekit/src/routes/editable-region/+page.svelte
+++ b/packages/sdks/snippets/sveltekit/src/routes/editable-region/+page.svelte
@@ -3,7 +3,11 @@
   import type { PageData } from './$types';
   import { CustomColumnsInfo } from './CustomColumnsInfo';
 
-  export let data: PageData;
+  interface Props {
+    data: PageData;
+  }
+
+  let { data }: Props = $props();
 </script>
 
 {#if !data.data && !isPreviewing(data.searchParams)}

--- a/packages/sdks/snippets/sveltekit/src/routes/editable-region/CustomColumns.svelte
+++ b/packages/sdks/snippets/sveltekit/src/routes/editable-region/CustomColumns.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
   import { Blocks, type BuilderBlock } from '@builder.io/sdk-svelte';
 
-  export let column1: BuilderBlock[];
-  export let column2: BuilderBlock[];
-  export let builderBlock: BuilderBlock;
+  interface Props {
+    column1: BuilderBlock[];
+    column2: BuilderBlock[];
+    builderBlock: BuilderBlock;
+  }
+
+  let { column1, column2, builderBlock }: Props = $props();
 </script>
 
 <!-- Left Column -->

--- a/packages/sdks/snippets/sveltekit/src/routes/home/+page.svelte
+++ b/packages/sdks/snippets/sveltekit/src/routes/home/+page.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import { Content, isPreviewing } from '@builder.io/sdk-svelte';
   import type { PageData } from './$types';
-  export let data: PageData;
+  interface Props {
+    data: PageData;
+  }
+
+  let { data }: Props = $props();
 </script>
 
 {#if !data.content && !isPreviewing(data.searchParams)}

--- a/packages/sdks/snippets/sveltekit/src/routes/landing-page/+page.svelte
+++ b/packages/sdks/snippets/sveltekit/src/routes/landing-page/+page.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import type { BuilderContent } from '@builder.io/sdk-svelte';
-  export let data: { links: BuilderContent | null };
   import NavBar from './NavBar.svelte';
+  interface Props {
+    data: { links: BuilderContent | null };
+  }
+
+  let { data }: Props = $props();
 </script>
 
 <nav>

--- a/packages/sdks/snippets/sveltekit/src/routes/landing-page/NavBar.svelte
+++ b/packages/sdks/snippets/sveltekit/src/routes/landing-page/NavBar.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import type { BuilderContent } from '@builder.io/sdk-svelte';
-  export let links: BuilderContent;
+  interface Props {
+    links: BuilderContent;
+  }
+
+  let { links }: Props = $props();
 </script>
 
 {#if links.data?.links}

--- a/packages/sdks/snippets/sveltekit/src/routes/live-preview/+page.svelte
+++ b/packages/sdks/snippets/sveltekit/src/routes/live-preview/+page.svelte
@@ -3,7 +3,7 @@
   import { onMount } from 'svelte';
   import { subscribeToEditor } from '@builder.io/sdk-svelte';
 
-  let content: BuilderContent | null = null;
+  let content: BuilderContent | null = $state(null);
 
   onMount(() => {
     let unsubscribe = subscribeToEditor({

--- a/packages/sdks/snippets/sveltekit/src/routes/marketing-event/+page.svelte
+++ b/packages/sdks/snippets/sveltekit/src/routes/marketing-event/+page.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import { Content, isPreviewing } from '@builder.io/sdk-svelte';
   import type { PageData } from './$types';
-  export let data: PageData;
+  interface Props {
+    data: PageData;
+  }
+
+  let { data }: Props = $props();
 </script>
 
 <!-- Your nav goes here -->

--- a/packages/sdks/snippets/sveltekit/src/routes/product/category/[handle]/+page.svelte
+++ b/packages/sdks/snippets/sveltekit/src/routes/product/category/[handle]/+page.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import type { PageData } from './$types';
-  export let data: PageData;
+  interface Props {
+    data: PageData;
+  }
+
+  let { data }: Props = $props();
 </script>
 
 {#if !data.productDetails}

--- a/packages/sdks/snippets/sveltekit/src/routes/products/ProductInfo.svelte
+++ b/packages/sdks/snippets/sveltekit/src/routes/products/ProductInfo.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  export let product: {
+  interface Props {
+    product: {
     id: number;
     title: string;
     price: number;
@@ -8,6 +9,9 @@
     image: string;
     rating: { rate: number; count: number };
   } | null;
+  }
+
+  let { product }: Props = $props();
 </script>
 
 {#if product}

--- a/packages/sdks/snippets/sveltekit/src/routes/products/[handle]/+page.svelte
+++ b/packages/sdks/snippets/sveltekit/src/routes/products/[handle]/+page.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
   import type { PageData } from './$types';
-  export let data: PageData;
 
   import ProductHeader from '../ProductHeader.svelte';
   import ProductFooter from '../ProductFooter.svelte';
   import ProductInfo from '../ProductInfo.svelte';
   import { Content, isPreviewing } from '@builder.io/sdk-svelte';
+  interface Props {
+    data: PageData;
+  }
+
+  let { data }: Props = $props();
 </script>
 
 {#if !data.product && !data.editorial && !isPreviewing()}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7170,7 +7170,7 @@ __metadata:
     "@sveltejs/kit": ^1.22.4
     "@sveltejs/package": ^2.2.0
     isolated-vm: ^6.0.0
-    svelte: ^4.1.2
+    svelte: ^5.43.6
     svelte-check: ^3.4.6
     svelte-preprocess: ^5.0.4
     tslib: ^2.3.1
@@ -13429,6 +13429,16 @@ __metadata:
     "@jridgewell/sourcemap-codec": ^1.4.10
     "@jridgewell/trace-mapping": ^0.3.24
   checksum: ff7a1764ebd76a5e129c8890aa3e2f46045109dabde62b0b6c6a250152227647178ff2069ea234753a690d8f3c4ac8b5e7b267bbee272bffb7f3b0a370ab6e52
+  languageName: node
+  linkType: hard
+
+"@jridgewell/remapping@npm:^2.3.4":
+  version: 2.3.5
+  resolution: "@jridgewell/remapping@npm:2.3.5"
+  dependencies:
+    "@jridgewell/gen-mapping": ^0.3.5
+    "@jridgewell/trace-mapping": ^0.3.24
+  checksum: 4a66a7397c3dc9c6b5c14a0024b1f98c5e1d90a0dbc1e5955b5038f2db339904df2a0ee8a66559fafb4fc23ff33700a2639fd40bbdd2e9e82b58b3bdf83738e3
   languageName: node
   linkType: hard
 
@@ -20614,6 +20624,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sveltejs/acorn-typescript@npm:^1.0.5":
+  version: 1.0.6
+  resolution: "@sveltejs/acorn-typescript@npm:1.0.6"
+  peerDependencies:
+    acorn: ^8.9.0
+  checksum: 2e0dbaaec570a1e237b49d9bc90fccfec491e648808786ae9a429bd686ff17e3b10e0d2ea22d3dca00f2917719bee3269adff63af5958946c7340dfb8f87de78
+  languageName: node
+  linkType: hard
+
 "@sveltejs/adapter-auto@npm:^2.1.0":
   version: 2.1.1
   resolution: "@sveltejs/adapter-auto@npm:2.1.1"
@@ -25194,7 +25213,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-query@npm:^5.3.2":
+"aria-query@npm:^5.3.1, aria-query@npm:^5.3.2":
   version: 5.3.2
   resolution: "aria-query@npm:5.3.2"
   checksum: d971175c85c10df0f6d14adfe6f1292409196114ab3c62f238e208b53103686f46cc70695a4f775b73bc65f6a09b6a092fd963c4f3a5a7d690c8fc5094925717
@@ -28591,6 +28610,13 @@ __metadata:
   version: 0.1.19
   resolution: "clone@npm:0.1.19"
   checksum: 5e710e16da67abe30c0664c8fd69c280635be59a4fae0a5fe58ed324e701e99348b48ce67288716fa223edd42ba574e58a3783cb2fcfa381b8b49ce7e56ac3f4
+  languageName: node
+  linkType: hard
+
+"clsx@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "clsx@npm:2.1.1"
+  checksum: acd3e1ab9d8a433ecb3cc2f6a05ab95fe50b4a3cfc5ba47abb6cbf3754585fcb87b84e90c822a1f256c4198e3b41c7f6c391577ffc8678ad587fc0976b24fd57
   languageName: node
   linkType: hard
 
@@ -34901,6 +34927,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esm-env@npm:^1.2.1":
+  version: 1.2.2
+  resolution: "esm-env@npm:1.2.2"
+  checksum: 3fb28f6f84b33219df8bf15ea0efcb1110512199014072a19e90c2ea37316dccb6309c90230d760c4c28a324ebc5ebecf0af809cefebe7558730bd6d401c93b5
+  languageName: node
+  linkType: hard
+
 "espree@npm:^9.6.0, espree@npm:^9.6.1":
   version: 9.6.1
   resolution: "espree@npm:9.6.1"
@@ -34928,6 +34961,15 @@ __metadata:
   dependencies:
     estraverse: ^5.1.0
   checksum: aefb0d2596c230118656cd4ec7532d447333a410a48834d80ea648b1e7b5c9bc9ed8b5e33a89cb04e487b60d622f44cf5713bf4abed7c97343edefdc84a35900
+  languageName: node
+  linkType: hard
+
+"esrap@npm:^2.1.0":
+  version: 2.1.2
+  resolution: "esrap@npm:2.1.2"
+  dependencies:
+    "@jridgewell/sourcemap-codec": ^1.4.15
+  checksum: b3b169ef9c878ea55736ff0e059fa348b6be7b23f77e893148c97c15dd69a97812e148c8c2ce8ea439dffe5f506631a4a7d44889dcaa8654bf3c0355ef43da99
   languageName: node
   linkType: hard
 
@@ -40424,6 +40466,15 @@ __metadata:
   dependencies:
     "@types/estree": "*"
   checksum: ac3bf5626fe9d0afbd7454760d73c47f16b9f471401b9749721ad3b66f0a39644390382acf88ca9d029c95782c1e2ec65662855e3ba91acf52d82231247a7fd3
+  languageName: node
+  linkType: hard
+
+"is-reference@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "is-reference@npm:3.0.3"
+  dependencies:
+    "@types/estree": ^1.0.6
+  checksum: 11371fb2669a8144bffb2ae9bd11b0342b7dc384c3c0f8d5996566b071614282a3a0d306fd2fd1c6b4c9078d0e2703d191b47f4f78f9ce08f464c44a3a412412
   languageName: node
   linkType: hard
 
@@ -59386,27 +59437,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"svelte@npm:^4.1.2":
-  version: 4.2.8
-  resolution: "svelte@npm:4.2.8"
-  dependencies:
-    "@ampproject/remapping": ^2.2.1
-    "@jridgewell/sourcemap-codec": ^1.4.15
-    "@jridgewell/trace-mapping": ^0.3.18
-    acorn: ^8.9.0
-    aria-query: ^5.3.0
-    axobject-query: ^3.2.1
-    code-red: ^1.0.3
-    css-tree: ^2.3.1
-    estree-walker: ^3.0.3
-    is-reference: ^3.0.1
-    locate-character: ^3.0.0
-    magic-string: ^0.30.4
-    periscopic: ^3.1.0
-  checksum: ef90cee2a88675faa17537d68c4d121c5c89fb5b71d6bb6e7c47bdfc68e13338d1c1673a892cf87faac13c6614e186068e895f8849555d9d2e083e3783f9b3e8
-  languageName: node
-  linkType: hard
-
 "svelte@npm:^4.2.12, svelte@npm:^4.2.7":
   version: 4.2.17
   resolution: "svelte@npm:4.2.17"
@@ -59448,6 +59478,28 @@ __metadata:
     magic-string: ^0.30.4
     periscopic: ^3.1.0
   checksum: 6bf48106adfd61ce8720bc0d70c177f64c1957959ffbb1560381a7b68a010dfa7b9d99147952c35475192dd2c56db6f3573f2676c4e585847ffcbeeec737090f
+  languageName: node
+  linkType: hard
+
+"svelte@npm:^5.43.6":
+  version: 5.43.6
+  resolution: "svelte@npm:5.43.6"
+  dependencies:
+    "@jridgewell/remapping": ^2.3.4
+    "@jridgewell/sourcemap-codec": ^1.5.0
+    "@sveltejs/acorn-typescript": ^1.0.5
+    "@types/estree": ^1.0.5
+    acorn: ^8.12.1
+    aria-query: ^5.3.1
+    axobject-query: ^4.1.0
+    clsx: ^2.1.1
+    esm-env: ^1.2.1
+    esrap: ^2.1.0
+    is-reference: ^3.0.3
+    locate-character: ^3.0.0
+    magic-string: ^0.30.11
+    zimmerframe: ^1.1.2
+  checksum: c79fb0432d097d583e497e2b1fd4ecb181c68e09de10f1dca2e9135ed0e06ce19b107a99fec293d2ebfad13fcc6393ec4b144034876b04ccf40973d2c46622d4
   languageName: node
   linkType: hard
 
@@ -65578,6 +65630,13 @@ __metadata:
   version: 2.2.4
   resolution: "zhead@npm:2.2.4"
   checksum: 22836aa6947b27d35176cde40e3f5b19c24e0f46ee52d860e8df674a35aec07b34f6c78437323c797d1dc37ec0847e61e4f07ab605d519cc742245b5fa25b889
+  languageName: node
+  linkType: hard
+
+"zimmerframe@npm:^1.1.2":
+  version: 1.1.4
+  resolution: "zimmerframe@npm:1.1.4"
+  checksum: f7917916db73ad09c4870dc7045fdefb9f0122257878ec53e75ff6ea633718369b99185a21aae1fed1d258e7d66d95080169ef1a386c599b8b912467f17932bc
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8159,13 +8159,13 @@ __metadata:
   dependencies:
     "@builder.io/sdk-svelte": "workspace:*"
     "@sdk/tests": "workspace:*"
-    "@sveltejs/vite-plugin-svelte": ^2.0.3
+    "@sveltejs/vite-plugin-svelte": ^4.0.0
     "@tsconfig/svelte": ^4.0.1
     svelte: ^5.0.0
-    svelte-check: ^3.4.6
+    svelte-check: ^4.0.0
     tslib: ^2.5.0
-    typescript: ^5.1.6
-    vite: ^4.5.11
+    typescript: ^5.5.0
+    vite: ^5.4.4
   languageName: unknown
   linkType: soft
 
@@ -20806,7 +20806,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sveltejs/vite-plugin-svelte@npm:^2.0.3, @sveltejs/vite-plugin-svelte@npm:^2.5.0":
+"@sveltejs/vite-plugin-svelte@npm:^2.5.0":
   version: 2.5.3
   resolution: "@sveltejs/vite-plugin-svelte@npm:2.5.3"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -13487,6 +13487,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/sourcemap-codec@npm:^1.5.5":
+  version: 1.5.5
+  resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
+  checksum: c2e36e67971f719a8a3a85ef5a5f580622437cc723c35d03ebd0c9c0b06418700ef006f58af742791f71f6a4fc68fcfaf1f6a74ec2f9a3332860e9373459dae7
+  languageName: node
+  linkType: hard
+
 "@jridgewell/trace-mapping@npm:0.3.9":
   version: 0.3.9
   resolution: "@jridgewell/trace-mapping@npm:0.3.9"
@@ -20333,14 +20340,14 @@ __metadata:
   resolution: "@snippet/svelte@workspace:packages/sdks/snippets/svelte"
   dependencies:
     "@builder.io/sdk-svelte": "workspace:*"
-    "@sveltejs/vite-plugin-svelte": ^3.0.2
+    "@sveltejs/vite-plugin-svelte": ^4.0.0
     "@tsconfig/svelte": ^5.0.2
     svelte: ^5.0.0
-    svelte-check: ^3.6.7
+    svelte-check: ^4.0.0
     svelte-routing: ^2.13.0
     tslib: ^2.6.2
-    typescript: ^5.2.2
-    vite: ^5.2.0
+    typescript: ^5.5.0
+    vite: ^5.4.4
   languageName: unknown
   linkType: soft
 
@@ -20787,6 +20794,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sveltejs/vite-plugin-svelte-inspector@npm:^3.0.0-next.0||^3.0.0":
+  version: 3.0.1
+  resolution: "@sveltejs/vite-plugin-svelte-inspector@npm:3.0.1"
+  dependencies:
+    debug: ^4.3.7
+  peerDependencies:
+    "@sveltejs/vite-plugin-svelte": ^4.0.0-next.0||^4.0.0
+    svelte: ^5.0.0-next.96 || ^5.0.0
+    vite: ^5.0.0
+  checksum: 03d0c4610b9a899255e978aa5b6a29b87630942e0b8a949c8ea2b2ca7ff24efa485000c1c65138001c13682620d41c0011178e90fdf880fa6b4bb1f2e90ec7ab
+  languageName: node
+  linkType: hard
+
 "@sveltejs/vite-plugin-svelte@npm:^2.0.3, @sveltejs/vite-plugin-svelte@npm:^2.5.0":
   version: 2.5.3
   resolution: "@sveltejs/vite-plugin-svelte@npm:2.5.3"
@@ -20805,7 +20825,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sveltejs/vite-plugin-svelte@npm:^3.0.0, @sveltejs/vite-plugin-svelte@npm:^3.0.2":
+"@sveltejs/vite-plugin-svelte@npm:^3.0.0":
   version: 3.1.0
   resolution: "@sveltejs/vite-plugin-svelte@npm:3.1.0"
   dependencies:
@@ -20820,6 +20840,23 @@ __metadata:
     svelte: ^4.0.0 || ^5.0.0-next.0
     vite: ^5.0.0
   checksum: 7d99c058feecf2cc5d6adac0185d128f386a63e98b25c3cdfb37af326036769015904fd01938756039128b23792874c4526025df5381e31f9de85682f88ead65
+  languageName: node
+  linkType: hard
+
+"@sveltejs/vite-plugin-svelte@npm:^4.0.0":
+  version: 4.0.4
+  resolution: "@sveltejs/vite-plugin-svelte@npm:4.0.4"
+  dependencies:
+    "@sveltejs/vite-plugin-svelte-inspector": ^3.0.0-next.0||^3.0.0
+    debug: ^4.3.7
+    deepmerge: ^4.3.1
+    kleur: ^4.1.5
+    magic-string: ^0.30.12
+    vitefu: ^1.0.3
+  peerDependencies:
+    svelte: ^5.0.0-next.96 || ^5.0.0
+    vite: ^5.0.0
+  checksum: 7f10dd92b5ccb79b2725fa830d89fd81535c65cfc691397e2fbe5f0982906859b5123a354b4784dde56a19984a38f33c61a09f81ab1c34c2b8ce827b50963f5f
   languageName: node
   linkType: hard
 
@@ -45033,6 +45070,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"magic-string@npm:^0.30.12":
+  version: 0.30.21
+  resolution: "magic-string@npm:0.30.21"
+  dependencies:
+    "@jridgewell/sourcemap-codec": ^1.5.5
+  checksum: 4ff76a4e8d439431cf49f039658751ed351962d044e5955adc257489569bd676019c906b631f86319217689d04815d7d064ee3ff08ab82ae65b7655a7e82a414
+  languageName: node
+  linkType: hard
+
 "magic-string@npm:^0.30.17":
   version: 0.30.17
   resolution: "magic-string@npm:0.30.17"
@@ -59240,7 +59286,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"svelte-check@npm:^3.6.0, svelte-check@npm:^3.6.7":
+"svelte-check@npm:^3.6.0":
   version: 3.7.1
   resolution: "svelte-check@npm:3.7.1"
   dependencies:
@@ -59257,6 +59303,24 @@ __metadata:
   bin:
     svelte-check: bin/svelte-check
   checksum: bb0b15f1a0b9d42c1788a6aa965810a5c53f13037ac60eecc1535fefa2a27732017e3ae05319d5f255e168100a9260f88071c0d3ccde0b7a28224cc57e3261e2
+  languageName: node
+  linkType: hard
+
+"svelte-check@npm:^4.0.0":
+  version: 4.3.4
+  resolution: "svelte-check@npm:4.3.4"
+  dependencies:
+    "@jridgewell/trace-mapping": ^0.3.25
+    chokidar: ^4.0.1
+    fdir: ^6.2.0
+    picocolors: ^1.0.0
+    sade: ^1.7.4
+  peerDependencies:
+    svelte: ^4.0.0 || ^5.0.0-next.0
+    typescript: ">=5.0.0"
+  bin:
+    svelte-check: bin/svelte-check
+  checksum: 1c125edf689a540e8af7a0afc528391bb74395ce3a83f223733a62ad8f2a8682f9b48699b3953573a519ded9b2e52019c1f4503f59ef702744ead3cdd437752c
   languageName: node
   linkType: hard
 
@@ -61150,6 +61214,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^5.5.0":
+  version: 5.9.3
+  resolution: "typescript@npm:5.9.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 0d0ffb84f2cd072c3e164c79a2e5a1a1f4f168e84cb2882ff8967b92afe1def6c2a91f6838fb58b168428f9458c57a2ba06a6737711fdd87a256bbe83e9a217f
+  languageName: node
+  linkType: hard
+
 "typescript@npm:~5.0.4":
   version: 5.0.4
   resolution: "typescript@npm:5.0.4"
@@ -61237,6 +61311,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 633cd749d6cd7bc842c6b6245847173bba99742a60776fae3c0fbcc0d1733cd51a733995e5f4dadd8afb0e64e57d3c7dbbeae953a072ee303940eca69e22f311
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^5.5.0#~builtin<compat/typescript>":
+  version: 5.9.3
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#~builtin<compat/typescript>::version=5.9.3&hash=14eedb"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 8bb8d86819ac86a498eada254cad7fb69c5f74778506c700c2a712daeaff21d3a6f51fd0d534fe16903cb010d1b74f89437a3d02d4d0ff5ca2ba9a4660de8497
   languageName: node
   linkType: hard
 
@@ -63600,6 +63684,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite@npm:^5.4.4":
+  version: 5.4.21
+  resolution: "vite@npm:5.4.21"
+  dependencies:
+    esbuild: ^0.21.3
+    fsevents: ~2.3.3
+    postcss: ^8.4.43
+    rollup: ^4.20.0
+  peerDependencies:
+    "@types/node": ^18.0.0 || >=20.0.0
+    less: "*"
+    lightningcss: ^1.21.0
+    sass: "*"
+    sass-embedded: "*"
+    stylus: "*"
+    sugarss: "*"
+    terser: ^5.4.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 7177fa03cff6a382f225290c9889a0d0e944d17eab705bcba89b58558a6f7adfa1f47e469b88f42a044a0eb40c12a1bf68b3cb42abb5295d04f9d7d4dd320837
+  languageName: node
+  linkType: hard
+
 "vite@npm:~5.4.17":
   version: 5.4.19
   resolution: "vite@npm:5.4.19"
@@ -63652,6 +63779,18 @@ __metadata:
     vite:
       optional: true
   checksum: 1a58f3f8b2fe493f595952ad2e8d2876a18e2de16b211c2e795af879863948db838bdcc962d300c7fbd8d827ee616905d7799c30a46206a045aec5f7c8e5031b
+  languageName: node
+  linkType: hard
+
+"vitefu@npm:^1.0.3":
+  version: 1.1.1
+  resolution: "vitefu@npm:1.1.1"
+  peerDependencies:
+    vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
+  peerDependenciesMeta:
+    vite:
+      optional: true
+  checksum: 58de990bb7b4665969627034067c3892c7483ed52eb996d6a1353e76a45feee43117a04bfef806d7670136d895f6935cf7c0c143148954583094ff274fcccfdb
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8180,7 +8180,7 @@ __metadata:
     svelte: ^5.0.0
     svelte-check: ^4.0.5
     tslib: ^2.4.1
-    typescript: ^5.1.6
+    typescript: ^5.5.0
     vite: ^5.4.9
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -7170,7 +7170,7 @@ __metadata:
     "@sveltejs/kit": ^1.22.4
     "@sveltejs/package": ^2.2.0
     isolated-vm: ^6.0.0
-    svelte: ^5.43.6
+    svelte: ^5.0.0
     svelte-check: ^3.4.6
     svelte-preprocess: ^5.0.4
     tslib: ^2.3.1
@@ -59481,7 +59481,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"svelte@npm:^5.43.6":
+"svelte@npm:^5.0.0":
   version: 5.43.6
   resolution: "svelte@npm:5.43.6"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,7 +72,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ampproject/remapping@npm:2.2.1, @ampproject/remapping@npm:^2.2.0, @ampproject/remapping@npm:^2.2.1":
+"@ampproject/remapping@npm:2.2.1, @ampproject/remapping@npm:^2.2.0":
   version: 2.2.1
   resolution: "@ampproject/remapping@npm:2.2.1"
   dependencies:
@@ -7177,7 +7177,7 @@ __metadata:
     typescript: ^5.1.6
     vite: ^4.5.11
   peerDependencies:
-    svelte: ^4.1.2
+    svelte: ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -8161,7 +8161,7 @@ __metadata:
     "@sdk/tests": "workspace:*"
     "@sveltejs/vite-plugin-svelte": ^2.0.3
     "@tsconfig/svelte": ^4.0.1
-    svelte: ^3.57.0
+    svelte: ^5.0.0
     svelte-check: ^3.4.6
     tslib: ^2.5.0
     typescript: ^5.1.6
@@ -8177,7 +8177,7 @@ __metadata:
     "@sdk/tests": "workspace:*"
     "@sveltejs/adapter-auto": ^3.2.5
     "@sveltejs/kit": ^2.8.3
-    svelte: ^4.2.19
+    svelte: ^5.0.0
     svelte-check: ^4.0.5
     tslib: ^2.4.1
     typescript: ^5.1.6
@@ -20335,7 +20335,7 @@ __metadata:
     "@builder.io/sdk-svelte": "workspace:*"
     "@sveltejs/vite-plugin-svelte": ^3.0.2
     "@tsconfig/svelte": ^5.0.2
-    svelte: ^4.2.12
+    svelte: ^5.0.0
     svelte-check: ^3.6.7
     svelte-routing: ^2.13.0
     tslib: ^2.6.2
@@ -20352,7 +20352,7 @@ __metadata:
     "@sveltejs/adapter-auto": ^3.0.0
     "@sveltejs/kit": ^2.0.0
     "@sveltejs/vite-plugin-svelte": ^3.0.0
-    svelte: ^4.2.7
+    svelte: ^5.0.0
     svelte-check: ^3.6.0
     tslib: ^2.4.1
     typescript: ^5.0.0
@@ -21408,7 +21408,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:1.0.5, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.1":
+"@types/estree@npm:*, @types/estree@npm:1.0.5, @types/estree@npm:^1.0.0":
   version: 1.0.5
   resolution: "@types/estree@npm:1.0.5"
   checksum: dd8b5bed28e6213b7acd0fb665a84e693554d850b0df423ac8076cc3ad5823a6bc26b0251d080bdc545af83179ede51dd3f6fa78cad2c46ed1f29624ddf3e41a
@@ -25901,15 +25901,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axobject-query@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "axobject-query@npm:4.0.0"
-  dependencies:
-    dequal: ^2.0.3
-  checksum: 97bcf61f22756a4d5c4da17465725ad034780705a0bb47c08cc7009d43a7a52b40e7be507da017b14b4c7c7bfb59392f48738228f1d401e041bd536fe8a9b600
-  languageName: node
-  linkType: hard
-
 "axobject-query@npm:^4.1.0":
   version: 4.1.0
   resolution: "axobject-query@npm:4.1.0"
@@ -28647,19 +28638,6 @@ __metadata:
   dependencies:
     convert-to-spaces: ^2.0.1
   checksum: d57137d8f4825879283a828cc02a1115b56858dc54ed06c625c8f67d6685d1becd2fbaa7f0ab19ecca1f5cca03f8c97bbc1f013cab40261e4d3275032e65efe9
-  languageName: node
-  linkType: hard
-
-"code-red@npm:^1.0.3":
-  version: 1.0.4
-  resolution: "code-red@npm:1.0.4"
-  dependencies:
-    "@jridgewell/sourcemap-codec": ^1.4.15
-    "@types/estree": ^1.0.1
-    acorn: ^8.10.0
-    estree-walker: ^3.0.3
-    periscopic: ^3.1.0
-  checksum: ca534d9daf0fb50f8180dd5cb2de9f670264584d1132e00743967c626888a253639023ae147687201b50d25e2fa31c2d100908d7a9286721c47e05c0079b64bd
   languageName: node
   linkType: hard
 
@@ -40460,7 +40438,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-reference@npm:^3.0.0, is-reference@npm:^3.0.1":
+"is-reference@npm:^3.0.0":
   version: 3.0.2
   resolution: "is-reference@npm:3.0.2"
   dependencies:
@@ -51273,7 +51251,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"periscopic@npm:^3.0.0, periscopic@npm:^3.1.0":
+"periscopic@npm:^3.0.0":
   version: 3.1.0
   resolution: "periscopic@npm:3.1.0"
   dependencies:
@@ -59430,54 +59408,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"svelte@npm:^3.30.0, svelte@npm:^3.57.0":
+"svelte@npm:^3.30.0":
   version: 3.59.2
   resolution: "svelte@npm:3.59.2"
   checksum: 3e9d770292ab5a0061ff2d3a6f77b323014399de7458371ab507465f9860d04d0c8c7a50239d15c78b920cd42065953e3c4a36abb69a2285c52c825017621444
-  languageName: node
-  linkType: hard
-
-"svelte@npm:^4.2.12, svelte@npm:^4.2.7":
-  version: 4.2.17
-  resolution: "svelte@npm:4.2.17"
-  dependencies:
-    "@ampproject/remapping": ^2.2.1
-    "@jridgewell/sourcemap-codec": ^1.4.15
-    "@jridgewell/trace-mapping": ^0.3.18
-    "@types/estree": ^1.0.1
-    acorn: ^8.9.0
-    aria-query: ^5.3.0
-    axobject-query: ^4.0.0
-    code-red: ^1.0.3
-    css-tree: ^2.3.1
-    estree-walker: ^3.0.3
-    is-reference: ^3.0.1
-    locate-character: ^3.0.0
-    magic-string: ^0.30.4
-    periscopic: ^3.1.0
-  checksum: f06ae5a8e14f03fb78a1b70d14ca2d66cb8cf7ef06a20f9432ec8ad0327072531181a8623a0fce20ffbb661e13c1a438e56843ca2ace835d85ec17c975c36d71
-  languageName: node
-  linkType: hard
-
-"svelte@npm:^4.2.19":
-  version: 4.2.19
-  resolution: "svelte@npm:4.2.19"
-  dependencies:
-    "@ampproject/remapping": ^2.2.1
-    "@jridgewell/sourcemap-codec": ^1.4.15
-    "@jridgewell/trace-mapping": ^0.3.18
-    "@types/estree": ^1.0.1
-    acorn: ^8.9.0
-    aria-query: ^5.3.0
-    axobject-query: ^4.0.0
-    code-red: ^1.0.3
-    css-tree: ^2.3.1
-    estree-walker: ^3.0.3
-    is-reference: ^3.0.1
-    locate-character: ^3.0.0
-    magic-string: ^0.30.4
-    periscopic: ^3.1.0
-  checksum: 6bf48106adfd61ce8720bc0d70c177f64c1957959ffbb1560381a7b68a010dfa7b9d99147952c35475192dd2c56db6f3573f2676c4e585847ffcbeeec737090f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -20357,13 +20357,13 @@ __metadata:
   dependencies:
     "@builder.io/sdk-svelte": "workspace:*"
     "@sveltejs/adapter-auto": ^3.0.0
-    "@sveltejs/kit": ^2.0.0
-    "@sveltejs/vite-plugin-svelte": ^3.0.0
+    "@sveltejs/kit": ^2.5.27
+    "@sveltejs/vite-plugin-svelte": ^4.0.0
     svelte: ^5.0.0
-    svelte-check: ^3.6.0
+    svelte-check: ^4.0.0
     tslib: ^2.4.1
-    typescript: ^5.0.0
-    vite: ^5.0.3
+    typescript: ^5.5.0
+    vite: ^5.4.4
   languageName: unknown
   linkType: soft
 
@@ -20631,6 +20631,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@standard-schema/spec@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@standard-schema/spec@npm:1.0.0"
+  checksum: 2d7d73a1c9706622750ab06fc40ef7c1d320b52d5e795f8a1c7a77d0d6a9f978705092bc4149327b3cff4c9a14e5b3800d3b00dc945489175a2d3031ded8332a
+  languageName: node
+  linkType: hard
+
 "@sveltejs/acorn-typescript@npm:^1.0.5":
   version: 1.0.6
   resolution: "@sveltejs/acorn-typescript@npm:1.0.6"
@@ -20699,29 +20706,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sveltejs/kit@npm:^2.0.0":
-  version: 2.5.9
-  resolution: "@sveltejs/kit@npm:2.5.9"
+"@sveltejs/kit@npm:^2.5.27":
+  version: 2.48.4
+  resolution: "@sveltejs/kit@npm:2.48.4"
   dependencies:
+    "@standard-schema/spec": ^1.0.0
+    "@sveltejs/acorn-typescript": ^1.0.5
     "@types/cookie": ^0.6.0
+    acorn: ^8.14.1
     cookie: ^0.6.0
-    devalue: ^5.0.0
-    esm-env: ^1.0.0
-    import-meta-resolve: ^4.0.0
+    devalue: ^5.3.2
+    esm-env: ^1.2.2
     kleur: ^4.1.5
     magic-string: ^0.30.5
     mrmime: ^2.0.0
     sade: ^1.8.1
     set-cookie-parser: ^2.6.0
-    sirv: ^2.0.4
-    tiny-glob: ^0.2.9
+    sirv: ^3.0.0
   peerDependencies:
-    "@sveltejs/vite-plugin-svelte": ^3.0.0
+    "@opentelemetry/api": ^1.0.0
+    "@sveltejs/vite-plugin-svelte": ^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0
     svelte: ^4.0.0 || ^5.0.0-next.0
-    vite: ^5.0.3
+    vite: ^5.0.3 || ^6.0.0 || ^7.0.0-beta.0
+  peerDependenciesMeta:
+    "@opentelemetry/api":
+      optional: true
   bin:
     svelte-kit: svelte-kit.js
-  checksum: 170cd535a87d5a6746ad222e36015edc8811a1f6bdea5fb9e398c17a6260a0f375dfe8b62f85c541420f68391fcdae8c4643be5b28c3630faf09c707fd4f6720
+  checksum: 095a67f2ab48dd8a6cf2a479e21c8fe8786a1d961b2c2bac98137f6d340b11a4b86f4dcb4b103922733432e56e7ebe53b015885e2a9264536776a2a66fc13020
   languageName: node
   linkType: hard
 
@@ -20781,19 +20793,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sveltejs/vite-plugin-svelte-inspector@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "@sveltejs/vite-plugin-svelte-inspector@npm:2.1.0"
-  dependencies:
-    debug: ^4.3.4
-  peerDependencies:
-    "@sveltejs/vite-plugin-svelte": ^3.0.0
-    svelte: ^4.0.0 || ^5.0.0-next.0
-    vite: ^5.0.0
-  checksum: 8ef577bb58f8b7b9ccc2e9fa556490be167bc1dce1b7585d98a33e12bc289c96e35d992925e2875ceb30864577aa5ba80a71d2f3215dc46a78c44f6377fe4ffe
-  languageName: node
-  linkType: hard
-
 "@sveltejs/vite-plugin-svelte-inspector@npm:^3.0.0-next.0||^3.0.0":
   version: 3.0.1
   resolution: "@sveltejs/vite-plugin-svelte-inspector@npm:3.0.1"
@@ -20822,24 +20821,6 @@ __metadata:
     svelte: ^3.54.0 || ^4.0.0 || ^5.0.0-next.0
     vite: ^4.0.0
   checksum: 71e6b047acf2a6cda3c167c2d08b18389694036e26b240c7f1e53968b2cf1e24863a845dd0aa8834a78e7e5b9bff5a63f2b4a8eee148b5f1e1de44924aea33e9
-  languageName: node
-  linkType: hard
-
-"@sveltejs/vite-plugin-svelte@npm:^3.0.0":
-  version: 3.1.0
-  resolution: "@sveltejs/vite-plugin-svelte@npm:3.1.0"
-  dependencies:
-    "@sveltejs/vite-plugin-svelte-inspector": ^2.0.0
-    debug: ^4.3.4
-    deepmerge: ^4.3.1
-    kleur: ^4.1.5
-    magic-string: ^0.30.9
-    svelte-hmr: ^0.16.0
-    vitefu: ^0.2.5
-  peerDependencies:
-    svelte: ^4.0.0 || ^5.0.0-next.0
-    vite: ^5.0.0
-  checksum: 7d99c058feecf2cc5d6adac0185d128f386a63e98b25c3cdfb37af326036769015904fd01938756039128b23792874c4526025df5381e31f9de85682f88ead65
   languageName: node
   linkType: hard
 
@@ -24653,6 +24634,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: 8755074ba55fff94e84e81c72f1013c2d9c78e973c31231c8ae505a5f966859baf654bddd75046bffd73ce816b149298977fff5077a3033dedba0ae2aad152d4
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.14.1":
+  version: 8.15.0
+  resolution: "acorn@npm:8.15.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 309c6b49aedf1a2e34aaf266de06de04aab6eb097c02375c66fdeb0f64556a6a823540409914fb364d9a11bc30d79d485a2eba29af47992d3490e9886c4391c3
   languageName: node
   linkType: hard
 
@@ -31137,17 +31127,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"devalue@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "devalue@npm:5.0.0"
-  checksum: 63723e194f3f17567e3436e63acf41ea286c87f1dc8c51b2e0cd39ee895d84ea10a1c593c862596ae22af732e2ca76f5401ec66de2547e5dd0dbd889fad38c30
-  languageName: node
-  linkType: hard
-
 "devalue@npm:^5.1.0":
   version: 5.1.1
   resolution: "devalue@npm:5.1.1"
   checksum: 3b6a655e97b59b528d68f89d644b4bd7be9cd502e49ed9ae990caac56b93dc015790e2d099f264b1533d7235e14ec9513e92a7bc1b5031d355064bb37dcc99ca
+  languageName: node
+  linkType: hard
+
+"devalue@npm:^5.3.2":
+  version: 5.4.2
+  resolution: "devalue@npm:5.4.2"
+  checksum: 3d4f870532995ee23132fafb57886ed03638c29ededc7f9d23cd5ff3d417860ca7a7fd719adee59b56c23a11de5882deb59874785e2f5685c5a4fd7877f2326e
   languageName: node
   linkType: hard
 
@@ -34942,7 +34932,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esm-env@npm:^1.2.1":
+"esm-env@npm:^1.2.1, esm-env@npm:^1.2.2":
   version: 1.2.2
   resolution: "esm-env@npm:1.2.2"
   checksum: 3fb28f6f84b33219df8bf15ea0efcb1110512199014072a19e90c2ea37316dccb6309c90230d760c4c28a324ebc5ebecf0af809cefebe7558730bd6d401c93b5
@@ -57435,17 +57425,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sirv@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "sirv@npm:2.0.4"
-  dependencies:
-    "@polka/url": ^1.0.0-next.24
-    mrmime: ^2.0.0
-    totalist: ^3.0.0
-  checksum: 6853384a51d6ee9377dd657e2b257e0e98b29abbfbfa6333e105197f0f100c8c56a4520b47028b04ab1833cf2312526206f38fcd4f891c6df453f40da1a15a57
-  languageName: node
-  linkType: hard
-
 "sirv@npm:^3.0.0":
   version: 3.0.0
   resolution: "sirv@npm:3.0.0"
@@ -59286,26 +59265,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"svelte-check@npm:^3.6.0":
-  version: 3.7.1
-  resolution: "svelte-check@npm:3.7.1"
-  dependencies:
-    "@jridgewell/trace-mapping": ^0.3.17
-    chokidar: ^3.4.1
-    fast-glob: ^3.2.7
-    import-fresh: ^3.2.1
-    picocolors: ^1.0.0
-    sade: ^1.7.4
-    svelte-preprocess: ^5.1.3
-    typescript: ^5.0.3
-  peerDependencies:
-    svelte: ^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0
-  bin:
-    svelte-check: bin/svelte-check
-  checksum: bb0b15f1a0b9d42c1788a6aa965810a5c53f13037ac60eecc1535fefa2a27732017e3ae05319d5f255e168100a9260f88071c0d3ccde0b7a28224cc57e3261e2
-  languageName: node
-  linkType: hard
-
 "svelte-check@npm:^4.0.0":
   version: 4.3.4
   resolution: "svelte-check@npm:4.3.4"
@@ -59351,16 +59310,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"svelte-hmr@npm:^0.16.0":
-  version: 0.16.0
-  resolution: "svelte-hmr@npm:0.16.0"
-  peerDependencies:
-    svelte: ^3.19.0 || ^4.0.0
-  checksum: c99a48df9776f47b4262b4a601bead6d100d7a031b13aa1203b97eb456afde7a9a27c4ddb0a66f8b4655f69cf0d955e96dd26040e54d421d431ae01a6c09b918
-  languageName: node
-  linkType: hard
-
-"svelte-preprocess@npm:^5.0.3, svelte-preprocess@npm:^5.1.3":
+"svelte-preprocess@npm:^5.0.3":
   version: 5.1.4
   resolution: "svelte-preprocess@npm:5.1.4"
   dependencies:
@@ -61194,7 +61144,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.0.0, typescript@npm:^5.2.2, typescript@npm:^5.3.2, typescript@npm:~5.4.0, typescript@npm:~5.4.2":
+"typescript@npm:^5.2.2, typescript@npm:^5.3.2, typescript@npm:~5.4.0, typescript@npm:~5.4.2":
   version: 5.4.5
   resolution: "typescript@npm:5.4.5"
   bin:
@@ -61294,7 +61244,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^5.0.0#~builtin<compat/typescript>, typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>, typescript@patch:typescript@^5.3.2#~builtin<compat/typescript>, typescript@patch:typescript@~5.4.0#~builtin<compat/typescript>, typescript@patch:typescript@~5.4.2#~builtin<compat/typescript>":
+"typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>, typescript@patch:typescript@^5.3.2#~builtin<compat/typescript>, typescript@patch:typescript@~5.4.0#~builtin<compat/typescript>, typescript@patch:typescript@~5.4.2#~builtin<compat/typescript>":
   version: 5.4.5
   resolution: "typescript@patch:typescript@npm%3A5.4.5#~builtin<compat/typescript>::version=5.4.5&hash=14eedb"
   bin:
@@ -63524,7 +63474,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^5.0.0, vite@npm:^5.0.3, vite@npm:^5.2.0, vite@npm:^5.2.8":
+"vite@npm:^5.0.0, vite@npm:^5.2.0, vite@npm:^5.2.8":
   version: 5.2.11
   resolution: "vite@npm:5.2.11"
   dependencies:


### PR DESCRIPTION
## Description

To support Svelte 5 in Svelte SDK. Svelte 5 is backwards compatible, supporting the v4 syntax according to this doc: [Svelte 5 migration guide • Svelte Docs](https://svelte.dev/docs/svelte/v5-migration-guide).

FR Request: https://github.com/BuilderIO/builder/issues/3421

_Screenshot_
N/A