### PR TITLE
fix[react][gen1]: ENG-12237 handle stateChangeListenerActivated to re-fire state in editor

### DIFF
--- a/.changeset/nervous-planes-raise.md
+++ b/.changeset/nervous-planes-raise.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/react': minor
+---
+
+Improve state inspector reliability in visual editor for gen1 react sdk

--- a/packages/react/src/components/builder-component.component.tsx
+++ b/packages/react/src/components/builder-component.component.tsx
@@ -601,6 +601,8 @@ export class BuilderComponent extends React.Component<
     }
   };
 
+  stateChangeListenerActivatedHandler = () => this.notifyStateChange();
+
   resizeFn = () => {
     const deviceSize = this.deviceSizeState;
     if (deviceSize !== this.state.state.deviceSize) {
@@ -766,6 +768,10 @@ export class BuilderComponent extends React.Component<
       window.addEventListener('resize', this.resizeListener);
       if (Builder.isEditing) {
         window.addEventListener('message', this.messageListener);
+        window.addEventListener(
+          'builder:component:stateChangeListenerActivated',
+          this.stateChangeListenerActivatedHandler
+        );
       }
 
       if (Builder.isEditing || Builder.isPreviewing) {
@@ -897,6 +903,10 @@ export class BuilderComponent extends React.Component<
     if (Builder.isBrowser) {
       window.removeEventListener('resize', this.resizeListener);
       window.removeEventListener('message', this.messageListener);
+      window.removeEventListener(
+        'builder:component:stateChangeListenerActivated',
+        this.stateChangeListenerActivatedHandler
+      );
     }
   }
 


### PR DESCRIPTION
## Description
- Issue - State inspector in the visual editor would show `state: {}` on load even though the canvas was rendering bindings correctly.
- The editor injects a listener into the iframe after it loads, then fires a 'builder:component:stateChangeListenerActivated' event to signal the SDK that the listener is ready. The intent is for the SDK to re-fire its current state at that point so the editor can pick it up.
- The above is already [correctly implemented ](https://github.com/BuilderIO/builder/blob/main/packages/sdks/src/components/content/components/enable-editor.lite.tsx#L391)for gen2 SDKs, so followed same pattern here.
- So my analysis is that for Gen1 SDKs when the editor's listener was injected, the state was never re-sent and the inspector stayed empty until the user interacted with the canvas.

_Screenshot_
- I was not able to repro the issue, I tried network throttling with 3G network and even made the performance 6x slower and was not able to repro the issue in current prod visual editor or locally.
- The ticket also mentions that it is just an intermittent issue. (https://builder-io.atlassian.net/browse/ENG-12237)
- I have just done a sanity testing with my fixes with this content entry - http://localhost:1234/content/f60dadea0ad94ed9b1dcd9434e6b6d6d/edit?activeDesignerTab=0&activeLocale=Default

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 94d7dccab9f148fa171fe9d01059571f5637930b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->