### PR TITLE
fix: remove trailing space in button label

### DIFF
--- a/examples/astro-solidjs/src/components/App.jsx
+++ b/examples/astro-solidjs/src/components/App.jsx
@@ -10,7 +10,7 @@ function MyFunComponent({ text }) {
     <div>
       <h3>{text.toUpperCase()}</h3>
       <p>{state.count}</p>
-      <button onClick={() => state.count++}>Click me </button>
+      <button onClick={() => state.count++}>Click me</button>
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-string UI text change in an example app; no logic, API, or data handling impact.
> 
> **Overview**
> Removes a trailing space from the `Click me` button text in `examples/astro-solidjs/src/components/App.jsx` to normalize the UI label.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b4f25034b217e4bc849dc6c56d409719ededa26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->