### PR TITLE
perf(Blocks,Block): add deep comparison to block/blocks memo call

### DIFF
--- a/.changeset/fair-islands-think.md
+++ b/.changeset/fair-islands-think.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/sdk-react-native": patch
+---
+
+Added deep memo comparison using react-fast-compare.

--- a/packages/sdks/mitosis.config.cjs
+++ b/packages/sdks/mitosis.config.cjs
@@ -174,13 +174,20 @@ const MEMOIZING_BLOCKS_COMPONENT_PLUGIN = () => ({
           imports: { memo: 'memo' },
           path: 'react',
         });
+        json.imports.push({
+          imports: { isEqual: 'default' },
+          path: 'react-fast-compare',
+        });
       }
       if (json.name === 'Blocks') {
         json.imports.push({
           imports: { memo: 'memo' },
           path: 'react',
         });
-
+        json.imports.push({
+          imports: { isEqual: 'default' },
+          path: 'react-fast-compare',
+        });
         json.hooks.init = {
           code: `
             ${json.hooks.init?.code || ''}
@@ -224,6 +231,7 @@ const MEMOIZING_BLOCKS_COMPONENT_PLUGIN = () => ({
             data: { code: 'props.blocks', type: 'single' },
             renderItem: { code: 'renderItem', type: 'single' },
             keyExtractor: { code: 'keyExtractor', type: 'single' },
+            extraData: { code: 'builderContext', type: 'single' },
             removeClippedSubviews: { code: 'true', type: 'single' },
             maxToRenderPerBatch: { code: '10', type: 'single' },
             windowSize: { code: '5', type: 'single' },
@@ -240,13 +248,13 @@ const MEMOIZING_BLOCKS_COMPONENT_PLUGIN = () => ({
       if (json.name === 'Blocks') {
         return code.replace(
           'export default Blocks',
-          'export default memo(Blocks)'
+          'export default memo(Blocks, isEqual)'
         );
       }
       if (json.name === 'Block') {
         return code.replace(
           'export default Block',
-          'export default memo(Block)'
+          'export default memo(Block, isEqual)'
         );
       }
       return code;

--- a/packages/sdks/output/react-native/package.json
+++ b/packages/sdks/output/react-native/package.json
@@ -111,6 +111,7 @@
     "@react-native-async-storage/async-storage": "1.23.1",
     "css-to-react-native": "^3.2.0",
     "isolated-vm": "^6.0.0",
+    "react-fast-compare": "^3.2.2",
     "react-native-storage": "^1.0.1",
     "react-native-video": "^5.1.1"
   },

--- a/packages/sdks/src/functions/evaluate/helpers.ts
+++ b/packages/sdks/src/functions/evaluate/helpers.ts
@@ -133,7 +133,7 @@ export function flattenState({
           rootSetState: rootSetState
             ? (subState) => {
                 target[prop] = subState;
-                rootSetState(target);
+                rootSetState({ ...target });
               }
             : undefined,
         });
@@ -149,8 +149,8 @@ export function flattenState({
       }
 
       target[prop] = value;
-
-      rootSetState?.(target);
+      // Pass a new object reference so React/RN detects the state change
+      rootSetState?.({ ...target });
       return true;
     },
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7093,6 +7093,7 @@ __metadata:
     babel-plugin-module-resolver: ^5.0.0
     css-to-react-native: ^3.2.0
     isolated-vm: ^6.0.0
+    react-fast-compare: ^3.2.2
     react-native-builder-bob: ^0.21.3
     react-native-storage: ^1.0.1
     react-native-url-polyfill: ^2.0.0


### PR DESCRIPTION
## Description

React.memo uses a shallow comparison, which isn't enough in this case.

Using [welldone-software/why-did-you-render](https://github.com/welldone-software/why-did-you-render)

I found our app home-screen content would update 12 times in one load with the wdyr message

"different objects that are equal by value".

This change adds a deep comparison, which when tested via patch-package, eliminated those re-renders.

Note: I tried to base this PR on [the one that initially made these memo changes](https://github.com/BuilderIO/builder/pull/3814/changes/e264c120fd38851208875a9915b55e26e952528f), hope it's okay :)

_Screenshot_

<img width="1722" height="208" alt="CleanShot 2026-01-27 at 19 59 52@2x" src="https://github.com/user-attachments/assets/e20498c5-d909-48da-946f-b8d890275fde" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes React Native rendering behavior by switching `React.memo` to a deep comparator and tweaking state update semantics; could mask legitimate re-renders or add comparison overhead if misapplied.
> 
> **Overview**
> Reduces unnecessary re-renders in the React Native SDK by switching `Block` and `Blocks` from default `React.memo` shallow comparison to a deep equality check via `react-fast-compare`.
> 
> Updates the React Native `Blocks` `FlatList` generation to pass `extraData={builderContext}` to ensure list items refresh when context changes, and adjusts `flattenState` to call `rootSetState` with a new object reference (`{ ...target }`) so React/RN reliably detects state updates.
> 
> Adds `react-fast-compare` as a dependency and includes a patch changeset for `@builder.io/sdk-react-native`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86699fe0593a3d544b8f81df9372fd826401815a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->