### PR TITLE
remove unused axios and axios-cache-adapter dependencies

### DIFF
--- a/packages/shopify/package-lock.json
+++ b/packages/shopify/package-lock.json
@@ -12,8 +12,6 @@
         "@emotion/core": "^10.1.1",
         "@emotion/styled": "^10.0.27",
         "@glimmer/syntax": "^0.42.1",
-        "axios": "^0.21.2",
-        "axios-cache-adapter": "^2.5.0",
         "clean-css": "^4.2.1",
         "csso": "^3.5.1",
         "dedent": "^0.7.0",
@@ -2080,26 +2078,6 @@
       "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==",
       "dev": true
     },
-    "node_modules/axios": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
-      "integrity": "sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
-    "node_modules/axios-cache-adapter": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/axios-cache-adapter/-/axios-cache-adapter-2.5.0.tgz",
-      "integrity": "sha512-YcMPdMoqmSLoZx7A5YD/PdYGuX6/Y9M2tHBhaIXvXrPeGgNnbW7nb3+uArWlT53WGHLfclnu2voMmS7jGXVg6A==",
-      "dependencies": {
-        "cache-control-esm": "1.0.0",
-        "lodash": "^4.17.11"
-      },
-      "peerDependencies": {
-        "axios": "0.18.1"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
@@ -2569,11 +2547,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/cache-control-esm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cache-control-esm/-/cache-control-esm-1.0.0.tgz",
-      "integrity": "sha512-Fa3UV4+eIk4EOih8FTV6EEsVKO0W5XWtNs6FC3InTfVz+EjurjPfDXY5wZDo/lxjDxg5RjNcurLyxEJBcEUx9g=="
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -3743,25 +3716,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
       }
     },
     "node_modules/for-in": {
@@ -10970,23 +10924,6 @@
       "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==",
       "dev": true
     },
-    "axios": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
-      "integrity": "sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==",
-      "requires": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
-    "axios-cache-adapter": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/axios-cache-adapter/-/axios-cache-adapter-2.5.0.tgz",
-      "integrity": "sha512-YcMPdMoqmSLoZx7A5YD/PdYGuX6/Y9M2tHBhaIXvXrPeGgNnbW7nb3+uArWlT53WGHLfclnu2voMmS7jGXVg6A==",
-      "requires": {
-        "cache-control-esm": "1.0.0",
-        "lodash": "^4.17.11"
-      }
-    },
     "babel-jest": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
@@ -11408,11 +11345,6 @@
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
       }
-    },
-    "cache-control-esm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cache-control-esm/-/cache-control-esm-1.0.0.tgz",
-      "integrity": "sha512-Fa3UV4+eIk4EOih8FTV6EEsVKO0W5XWtNs6FC3InTfVz+EjurjPfDXY5wZDo/lxjDxg5RjNcurLyxEJBcEUx9g=="
     },
     "callsites": {
       "version": "3.1.0",
@@ -12387,11 +12319,6 @@
       "requires": {
         "locate-path": "^3.0.0"
       }
-    },
-    "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/packages/shopify/package-lock.json
+++ b/packages/shopify/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/shopify",
-  "version": "1.3.42-7",
+  "version": "1.3.42",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/shopify",
-      "version": "1.3.42-7",
+      "version": "1.3.42",
       "license": "MIT",
       "dependencies": {
         "@emotion/core": "^10.1.1",

--- a/packages/shopify/package.json
+++ b/packages/shopify/package.json
@@ -71,8 +71,6 @@
     "@emotion/core": "^10.1.1",
     "@emotion/styled": "^10.0.27",
     "@glimmer/syntax": "^0.42.1",
-    "axios": "^0.21.2",
-    "axios-cache-adapter": "^2.5.0",
     "clean-css": "^4.2.1",
     "csso": "^3.5.1",
     "dedent": "^0.7.0",

--- a/packages/shopify/package.json
+++ b/packages/shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/shopify",
-  "version": "1.3.42-7",
+  "version": "1.3.42",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "repository": {


### PR DESCRIPTION
## Description

PR tries to remove unused axios and axios-cache-adapter dependencies

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only cleanup with no source changes; axios was not referenced in the package.
> 
> **Overview**
> Removes unused **`axios`** and **`axios-cache-adapter`** from `@builder.io/shopify` dependencies and refreshes **`package-lock.json`** so those packages (and related lockfile entries) are dropped.
> 
> Also sets the package version from **`1.3.42-7`** to **`1.3.42`** for release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1056561ffcb79b1f24fcce21126c6d7c9b452256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->