### PR TITLE
chore[plugins][commerceLayer]: ENG-11943 bumping up versions for plugin-tools and commercelayer plugins

### DIFF
--- a/packages/plugin-tools/package-lock.json
+++ b/packages/plugin-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/plugin-tools",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-tools",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/packages/plugin-tools/package.json
+++ b/packages/plugin-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-tools",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "",
   "keywords": [],
   "main": "dist/index.umd.js",

--- a/plugins/commercelayer/package-lock.json
+++ b/plugins/commercelayer/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@builder.io/plugin-commercelayer",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-commercelayer",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
-        "@builder.io/plugin-tools": "0.0.8"
+        "@builder.io/plugin-tools": "0.0.9"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^6.1.0",
@@ -30,9 +30,9 @@
       }
     },
     "node_modules/@builder.io/plugin-tools": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@builder.io/plugin-tools/-/plugin-tools-0.0.8.tgz",
-      "integrity": "sha512-+/txY2WwEygqNyXBKmRvEgdY6UXXL7OAg1vN5eoTfCtHkmBrUkCmCx2rjy/NVT/yKLz2qlTx2C5cRYo8mBwBnw==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@builder.io/plugin-tools/-/plugin-tools-0.0.9.tgz",
+      "integrity": "sha512-zlVOnJ+ubM8mV1AJ+6+j0wgq3ARkOwResRjZnpjPFvRFLh4LDybGadM+xsDeyHY/UMrb1WVX3SspmrSo3PA+YQ==",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/plugins/commercelayer/package.json
+++ b/plugins/commercelayer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-commercelayer",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Commerce Layer plugin for Builder.io",
   "keywords": [],
   "main": "dist/plugin.system.js",
@@ -41,6 +41,6 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@builder.io/plugin-tools": "0.0.8"
+    "@builder.io/plugin-tools": "0.0.9"
   }
 }


### PR DESCRIPTION
## Description

Bumping up the versions for plugin-tools and commercelayer plugins. 

Related PR (merged): https://github.com/BuilderIO/builder/pull/4505

_Screenshot_
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version/lockfile bumps only; main risk is publishing/consuming the new `@builder.io/plugin-tools@0.0.9` package in `plugin-commercelayer` without runtime code changes.
> 
> **Overview**
> Bumps `@builder.io/plugin-tools` from `0.0.8` to `0.0.9` (package + lockfile).
> 
> Bumps `@builder.io/plugin-commercelayer` from `0.1.4` to `0.1.5` and updates its dependency/lockfile to consume `@builder.io/plugin-tools@0.0.9` (including updated tarball integrity metadata).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bf5f7476ff164ba0c874cead875a2ab8b7e7002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->