### PR TITLE
fix[widgets][carousel]: ENG-12409 prevent dom-prop warnings and hide the empty arrows

### DIFF
--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/widgets",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "",
   "keywords": [],
   "main": "dist/builder-widgets.cjs.js",

--- a/packages/widgets/src/components/Carousel.tsx
+++ b/packages/widgets/src/components/Carousel.tsx
@@ -116,7 +116,12 @@ export class CarouselComponent extends React.Component<CarouselProps> {
                     focusOnSelect={this.props.focusOnSelect}
                     // TODO: on change emit event on element?
                     // renderBottomCenterControls={this.props.hideDots ? () => null : undefined}
-
+                    arrows={
+                      !!(
+                        (this.props.prevButton && this.props.prevButton.length) ||
+                        (this.props.nextButton && this.props.nextButton.length)
+                      )
+                    }
                     // OOF!!
                     nextArrow={
                       <CarouselArrow>

--- a/packages/widgets/src/components/Carousel.tsx
+++ b/packages/widgets/src/components/Carousel.tsx
@@ -12,6 +12,16 @@ import Slider, { ResponsiveObject, Settings } from 'react-slick';
 
 type BuilderBlockType = BuilderElement;
 
+const CarouselArrow = ({
+  currentSlide,
+  slideCount,
+  children,
+  ...rest
+}: React.HTMLAttributes<HTMLDivElement> & {
+  currentSlide?: number;
+  slideCount?: number;
+}) => <div {...rest}>{children}</div>;
+
 interface CarouselProps {
   slides: Array<
     React.ReactNode | { content: BuilderBlockType[] } /* BuilderBlock <- export this type */
@@ -109,23 +119,23 @@ export class CarouselComponent extends React.Component<CarouselProps> {
 
                     // OOF!!
                     nextArrow={
-                      <div>
+                      <CarouselArrow>
                         <BuilderBlocks
                           parentElementId={this.props.builderBlock.id}
                           dataPath="component.options.prevButton"
                           blocks={this.props.prevButton}
                         />
-                      </div>
+                      </CarouselArrow>
                     }
                     // OOF!!
                     prevArrow={
-                      <div>
+                      <CarouselArrow>
                         <BuilderBlocks
                           parentElementId={this.props.builderBlock.id}
                           dataPath="component.options.nextButton"
                           blocks={this.props.nextButton}
                         />
-                      </div>
+                      </CarouselArrow>
                     }
                     {...this.props.slickProps}
                   >


### PR DESCRIPTION
## Description
- The arrow buttons were plain divs passed to react-slick. Slick clones them and adds currentSlide / slideCount props, which React was complaining about that they aren't valid DOM attributes.
- So I have now wrapped the arrows in a small CarouselArrow component that filters those out before spreading the rest onto the div.
- Also fixed another issue, wherein setting empty content on the arrows didn't actually hide them, because slick still draws a 20x20 absolute-positioned click target.
- Now we set arrows: false on slick when both prevButton and nextButton are empty. Anyone passing slickProps.arrows explicitly will still get the value.

_Screenshot_
## Before
Warnings related to props
<img width="1966" height="1434" alt="image" src="https://github.com/user-attachments/assets/c6c94533-e3c0-45c9-90b1-45d31ded9206" />

<img width="1966" height="1434" alt="image" src="https://github.com/user-attachments/assets/d4418c7b-d913-43e1-af42-80ff8a525ac3" />

## After
No warnings
<img width="3012" height="1810" alt="image" src="https://github.com/user-attachments/assets/5a837a45-3a3c-4764-ba23-2dfa69bb4fce" />

The carousel doesn't leave invisible click areas at the edges
<img width="1495" height="909" alt="image" src="https://github.com/user-attachments/assets/4dcd3f84-48ed-46e6-bb23-7fdd49ae7d1b" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized carousel UI fix with no auth, data, or API impact; only affects arrow rendering and slick configuration defaults.
> 
> **Overview**
> Fixes **react-slick** carousel arrow behavior in `Carousel.tsx` by wrapping custom prev/next controls in a **`CarouselArrow`** helper that strips `currentSlide` and `slideCount` before they reach the DOM, eliminating React invalid-attribute warnings when slick clones the arrow elements.
> 
> Also sets **`arrows`** on the slider to **false** when both `prevButton` and `nextButton` have no blocks, so slick no longer renders the default 20×20 invisible edge click targets when arrows are intentionally empty. An explicit `slickProps.arrows` can still override because `slickProps` is spread after this default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7f4f4127220c08c1d81cae6752f19df53b69438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->