### PR TITLE
fix[gen2][react]: ENG-12210 custom component children passed as Fragment instead of array

### DIFF
--- a/.changeset/wet-terms-press.md
+++ b/.changeset/wet-terms-press.md
@@ -1,0 +1,7 @@
+---
+"@builder.io/sdk-react-nextjs": patch
+"@builder.io/sdk-react": patch
+"@builder.io/sdk-react-native": patch
+---
+
+Fix: remove redundant `<Show>` wrapper around `<For>` in `component-ref` that was wrapping custom component `children` in a `React.Fragment`, breaking `React.Children.count` and iteration.

--- a/packages/sdks/src/components/block/components/component-ref/component-ref.lite.tsx
+++ b/packages/sdks/src/components/block/components/component-ref/component-ref.lite.tsx
@@ -51,19 +51,17 @@ export default function ComponentRef(props: ComponentProps) {
           contextValue: props.context.value,
         })}
       >
-        <Show when={props.componentRef}>
-          <For each={props.blockChildren}>
-            {(child) => (
-              <Block
-                key={child.id}
-                block={child}
-                context={props.context}
-                registeredComponents={props.registeredComponents}
-                linkComponent={props.linkComponent}
-              />
-            )}
-          </For>
-        </Show>
+        <For each={props.blockChildren}>
+          {(child) => (
+            <Block
+              key={child.id}
+              block={child}
+              context={props.context}
+              registeredComponents={props.registeredComponents}
+              linkComponent={props.linkComponent}
+            />
+          )}
+        </For>
       </state.Wrapper>
     </Show>
   );

--- a/packages/sdks/src/components/block/components/component-ref/component-ref.lite.tsx
+++ b/packages/sdks/src/components/block/components/component-ref/component-ref.lite.tsx
@@ -35,6 +35,9 @@ export default function ComponentRef(props: ComponentProps) {
           default: InteractiveElement,
         })
       : props.componentRef,
+    get blockChildrenToRender() {
+      return props.componentRef ? props.blockChildren : [];
+    },
   });
 
   return (
@@ -51,7 +54,7 @@ export default function ComponentRef(props: ComponentProps) {
           contextValue: props.context.value,
         })}
       >
-        <For each={props.componentRef ? props.blockChildren : []}>
+        <For each={state.blockChildrenToRender}>
           {(child) => (
             <Block
               key={child.id}

--- a/packages/sdks/src/components/block/components/component-ref/component-ref.lite.tsx
+++ b/packages/sdks/src/components/block/components/component-ref/component-ref.lite.tsx
@@ -51,7 +51,7 @@ export default function ComponentRef(props: ComponentProps) {
           contextValue: props.context.value,
         })}
       >
-        <For each={props.blockChildren}>
+        <For each={props.componentRef ? props.blockChildren : []}>
           {(child) => (
             <Block
               key={child.id}


### PR DESCRIPTION
## Description
- Removed a redundant inner `<Show>` guard in `component-ref.lite.tsx` that caused the React SDKs to wrap children in a `React.Fragment`. 
- There is already an outer `<Show>` guard which is already there to gate rendering based on the `props.componentRef`.
- This broke the React.Children.count in custom components with `canHaveChildren: true`.

_Screenshot_
### Issue
Loom - https://www.loom.com/share/7db1876f7eb84959aa311ef2a9b166d4

### Fix
<img width="1509" height="593" alt="image" src="https://github.com/user-attachments/assets/305b7883-0ac5-4d84-a4e6-9f8d24d729f1" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized rendering change plus version bumps; main risk is subtle regressions in child rendering order/guards for custom components.
> 
> **Overview**
> Fixes custom component `children` rendering in `component-ref` by removing an inner redundant `<Show>` around the `<For>` loop that was causing children to be wrapped in a `React.Fragment`, breaking `React.Children.count` and iteration.
> 
> Adds a small `blockChildrenToRender` computed in state so the `<For>` receives `[]` when `componentRef` is absent, while keeping the existing outer render guard. Includes a patch changeset for `@builder.io/sdk-react`, `@builder.io/sdk-react-nextjs`, and `@builder.io/sdk-react-native`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afdf1e79082aa9b7121fb13e337734316f6bea8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->