### PR TITLE
feat[plugins][commerceLayer]: ENG-11943 Display SKU/Bundle Code Instead of ID in Commerce Layer Plugin

### DIFF
--- a/packages/plugin-tools/src/editors/ResourcesPicker.tsx
+++ b/packages/plugin-tools/src/editors/ResourcesPicker.tsx
@@ -71,12 +71,12 @@ export const ResourcePreviewCell: React.FC<ResourcePreviewCellProps> = props =>
               whiteSpace: 'nowrap',
             }}
             title={props.resource.title !== 'untitled'
-              ? `${props.resource.title} - ${props.resource.id}`
+              ? `${props.resource.title} - ${props.resource.handle || props.resource.id}`
               : props.resource.title}
           >
             {props.resource.title !== 'untitled' ? (
               <div>
-                {props.resource.title} - {props.resource.id}
+                {props.resource.title} - {props.resource.handle || props.resource.id}
               </div>
             ) : (
               props.resource.title


### PR DESCRIPTION
## Description

When a SKU or Bundle is selected in the Commerce Layer plugin, the field label displays the internal Commerce Layer ID (e.g., nPwySKzvQM) instead of the human-readable SKU/Bundle code (e.g., 833600101). This makes it difficult for editors to identify which SKU or Bundle is selected at a glance.

The `ResourcePreviewCell` component in `plugin-tools` was using `resource.id` (the internal ID) for the label. We're now using `resource.handle` to display the SKU Code. 

_Screenshot_
**SKU created in Commerce Layer:**
<img width="801" height="685" alt="Screenshot 2026-04-07 at 11 38 05 AM" src="https://github.com/user-attachments/assets/cc6c2685-5f49-47f0-899a-c3c3842f6092" />

**BEFORE:**
<img width="801" height="269" alt="Screenshot 2026-04-07 at 11 37 52 AM" src="https://github.com/user-attachments/assets/604150e2-3f5d-4395-a70a-70da29cf5986" />

**AFTER:**
<img width="795" height="268" alt="Screenshot 2026-04-07 at 11 30 47 AM" src="https://github.com/user-attachments/assets/b9c094d3-ee4a-41c5-bec6-ac2667256d5c" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that affects how selected resources are labeled in the picker/preview, with a safe fallback to `id` when `handle` is missing.
> 
> **Overview**
> Updates `ResourcePreviewCell` in `ResourcesPicker.tsx` to display a resource’s human-friendly `handle` (e.g., SKU/bundle code) alongside the title instead of the internal `id`, falling back to `id` when no `handle` is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88e1e32c3aca4d002c8a425cd5460288fa3dc4ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->