### PR TITLE
fix: BuilderComponent injects pixel unconditionally

### DIFF
--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -1173,13 +1173,20 @@ export class BuilderComponent extends React.Component<
                           );
                         }
 
-                        const blocks = data?.blocks || [];
+                        const allBlocks = data?.blocks || [];
+
+                        // Strip the pixel block when tracking is disabled
+                        const blocks = builder.canTrack
+                          ? allBlocks
+                          : allBlocks.filter(
+                              (b: BuilderElement) => !b?.id?.startsWith('builder-pixel')
+                            );
 
                         const hasPixel = blocks.find((block: BuilderElement) =>
                           block.id?.startsWith('builder-pixel')
                         );
 
-                        if (data && !hasPixel && blocks.length > 0) {
+                        if (data && !hasPixel && blocks.length > 0 && builder.canTrack) {
                           blocks.push(getBuilderPixel(builder.apiKey!));
                         }
 


### PR DESCRIPTION
## Description

In React Gen 1 SDK, we can disable tracking by:

```
builder.canTrack = false
OR
window.builderNoTrack = true
```
However, even after setting these, the pixel call (cdn.builder.io/api/v1/pixel) was still being fired, which means that any site was unknowingly firing a tracking request on every page load, even when users had not given consent. 

This PR fixes that issue by respecting the above flags, when set for react gen1 sdk. 

_Screenshot_
Before:
https://www.loom.com/share/7af5a1fac80647278991ef413b7151c0

After:
https://www.loom.com/share/fbd2247d47304adb905a78ab3690c977

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk behavior change limited to tracking: the Builder pixel block is now removed/never appended when `builder.canTrack` is false, which could reduce analytics/events but should not affect page rendering otherwise.
> 
> **Overview**
> Ensures the React Gen1 SDK **fully disables tracking** when `builder.canTrack` (or the underlying `builderNoTrack` flow) is set.
> 
> `BuilderComponent` now filters out any existing `builder-pixel` block when tracking is disabled and only appends a new pixel via `getBuilderPixel()` when tracking is enabled, preventing unwanted `cdn.builder.io/api/v1/pixel` requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f93afdb4ef6b18a7644e2463652d23294b2e57f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->