### PR TITLE
fix[gen2][angular]: ENG-11558 gate deprecated allowSignalWrites on Angular runtime version less than 19

### DIFF
--- a/.changeset/flat-rabbits-begin.md
+++ b/.changeset/flat-rabbits-begin.md
@@ -1,5 +1,5 @@
 ---
-"@builder.io/sdk-angular": minor
+'@builder.io/sdk-angular': patch
 ---
 
 Angular signals: gate the deprecated `allowSignalWrites` effect option on the runtime Angular version (`VERSION.major < 19`) instead of dropping it. This silences the deprecation warning on Angular 19+ while keeping backwards compatibility with lower versions.

--- a/.changeset/flat-rabbits-begin.md
+++ b/.changeset/flat-rabbits-begin.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/sdk-angular": minor
+---
+
+Angular signals: gate the deprecated `allowSignalWrites` effect option on the runtime Angular version (`VERSION.major < 19`) instead of dropping it. This silences the deprecation warning on Angular 19+ while keeping backwards compatibility with lower versions.

--- a/packages/sdks/package.json
+++ b/packages/sdks/package.json
@@ -57,8 +57,8 @@
     "upgrade-example:all": "yarn loop upgrade-example latest"
   },
   "dependencies": {
-    "@builder.io/mitosis": "^0.13.1",
-    "@builder.io/mitosis-cli": "^0.13.1",
+    "@builder.io/mitosis": "^0.13.2",
+    "@builder.io/mitosis-cli": "^0.13.2",
     "isolated-vm": "^6.0.0",
     "node-fetch": "^2.6.1",
     "seedrandom": "^3.0.5",

--- a/packages/sdks/package.json
+++ b/packages/sdks/package.json
@@ -57,8 +57,8 @@
     "upgrade-example:all": "yarn loop upgrade-example latest"
   },
   "dependencies": {
-    "@builder.io/mitosis": "^0.11.1",
-    "@builder.io/mitosis-cli": "^0.11.1",
+    "@builder.io/mitosis": "^0.13.1",
+    "@builder.io/mitosis-cli": "^0.13.1",
     "isolated-vm": "^6.0.0",
     "node-fetch": "^2.6.1",
     "seedrandom": "^3.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6798,11 +6798,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@builder.io/mitosis-cli@npm:^0.11.1":
-  version: 0.11.1
-  resolution: "@builder.io/mitosis-cli@npm:0.11.1"
+"@builder.io/mitosis-cli@npm:^0.13.1":
+  version: 0.13.1
+  resolution: "@builder.io/mitosis-cli@npm:0.13.1"
   dependencies:
-    "@builder.io/mitosis": 0.11.1
+    "@builder.io/mitosis": 0.13.1
     cosmiconfig: 9.0.0
     debug: ^4.3.4
     dedent: ^0.7.0
@@ -6816,13 +6816,13 @@ __metadata:
     ts-morph: ^19.0.0
   bin:
     mitosis: bin/mitosis
-  checksum: ab7298272a291bae48a28a760ef2b765b34c8c3ab4c279a25e9551c82877fcbc62ffff49a07c665bf8090b2aee1d432c198ab600ad6b195709719d48a6b6eb23
+  checksum: e92b488b72a3b7efcb41b9b533df8a1e0544dcea2747a4735e3d263f748814d8cee402ef41759230ece0e8ded2998dc87ea21cda7227893668630bbbcf01ae4c
   languageName: node
   linkType: hard
 
-"@builder.io/mitosis@npm:0.11.1, @builder.io/mitosis@npm:^0.11.1":
-  version: 0.11.1
-  resolution: "@builder.io/mitosis@npm:0.11.1"
+"@builder.io/mitosis@npm:0.13.1, @builder.io/mitosis@npm:^0.13.1":
+  version: 0.13.1
+  resolution: "@builder.io/mitosis@npm:0.13.1"
   dependencies:
     "@angular/compiler": ^11.2.11
     "@babel/core": 7.14.5
@@ -6847,7 +6847,7 @@ __metadata:
     svelte-preprocess: ^5.0.3
     ts-morph: ^19.0.0
     typescript: ^5.3.2
-  checksum: e641cd89ce6b28a88475abf3adcc8b3a1e9b040995fd14dc2ac9e7aefddcb8cd3ba18fa44a4d56b4fa288b90e5daf7111db993a4dfb96177bff202ef2015800d
+  checksum: 4a417214d201956b48e3a4916a0147873aadcd6228389a362389f9204f388fd4aa803d4bcbe3c1fc0a596fb6945fc6b2c25b48a21117cbc77e015056d9a6b22c
   languageName: node
   linkType: hard
 
@@ -7252,8 +7252,8 @@ __metadata:
   dependencies:
     "@arethetypeswrong/cli": ^0.13.3
     "@builder.io/eslint-plugin-mitosis": ^0.0.16
-    "@builder.io/mitosis": ^0.11.1
-    "@builder.io/mitosis-cli": ^0.11.1
+    "@builder.io/mitosis": ^0.13.1
+    "@builder.io/mitosis-cli": ^0.13.1
     "@types/node-fetch": ^2.5.12
     "@types/seedrandom": ^3.0.4
     "@types/traverse": ^0.6.32

--- a/yarn.lock
+++ b/yarn.lock
@@ -6798,11 +6798,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@builder.io/mitosis-cli@npm:^0.13.1":
-  version: 0.13.1
-  resolution: "@builder.io/mitosis-cli@npm:0.13.1"
+"@builder.io/mitosis-cli@npm:^0.13.2":
+  version: 0.13.2
+  resolution: "@builder.io/mitosis-cli@npm:0.13.2"
   dependencies:
-    "@builder.io/mitosis": 0.13.1
+    "@builder.io/mitosis": 0.13.2
     cosmiconfig: 9.0.0
     debug: ^4.3.4
     dedent: ^0.7.0
@@ -6816,13 +6816,13 @@ __metadata:
     ts-morph: ^19.0.0
   bin:
     mitosis: bin/mitosis
-  checksum: e92b488b72a3b7efcb41b9b533df8a1e0544dcea2747a4735e3d263f748814d8cee402ef41759230ece0e8ded2998dc87ea21cda7227893668630bbbcf01ae4c
+  checksum: 1d958d523f72606a9dd7a0fd1288f55be1e80925fa9120e6f4297c988a99fa281e005bd58309411f7a610fdcb57e2e6830cee1693137e56162abceee8c2eb346
   languageName: node
   linkType: hard
 
-"@builder.io/mitosis@npm:0.13.1, @builder.io/mitosis@npm:^0.13.1":
-  version: 0.13.1
-  resolution: "@builder.io/mitosis@npm:0.13.1"
+"@builder.io/mitosis@npm:0.13.2, @builder.io/mitosis@npm:^0.13.2":
+  version: 0.13.2
+  resolution: "@builder.io/mitosis@npm:0.13.2"
   dependencies:
     "@angular/compiler": ^11.2.11
     "@babel/core": 7.14.5
@@ -6847,7 +6847,7 @@ __metadata:
     svelte-preprocess: ^5.0.3
     ts-morph: ^19.0.0
     typescript: ^5.3.2
-  checksum: 4a417214d201956b48e3a4916a0147873aadcd6228389a362389f9204f388fd4aa803d4bcbe3c1fc0a596fb6945fc6b2c25b48a21117cbc77e015056d9a6b22c
+  checksum: 39c9a8a95f43b1e1022c5db19929eb2dd876a1caf05a1417ec47d8f0faf3d24ffaed55d7a65a9eb0e2a0b29a8b0b49834ac61180082a8b03ca9dc155323f5633
   languageName: node
   linkType: hard
 
@@ -7252,8 +7252,8 @@ __metadata:
   dependencies:
     "@arethetypeswrong/cli": ^0.13.3
     "@builder.io/eslint-plugin-mitosis": ^0.0.16
-    "@builder.io/mitosis": ^0.13.1
-    "@builder.io/mitosis-cli": ^0.13.1
+    "@builder.io/mitosis": ^0.13.2
+    "@builder.io/mitosis-cli": ^0.13.2
     "@types/node-fetch": ^2.5.12
     "@types/seedrandom": ^3.0.4
     "@types/traverse": ^0.6.32


### PR DESCRIPTION
## Description
- Gate deprecated `allowSignalWrites` on Angular runtime version (VERSION.major < 19) via mitosis 0.13.1, silencing the v19+ deprecation warning while preserving v17/18 compatibility.
- The change is related to this mitosis upgrade - https://github.com/BuilderIO/mitosis/pull/1797
- I have tested this change with a [dev release](https://www.npmjs.com/package/@builder.io/sdk-angular/v/0.25.2-1) and changes are working fine for both project having angular 17 and angular 19.

_Screenshot_
### Before
<img width="1496" height="863" alt="image" src="https://github.com/user-attachments/assets/855f8ac0-74f6-401b-925d-4916cbb124f6" />

### After
<img width="1503" height="873" alt="image" src="https://github.com/user-attachments/assets/51f5ba6e-360a-4d62-bcb1-0ca973e79e38" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and codegen-output change for Angular signals compatibility; no auth, data, or broad runtime logic in this diff.
> 
> **Overview**
> Bumps **`@builder.io/mitosis`** and **`@builder.io/mitosis-cli`** from **0.11.1** to **0.13.2** in `packages/sdks` (and lockfile) so regenerated Angular SDK output can **conditionally** pass the deprecated `allowSignalWrites` option to `effect()` only when the app runs on **Angular &lt; 19** (`VERSION.major &lt; 19`). On **19+**, that option is omitted to avoid the deprecation warning while **17/18** behavior stays the same.
> 
> Documents a **patch** release for **`@builder.io/sdk-angular`** in the changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19d98f6d9aff28c70606340cfc29a92099dc2511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->