### PR TITLE
fix: Duplicate inline A/B test scripts injected when multiple Content components render on the same page

### DIFF
--- a/.changeset/afraid-cobras-lay.md
+++ b/.changeset/afraid-cobras-lay.md
@@ -1,0 +1,12 @@
+---
+"@builder.io/sdk-react": patch
+"@builder.io/sdk-angular": patch
+"@builder.io/sdk-react-nextjs": patch
+"@builder.io/sdk-qwik": patch
+"@builder.io/sdk-react-native": patch
+"@builder.io/sdk-solid": patch
+"@builder.io/sdk-svelte": patch
+"@builder.io/sdk-vue": patch
+---
+
+remove duplicate a/b test scripts being inserted in DOM

--- a/packages/sdks-tests/src/e2e-tests/ab-test.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/ab-test.spec.ts
@@ -10,7 +10,8 @@ import { CONTENT as AB_TEST_CONTENT } from '../specs/ab-test.js';
 
 const SELECTOR = 'div[builder-content-id]';
 
-const assertSingleInitVariantsScript = async (page: Page) => {
+const assertSingleInitVariantsScript = async (page: Page, { skip = false } = {}) => {
+  if (skip) return;
   await expect(page.locator('script[data-id="builderio-init-variants-fns"]')).toHaveCount(1);
 };
 
@@ -95,6 +96,7 @@ test.describe('A/B tests', () => {
         baseURL,
         packageName,
         browser,
+        sdk,
       }) => {
         const { page } = await initializeAbTest(
           {
@@ -129,7 +131,7 @@ test.describe('A/B tests', () => {
         });
 
         await page.goto('/ab-test', { waitUntil: 'networkidle' });
-        await assertSingleInitVariantsScript(page);
+        await assertSingleInitVariantsScript(page, { skip: checkIsGen1React(sdk) });
 
         expect(trackCalls).toBe(1);
 
@@ -143,6 +145,7 @@ test.describe('A/B tests', () => {
         baseURL,
         packageName,
         browser,
+        sdk,
       }) => {
         const { page } = await initializeAbTest(
           {
@@ -170,7 +173,7 @@ test.describe('A/B tests', () => {
         });
 
         await page.goto('/ab-test', { waitUntil: 'networkidle' });
-        await assertSingleInitVariantsScript(page);
+        await assertSingleInitVariantsScript(page, { skip: checkIsGen1React(sdk) });
 
         expect(trackCalls).toBe(1);
 
@@ -201,6 +204,7 @@ test.describe('A/B tests', () => {
         baseURL,
         packageName,
         browser,
+        sdk,
       }) => {
         const { page } = await initializeAbTest(
           {
@@ -215,7 +219,7 @@ test.describe('A/B tests', () => {
           }
         );
         await page.goto('/symbol-ab-test');
-        await assertSingleInitVariantsScript(page);
+        await assertSingleInitVariantsScript(page, { skip: checkIsGen1React(sdk) });
 
         await expect(page.getByText(TEXTS.DEFAULT_CONTENT).locator('visible=true')).toBeVisible();
         await expect(
@@ -231,6 +235,7 @@ test.describe('A/B tests', () => {
         baseURL,
         packageName,
         browser,
+        sdk,
       }) => {
         const { page } = await initializeAbTest(
           {
@@ -246,7 +251,7 @@ test.describe('A/B tests', () => {
         );
 
         await page.goto('/symbol-ab-test');
-        await assertSingleInitVariantsScript(page);
+        await assertSingleInitVariantsScript(page, { skip: checkIsGen1React(sdk) });
 
         await expect(page.getByText(TEXTS.VARIANT_1).locator('visible=true')).toBeVisible();
         await expect(

--- a/packages/sdks-tests/src/e2e-tests/ab-test.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/ab-test.spec.ts
@@ -1,4 +1,4 @@
-import type { Browser } from '@playwright/test';
+import type { Browser, Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { checkIsGen1React, checkIsRN, test } from '../helpers/index.js';
 import {
@@ -9,6 +9,10 @@ import {
 import { CONTENT as AB_TEST_CONTENT } from '../specs/ab-test.js';
 
 const SELECTOR = 'div[builder-content-id]';
+
+const assertSingleInitVariantsScript = async (page: Page) => {
+  await expect(page.locator('script[data-id="builderio-init-variants-fns"]')).toHaveCount(1);
+};
 
 const createContextWithCookies = async ({
   cookies,
@@ -125,6 +129,7 @@ test.describe('A/B tests', () => {
         });
 
         await page.goto('/ab-test', { waitUntil: 'networkidle' });
+        await assertSingleInitVariantsScript(page);
 
         expect(trackCalls).toBe(1);
 
@@ -165,6 +170,7 @@ test.describe('A/B tests', () => {
         });
 
         await page.goto('/ab-test', { waitUntil: 'networkidle' });
+        await assertSingleInitVariantsScript(page);
 
         expect(trackCalls).toBe(1);
 
@@ -209,6 +215,7 @@ test.describe('A/B tests', () => {
           }
         );
         await page.goto('/symbol-ab-test');
+        await assertSingleInitVariantsScript(page);
 
         await expect(page.getByText(TEXTS.DEFAULT_CONTENT).locator('visible=true')).toBeVisible();
         await expect(
@@ -239,6 +246,7 @@ test.describe('A/B tests', () => {
         );
 
         await page.goto('/symbol-ab-test');
+        await assertSingleInitVariantsScript(page);
 
         await expect(page.getByText(TEXTS.VARIANT_1).locator('visible=true')).toBeVisible();
         await expect(

--- a/packages/sdks/src/components/content-variants/content-variants.lite.tsx
+++ b/packages/sdks/src/components/content-variants/content-variants.lite.tsx
@@ -22,6 +22,7 @@ import {
   getInitVariantsFnsScriptString,
   getUpdateCookieAndStylesScript,
   getVariants,
+  removeDuplicateScript,
 } from './helpers.js';
 
 useMetadata({
@@ -78,7 +79,7 @@ export default function ContentVariants(props: VariantsProviderProps) {
         .map((value) => `.variant-${value.testVariationId} { display: none; } `)
         .join('');
     },
-    get defaultContent() {
+    get defaultContent(): ContentVariantsPrps['content'] {
       return state.shouldRenderVariants
         ? { ...props.content, testVariationId: props.content?.id }
         : handleABTestingSync({
@@ -90,19 +91,36 @@ export default function ContentVariants(props: VariantsProviderProps) {
 
   return (
     <>
-      <Show when={!props.isNestedRender && TARGET !== 'reactNative'}>
+      <Show
+        when={
+          !props.isNestedRender &&
+          TARGET !== 'reactNative'
+        }
+      >
         <InlinedScript
-          scriptStr={getInitVariantsFnsScriptString()}
+          scriptStr={removeDuplicateScript(
+            'builderio-init-variants-fns',
+            getInitVariantsFnsScriptString()
+          )}
           id="builderio-init-variants-fns"
           nonce={props.nonce || ''}
         />
-        {SDKS_SUPPORTING_PERSONALIZATION.includes(TARGET) && (
-          <InlinedScript
-            nonce={props.nonce || ''}
-            scriptStr={getInitPersonalizationVariantsFnsScriptString()}
-            id="builderio-init-personalization-variants-fns"
-          />
-        )}
+      </Show>
+      <Show
+        when={
+          !props.isNestedRender &&
+          TARGET !== 'reactNative' &&
+          SDKS_SUPPORTING_PERSONALIZATION.includes(TARGET)
+        }
+      >
+        <InlinedScript
+          nonce={props.nonce || ''}
+          scriptStr={removeDuplicateScript(
+            'builderio-init-personalization-variants-fns',
+            getInitPersonalizationVariantsFnsScriptString()
+          )}
+          id="builderio-init-personalization-variants-fns"
+        />
       </Show>
       <Show when={state.shouldRenderVariants}>
         <InlinedStyles

--- a/packages/sdks/src/components/content-variants/content-variants.lite.tsx
+++ b/packages/sdks/src/components/content-variants/content-variants.lite.tsx
@@ -104,7 +104,6 @@ export default function ContentVariants(props: VariantsProviderProps) {
           )}
           id="builderio-init-variants-fns"
           nonce={props.nonce || ''}
-          dedupe
         />
       </Show>
       <Show
@@ -121,7 +120,6 @@ export default function ContentVariants(props: VariantsProviderProps) {
             getInitPersonalizationVariantsFnsScriptString()
           )}
           id="builderio-init-personalization-variants-fns"
-          dedupe
         />
       </Show>
       <Show when={state.shouldRenderVariants}>

--- a/packages/sdks/src/components/content-variants/content-variants.lite.tsx
+++ b/packages/sdks/src/components/content-variants/content-variants.lite.tsx
@@ -104,6 +104,7 @@ export default function ContentVariants(props: VariantsProviderProps) {
           )}
           id="builderio-init-variants-fns"
           nonce={props.nonce || ''}
+          dedupe
         />
       </Show>
       <Show
@@ -120,6 +121,7 @@ export default function ContentVariants(props: VariantsProviderProps) {
             getInitPersonalizationVariantsFnsScriptString()
           )}
           id="builderio-init-personalization-variants-fns"
+          dedupe
         />
       </Show>
       <Show when={state.shouldRenderVariants}>

--- a/packages/sdks/src/components/content-variants/helpers.ts
+++ b/packages/sdks/src/components/content-variants/helpers.ts
@@ -71,26 +71,33 @@ const isHydrationTarget = getIsHydrationTarget(TARGET);
 
 export const removeDuplicateScript = (id: string, scriptStr: string) => `
   (function() {
-    if (!window.__builderioScriptObserver) {
-      window.__builderioScriptObserver = true;
-      var observer = new MutationObserver(function(mutations) {
-        mutations.forEach(function(mutation) {
-          mutation.addedNodes.forEach(function(node) {
-            if (node.nodeName === 'SCRIPT') {
-              var dataId = node.getAttribute('data-id');
-              if (dataId) {
-                var all = document.querySelectorAll('script[data-id="' + dataId + '"]');
-                for (var i = 1; i < all.length; i++) {
-                  all[i].parentNode && all[i].parentNode.removeChild(all[i]);
-                }
-              }
-            }
-          });
-        });
+    var selector = 'script[data-id="${id}"]';
+    var scriptKey = '__builderioScriptInitialized_${id}';
+    var observerKey = '__builderioScriptObserver_${id}';
+
+    // Synchronously remove any duplicates already in the DOM
+    var existing = document.querySelectorAll(selector);
+    existing.forEach(function(script, index) {
+      if (index > 0) {
+        script.parentNode && script.parentNode.removeChild(script);
+      }
+    });
+
+    // Watch for duplicates added later (e.g. RSC streaming chunks)
+    if (!window[observerKey] && typeof MutationObserver !== 'undefined') {
+      window[observerKey] = new MutationObserver(function() {
+        var all = document.querySelectorAll(selector);
+        for (var i = 1; i < all.length; i++) {
+          all[i].parentNode && all[i].parentNode.removeChild(all[i]);
+        }
       });
-      observer.observe(document.documentElement, { childList: true, subtree: true });
+      window[observerKey].observe(document.documentElement, { childList: true, subtree: true });
     }
-    ${scriptStr}
+
+    if (!window[scriptKey]) {
+      window[scriptKey] = true;
+      ${scriptStr}
+    }
   })();
 `;
 

--- a/packages/sdks/src/components/content-variants/helpers.ts
+++ b/packages/sdks/src/components/content-variants/helpers.ts
@@ -71,45 +71,15 @@ const isHydrationTarget = getIsHydrationTarget(TARGET);
 
 export const removeDuplicateScript = (id: string, scriptStr: string) => `
   (function() {
-    var selector = 'script[data-id="${id}"]';
+    var scripts = document.querySelectorAll('script[data-id="${id}"]');
+    var firstScript = scripts[0];
     var scriptKey = '__builderioScriptInitialized_${id}';
-    var observerKey = '__builderioScriptObserver_${id}';
-    var removeIfDuplicate = function(script) {
-      var firstScript = document.querySelector(selector);
-      if (firstScript && script !== firstScript) {
-        script.remove();
-      }
-    };
-    var cleanupExisting = function() {
-      document.querySelectorAll(selector).forEach(function(script, index) {
-        if (index > 0) {
-          script.remove();
-        }
-      });
-    };
-    var checkAddedNode = function(node) {
-      if (node.nodeType !== 1) return;
-      if (node.matches && node.matches(selector)) {
-        removeIfDuplicate(node);
-      }
-      if (node.querySelectorAll) {
-        node.querySelectorAll(selector).forEach(removeIfDuplicate);
-      }
-    };
 
-    cleanupExisting();
-
-    if (!window[observerKey] && typeof MutationObserver !== 'undefined') {
-      window[observerKey] = new MutationObserver(function(mutations) {
-        mutations.forEach(function(mutation) {
-          mutation.addedNodes.forEach(checkAddedNode);
-        });
-      });
-      window[observerKey].observe(document.documentElement, {
-        childList: true,
-        subtree: true,
-      });
-    }
+    scripts.forEach(function(script) {
+      if (script !== firstScript) {
+        script.parentNode?.removeChild(script);
+      }
+    });
 
     if (!window[scriptKey]) {
       window[scriptKey] = true;

--- a/packages/sdks/src/components/content-variants/helpers.ts
+++ b/packages/sdks/src/components/content-variants/helpers.ts
@@ -71,20 +71,26 @@ const isHydrationTarget = getIsHydrationTarget(TARGET);
 
 export const removeDuplicateScript = (id: string, scriptStr: string) => `
   (function() {
-    var scripts = document.querySelectorAll('script[data-id="${id}"]');
-    var firstScript = scripts[0];
-    var scriptKey = '__builderioScriptInitialized_${id}';
-
-    scripts.forEach(function(script) {
-      if (script !== firstScript) {
-        script.parentNode?.removeChild(script);
-      }
-    });
-
-    if (!window[scriptKey]) {
-      window[scriptKey] = true;
-      ${scriptStr}
+    if (!window.__builderioScriptObserver) {
+      window.__builderioScriptObserver = true;
+      var observer = new MutationObserver(function(mutations) {
+        mutations.forEach(function(mutation) {
+          mutation.addedNodes.forEach(function(node) {
+            if (node.nodeName === 'SCRIPT') {
+              var dataId = node.getAttribute('data-id');
+              if (dataId) {
+                var all = document.querySelectorAll('script[data-id="' + dataId + '"]');
+                for (var i = 1; i < all.length; i++) {
+                  all[i].parentNode && all[i].parentNode.removeChild(all[i]);
+                }
+              }
+            }
+          });
+        });
+      });
+      observer.observe(document.documentElement, { childList: true, subtree: true });
     }
+    ${scriptStr}
   })();
 `;
 

--- a/packages/sdks/src/components/content-variants/helpers.ts
+++ b/packages/sdks/src/components/content-variants/helpers.ts
@@ -69,6 +69,55 @@ const isAngularSDK = TARGET === 'angular';
 
 const isHydrationTarget = getIsHydrationTarget(TARGET);
 
+export const removeDuplicateScript = (id: string, scriptStr: string) => `
+  (function() {
+    var selector = 'script[data-id="${id}"]';
+    var scriptKey = '__builderioScriptInitialized_${id}';
+    var observerKey = '__builderioScriptObserver_${id}';
+    var removeIfDuplicate = function(script) {
+      var firstScript = document.querySelector(selector);
+      if (firstScript && script !== firstScript) {
+        script.remove();
+      }
+    };
+    var cleanupExisting = function() {
+      document.querySelectorAll(selector).forEach(function(script, index) {
+        if (index > 0) {
+          script.remove();
+        }
+      });
+    };
+    var checkAddedNode = function(node) {
+      if (node.nodeType !== 1) return;
+      if (node.matches && node.matches(selector)) {
+        removeIfDuplicate(node);
+      }
+      if (node.querySelectorAll) {
+        node.querySelectorAll(selector).forEach(removeIfDuplicate);
+      }
+    };
+
+    cleanupExisting();
+
+    if (!window[observerKey] && typeof MutationObserver !== 'undefined') {
+      window[observerKey] = new MutationObserver(function(mutations) {
+        mutations.forEach(function(mutation) {
+          mutation.addedNodes.forEach(checkAddedNode);
+        });
+      });
+      window[observerKey].observe(document.documentElement, {
+        childList: true,
+        subtree: true,
+      });
+    }
+
+    if (!window[scriptKey]) {
+      window[scriptKey] = true;
+      ${scriptStr}
+    }
+  })();
+`;
+
 export const getInitVariantsFnsScriptString = () => `
   window.${UPDATE_COOKIES_AND_STYLES_SCRIPT_NAME} = ${UPDATE_COOKIES_AND_STYLES_SCRIPT}
   window.${UPDATE_VARIANT_VISIBILITY_SCRIPT_FN_NAME} = ${UPDATE_VARIANT_VISIBILITY_SCRIPT}

--- a/packages/sdks/src/components/inlined-script.lite.tsx
+++ b/packages/sdks/src/components/inlined-script.lite.tsx
@@ -1,31 +1,16 @@
-import { Show, useStore } from '@builder.io/mitosis';
-import { isBrowser } from '../functions/is-browser.js';
 import type { BuilderNonceProp } from '../types/builder-props.js';
 
 interface Props extends BuilderNonceProp {
   scriptStr: string;
   id: string;
-  dedupe?: boolean;
 }
 
 export default function InlinedScript(props: Props) {
-  const state = useStore({
-    get shouldRender() {
-      return (
-        !props.dedupe ||
-        !isBrowser() ||
-        !document.querySelector(`script[data-id="${props.id}"]`)
-      );
-    },
-  });
-
   return (
-    <Show when={state.shouldRender}>
-      <script
-        innerHTML={props.scriptStr}
-        data-id={props.id}
-        nonce={props.nonce || ''}
-      />
-    </Show>
+    <script
+      innerHTML={props.scriptStr}
+      data-id={props.id}
+      nonce={props.nonce || ''}
+    />
   );
 }

--- a/packages/sdks/src/components/inlined-script.lite.tsx
+++ b/packages/sdks/src/components/inlined-script.lite.tsx
@@ -1,16 +1,31 @@
+import { Show, useStore } from '@builder.io/mitosis';
+import { isBrowser } from '../functions/is-browser.js';
 import type { BuilderNonceProp } from '../types/builder-props.js';
 
 interface Props extends BuilderNonceProp {
   scriptStr: string;
   id: string;
+  dedupe?: boolean;
 }
 
 export default function InlinedScript(props: Props) {
+  const state = useStore({
+    get shouldRender() {
+      return (
+        !props.dedupe ||
+        !isBrowser() ||
+        !document.querySelector(`script[data-id="${props.id}"]`)
+      );
+    },
+  });
+
   return (
-    <script
-      innerHTML={props.scriptStr}
-      data-id={props.id}
-      nonce={props.nonce || ''}
-    />
+    <Show when={state.shouldRender}>
+      <script
+        innerHTML={props.scriptStr}
+        data-id={props.id}
+        nonce={props.nonce || ''}
+      />
+    </Show>
   );
 }


### PR DESCRIPTION
## Description

- Fix Duplicate inline A/B test scripts injected when multiple Content components render on the same page

**Loom**
Issue: https://www.loom.com/share/21d436c93fae4cc6836042fe15ca40e6
Fix: https://www.loom.com/share/8f4f24a45db3431cbc69d5bf77cc5ec1


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared variant/personalization initialization injected into pages across multiple SDK targets; mistakes could break experiment rendering or cause hydration/streaming regressions. Change is localized but runs in the browser on every render and uses a MutationObserver/window globals.
> 
> **Overview**
> Prevents duplicate inline A/B testing and personalization init scripts from being injected when multiple `Content`/`ContentVariants` instances render on the same page (including RSC streaming cases).
> 
> Wraps the init script strings with a new `removeDuplicateScript()` helper that (1) removes extra `script[data-id=...]` tags, (2) sets up a `MutationObserver` to delete future duplicates, and (3) gates execution behind a per-script `window` initialization flag.
> 
> Updates Playwright A/B test e2e coverage to assert only one `builderio-init-variants-fns` script exists (skipping Gen1 React where applicable), and adds a changeset bumping all affected SDK packages as patch releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7a01a08148be2b59136cc3933b519b51f4cbd0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->