### PR TITLE
feat(plugin-tools): ENG-12227 add remove button to ResourcesPickerButton

### DIFF
--- a/packages/plugin-tools/package-lock.json
+++ b/packages/plugin-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/plugin-tools",
-  "version": "0.0.9",
+  "version": "0.0.10-2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-tools",
-      "version": "0.0.9",
+      "version": "0.0.10-2",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/packages/plugin-tools/package-lock.json
+++ b/packages/plugin-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/plugin-tools",
-  "version": "0.0.10-2",
+  "version": "0.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-tools",
-      "version": "0.0.10-2",
+      "version": "0.0.10",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/packages/plugin-tools/package.json
+++ b/packages/plugin-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-tools",
-  "version": "0.0.9",
+  "version": "0.0.10-2",
   "description": "",
   "keywords": [],
   "main": "dist/index.umd.js",

--- a/packages/plugin-tools/package.json
+++ b/packages/plugin-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-tools",
-  "version": "0.0.10-2",
+  "version": "0.0.10",
   "description": "",
   "keywords": [],
   "main": "dist/index.umd.js",

--- a/packages/plugin-tools/src/editors/ResourcesPicker.tsx
+++ b/packages/plugin-tools/src/editors/ResourcesPicker.tsx
@@ -333,7 +333,7 @@ export const ResourcesPickerButton: React.FC<ResourcesPickerButtonProps> = props
                 store.resourceHandle = undefined;
                 store.resourceId = undefined;
                 store.resourceInfo = null;
-                props.onChange(null as any);
+                props.onChange(undefined);
               })}
             >
               <Close css={{ color: '#888' }} />

--- a/packages/plugin-tools/src/editors/ResourcesPicker.tsx
+++ b/packages/plugin-tools/src/editors/ResourcesPicker.tsx
@@ -336,7 +336,7 @@ export const ResourcesPickerButton: React.FC<ResourcesPickerButtonProps> = props
                 store.resourceHandle = undefined;
                 store.resourceId = undefined;
                 store.resourceInfo = null;
-                props.onChange(undefined);
+                props.onChange(null);
               })}
             >
               <Close css={{ color: '#888' }} />

--- a/packages/plugin-tools/src/editors/ResourcesPicker.tsx
+++ b/packages/plugin-tools/src/editors/ResourcesPicker.tsx
@@ -13,7 +13,7 @@ import {
   TextField,
   Typography,
 } from '@material-ui/core';
-import { Create, Search } from '@material-ui/icons';
+import { Close, Create, Search } from '@material-ui/icons';
 import { runInAction, action } from 'mobx';
 import { useObserver, useLocalStore } from 'mobx-react';
 import React, { useEffect } from 'react';
@@ -301,11 +301,11 @@ export const ResourcesPickerButton: React.FC<ResourcesPickerButtonProps> = props
               position: 'relative',
             }}
           >
-            <ResourcePreviewCell button css={{ paddingRight: 30 }} resource={store.resourceInfo} />
+            <ResourcePreviewCell button css={{ paddingRight: 70 }} resource={store.resourceInfo} />
             <IconButton
               css={{
                 position: 'absolute',
-                right: 2,
+                right: 42,
                 top: 0,
                 bottom: 0,
                 height: 50,
@@ -317,6 +317,26 @@ export const ResourcesPickerButton: React.FC<ResourcesPickerButtonProps> = props
               }}
             >
               <Create css={{ color: '#888' }} />
+            </IconButton>
+            <IconButton
+              css={{
+                position: 'absolute',
+                right: 2,
+                top: 0,
+                bottom: 0,
+                height: 50,
+                marginTop: 'auto',
+                marginBottom: 'auto',
+                opacity: 0.7,
+              }}
+              onClick={action(() => {
+                store.resourceHandle = undefined;
+                store.resourceId = undefined;
+                store.resourceInfo = null;
+                props.onChange(null as any);
+              })}
+            >
+              <Close css={{ color: '#888' }} />
             </IconButton>
           </Paper>
         )}

--- a/packages/plugin-tools/src/interfaces/custom-react-editor-props.ts
+++ b/packages/plugin-tools/src/interfaces/custom-react-editor-props.ts
@@ -1,6 +1,6 @@
 export interface CustomReactEditorProps<T = any> {
   value?: T;
-  onChange(val: T | undefined): void;
+  onChange(val: T | undefined | null): void;
   context: any;
   field?: any;
 }

--- a/plugins/commercelayer/package-lock.json
+++ b/plugins/commercelayer/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@builder.io/plugin-commercelayer",
-  "version": "0.1.5",
+  "version": "0.1.6-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-commercelayer",
-      "version": "0.1.5",
+      "version": "0.1.6-4",
       "license": "MIT",
       "dependencies": {
-        "@builder.io/plugin-tools": "0.0.9"
+        "@builder.io/plugin-tools": "0.0.10-2"
       },
       "devDependencies": {
+        "@rollup/plugin-commonjs": "^25.0.8",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.0.0",
         "@rollup/plugin-replace": "^5.0.5",
@@ -30,9 +31,9 @@
       }
     },
     "node_modules/@builder.io/plugin-tools": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@builder.io/plugin-tools/-/plugin-tools-0.0.9.tgz",
-      "integrity": "sha512-zlVOnJ+ubM8mV1AJ+6+j0wgq3ARkOwResRjZnpjPFvRFLh4LDybGadM+xsDeyHY/UMrb1WVX3SspmrSo3PA+YQ==",
+      "version": "0.0.10-2",
+      "resolved": "https://registry.npmjs.org/@builder.io/plugin-tools/-/plugin-tools-0.0.10-2.tgz",
+      "integrity": "sha512-51LVY6Q3Z3K64jiLfNkneJ/JlPNGMmiEsEkJdnjaUrX5Z1PWvLpJJOha/u9SnUD/VurFvbA/px+e3gb8jms98Q==",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",
@@ -491,6 +492,76 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "25.0.8",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.8.tgz",
+      "integrity": "sha512-ZEZWTK5n6Qde0to4vS9Mr5x/0UZoqCxPVR9KRUjU4kA2sO7GEUn1fop0DAwpO6z0Nw/kJON9bDmSxdWxO/TT1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.2",
+        "glob": "^8.0.3",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@rollup/plugin-json": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
@@ -945,6 +1016,13 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1157,6 +1235,16 @@
       "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/lodash": {
       "version": "4.17.21",

--- a/plugins/commercelayer/package-lock.json
+++ b/plugins/commercelayer/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@builder.io/plugin-commercelayer",
-  "version": "0.1.6-4",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-commercelayer",
-      "version": "0.1.6-4",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
-        "@builder.io/plugin-tools": "0.0.10-2"
+        "@builder.io/plugin-tools": "0.0.10"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.8",
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@builder.io/plugin-tools": {
-      "version": "0.0.10-2",
-      "resolved": "https://registry.npmjs.org/@builder.io/plugin-tools/-/plugin-tools-0.0.10-2.tgz",
-      "integrity": "sha512-51LVY6Q3Z3K64jiLfNkneJ/JlPNGMmiEsEkJdnjaUrX5Z1PWvLpJJOha/u9SnUD/VurFvbA/px+e3gb8jms98Q==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@builder.io/plugin-tools/-/plugin-tools-0.0.10.tgz",
+      "integrity": "sha512-OgFSlxrZZjARYitZSsBOuL+RKQmQ7tluUwFuqfX+C5BJefrJ7J6Nxc5EyvtJysWq4sPLHnDoIxwYN/g08cuhCA==",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/plugins/commercelayer/package.json
+++ b/plugins/commercelayer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-commercelayer",
-  "version": "0.1.6-4",
+  "version": "0.1.6",
   "description": "Commerce Layer plugin for Builder.io",
   "keywords": [],
   "main": "dist/plugin.system.js",
@@ -42,6 +42,6 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@builder.io/plugin-tools": "0.0.10-2"
+    "@builder.io/plugin-tools": "0.0.10"
   }
 }

--- a/plugins/commercelayer/package.json
+++ b/plugins/commercelayer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-commercelayer",
-  "version": "0.1.5",
+  "version": "0.1.6-4",
   "description": "Commerce Layer plugin for Builder.io",
   "keywords": [],
   "main": "dist/plugin.system.js",
@@ -27,6 +27,7 @@
     "release:patch": "npm run build && npm version patch --no-git-tag-version && npm publish"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^25.0.8",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.0.0",
     "@rollup/plugin-replace": "^5.0.5",
@@ -41,6 +42,6 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@builder.io/plugin-tools": "0.0.9"
+    "@builder.io/plugin-tools": "0.0.10-2"
   }
 }

--- a/plugins/commercelayer/rollup.config.ts
+++ b/plugins/commercelayer/rollup.config.ts
@@ -2,6 +2,7 @@ import replace from '@rollup/plugin-replace';
 import serve from 'rollup-plugin-serve';
 import esbuild from 'rollup-plugin-esbuild';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import { readFileSync } from 'fs';
 
@@ -15,6 +16,7 @@ export default {
   external: [
     'react',
     '@builder.io/react',
+    '@builder.io/sdk',
     '@builder.io/app-context',
     '@material-ui/core',
     '@emotion/core',
@@ -34,9 +36,10 @@ export default {
       preventAssignment: true
     }),
     json(),
-    nodeResolve({ 
+    nodeResolve({
       mainFields: ['module', 'browser']
     }),
+    commonjs(),
     esbuild(),
 
     ...(SERVE
@@ -53,4 +56,4 @@ export default {
         ]
       : []),
   ],
-} 
+}


### PR DESCRIPTION
Commerce plugins (CommerceLayer, SFCC, etc.) had no way to remove a selected resource once added. This adds a Close icon button next to the existing edit button that clears the selection and updates the content JSON, matching the pattern used by the reference field type.

https://www.loom.com/share/10758e859af547dca10fad16fa4bb71e

## Description

## Summary
- Adds a Close (X) icon button next to the existing edit (pencil) button in `ResourcesPickerButton` so users can remove a selected resource
- Clears `resourceHandle`, `resourceId`, `resourceInfo` and calls `onChange(null)` to update the content JSON
- Applies to all commerce plugins (CommerceLayer, Shopify, SFCC, etc.) since they share `@builder.io/plugin-tools`

## Test plan
- [ ] Load a commerce plugin (e.g. CommerceLayer) locally via `npm start`
- [ ] Add a product/resource field to a model and select a product
- [ ] Verify both edit (pencil) and remove (X) buttons appear on the selected resource
- [ ] Click the X button and verify the resource is removed from the UI and cleared from the content JSON
- [ ] Verify clicking "Choose {resourceName}" allows re-selecting a new resource after removal


_Screenshot_
If relevant, add a screenshot or two of the changes you made.
Before:
<img width="1470" height="762" alt="Screenshot 2026-04-13 at 8 33 40 PM" src="https://github.com/user-attachments/assets/deb2033c-be5b-4b8c-9185-73ceb8ee6fac" />

After fix: 

<img width="1470" height="762" alt="Screenshot 2026-04-13 at 8 34 43 PM" src="https://github.com/user-attachments/assets/adb76b2f-1fd5-402c-95aa-ac5b1e23bb9e" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the `CustomReactEditorProps.onChange` type to accept `null`, which may require downstream TypeScript updates, and adjusts CommerceLayer’s build pipeline dependencies/plugins.
> 
> **Overview**
> Adds a **remove (Close/X) action** to `ResourcesPickerButton` so a previously selected commerce resource can be cleared; it resets local selection state and calls `onChange(null)`.
> 
> Updates the shared editor prop type to allow `null` values, bumps `@builder.io/plugin-tools` to `0.0.10`, and updates the CommerceLayer plugin to consume it while also tweaking Rollup config/deps (adds `@rollup/plugin-commonjs` and marks `@builder.io/sdk` as external).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63b86d67f41bf0fd3170df682fe09269d9ddd645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->