### PR TITLE
fix[plugin][commerceLayer]: ENG-11355 improve truncation of field labels in commerce layer plugin

### DIFF
--- a/packages/plugin-tools/src/editors/ResourcesPicker.tsx
+++ b/packages/plugin-tools/src/editors/ResourcesPicker.tsx
@@ -70,6 +70,9 @@ export const ResourcePreviewCell: React.FC<ResourcePreviewCellProps> = props =>
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
             }}
+            title={props.resource.title !== 'untitled'
+              ? `${props.resource.title} - ${props.resource.id}`
+              : props.resource.title}
           >
             {props.resource.title !== 'untitled' ? (
               <div>

--- a/packages/plugin-tools/src/editors/ResourcesPicker.tsx
+++ b/packages/plugin-tools/src/editors/ResourcesPicker.tsx
@@ -65,7 +65,7 @@ export const ResourcePreviewCell: React.FC<ResourcePreviewCellProps> = props =>
         primary={
           <div
             css={{
-              maxWidth: 400,
+              width: '100%',
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',


### PR DESCRIPTION
## Description

Long SKU and Bundle names were being truncated too aggressively in the Commerce Layer plugin UI, even when there was enough horizontal space to display more of the label. This PR fixes that issue. 

The `textOverflow: 'ellipsis'` and `whiteSpace: 'nowrap'` are still in place, so long names will truncate gracefully.

_Screenshot_
https://www.loom.com/share/138a0db3ae844a8ebbed8273518d1e4c


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts text layout and adds a tooltip; no data flow or business logic is affected.
> 
> **Overview**
> Improves how resource labels truncate in `ResourcePreviewCell` by removing the fixed `maxWidth: 400` constraint and letting the label use the full available width (`width: '100%'`).
> 
> Adds a `title` attribute so the full resource label (or `title - id`) is available on hover when the text is ellipsized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cdd4703cb4293bf923e896fc5f0dea85b0f275a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->