### PR TITLE
chore[plugins][commercelayer]: bump up versions of plugin-tools and commercelayer

### DIFF
--- a/packages/plugin-tools/package-lock.json
+++ b/packages/plugin-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/plugin-tools",
-  "version": "0.0.6",
+  "version": "0.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-tools",
-      "version": "0.0.6",
+      "version": "0.0.8",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/packages/plugin-tools/package.json
+++ b/packages/plugin-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-tools",
-  "version": "0.0.6",
+  "version": "0.0.8",
   "description": "",
   "keywords": [],
   "main": "dist/index.umd.js",

--- a/plugins/commercelayer/package-lock.json
+++ b/plugins/commercelayer/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@builder.io/plugin-commercelayer",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-commercelayer",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
-        "@builder.io/plugin-tools": "^0.0.6"
+        "@builder.io/plugin-tools": "0.0.8"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^6.1.0",
@@ -30,9 +30,9 @@
       }
     },
     "node_modules/@builder.io/plugin-tools": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@builder.io/plugin-tools/-/plugin-tools-0.0.6.tgz",
-      "integrity": "sha512-XcTQrTpT3XPwEIoKT9gg5WnPsCbURxdPuuUqcoeYI2qKPSMiOGLf7NxhJRwmQySuW6cpLew2gK1qRzgW3ErZhg==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@builder.io/plugin-tools/-/plugin-tools-0.0.8.tgz",
+      "integrity": "sha512-+/txY2WwEygqNyXBKmRvEgdY6UXXL7OAg1vN5eoTfCtHkmBrUkCmCx2rjy/NVT/yKLz2qlTx2C5cRYo8mBwBnw==",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/plugins/commercelayer/package.json
+++ b/plugins/commercelayer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-commercelayer",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Commerce Layer plugin for Builder.io",
   "keywords": [],
   "main": "dist/plugin.system.js",
@@ -41,6 +41,6 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@builder.io/plugin-tools": "^0.0.6"
+    "@builder.io/plugin-tools": "0.0.8"
   }
 }


### PR DESCRIPTION
## Description

Bump up versions of plugin-tools and commerce layer plugin. Note that the version of plugin-tools was 0.0.7 on npm but wasn't updated in the code. That's why, we're now bumping it to 0.0.8. 

Related PR (merged): https://github.com/BuilderIO/builder/pull/4477

_Screenshot_
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump touching only package metadata and lockfiles; main risk is dependency resolution/publishing consistency for `@builder.io/plugin-tools` in the Commerce Layer plugin.
> 
> **Overview**
> Bumps `@builder.io/plugin-tools` from `0.0.6` to `0.0.8` (package + lockfile).
> 
> Releases `@builder.io/plugin-commercelayer` `0.1.4` and pins its dependency on `@builder.io/plugin-tools` to `0.0.8` (was `^0.0.6`), updating the corresponding `package-lock.json` resolved tarball/integrity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b96178db2306c87f6bf97b61b84d5edee5edcd4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->