### PR TITLE
fix[widgets][Carousel]: ENG-11356 fix carousel slides shown on Desktop during initial load

### DIFF
--- a/packages/widgets/src/components/Carousel.tsx
+++ b/packages/widgets/src/components/Carousel.tsx
@@ -7,6 +7,7 @@ import {
   BuilderStoreContext,
   stringToFunction,
 } from '@builder.io/react';
+import { debounce } from 'lodash-es';
 import * as React from 'react';
 import Slider, { ResponsiveObject, Settings } from 'react-slick';
 
@@ -54,8 +55,13 @@ export class CarouselComponent extends React.Component<CarouselProps> {
     return slickProps?.slidesToShow ?? 1;
   }
 
+  private handleResize = debounce(() => {
+    this.setState({ slidesToShow: this.getBreakpointSlidesToShow() });
+  }, 50);
+
   componentDidMount() {
     this.setState({ slidesToShow: this.getBreakpointSlidesToShow() });
+    window.addEventListener('resize', this.handleResize);
 
     setTimeout(() => {
       this.divRef.current?.dispatchEvent(
@@ -69,6 +75,11 @@ export class CarouselComponent extends React.Component<CarouselProps> {
         })
       );
     });
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+    this.handleResize.cancel();
   }
 
   render() {
@@ -98,6 +109,7 @@ export class CarouselComponent extends React.Component<CarouselProps> {
                     <style type="text/css">{slickStyles}</style>
                   )}
                   <Slider
+                    {...this.props.slickProps}
                     slidesToShow={this.state.slidesToShow}
                     responsive={this.props.responsive}
                     ref={this.sliderRef}
@@ -147,7 +159,6 @@ export class CarouselComponent extends React.Component<CarouselProps> {
                         />
                       </div>
                     }
-                    {...this.props.slickProps}
                   >
                     {/* todo: children.forEach hmm insert block inside */}
                     {this.props.useChildrenForSlides

--- a/packages/widgets/src/components/Carousel.tsx
+++ b/packages/widgets/src/components/Carousel.tsx
@@ -77,6 +77,15 @@ export class CarouselComponent extends React.Component<CarouselProps> {
     });
   }
 
+  componentDidUpdate(prevProps: CarouselProps) {
+    if (
+      prevProps.responsive !== this.props.responsive ||
+      prevProps.slickProps?.slidesToShow !== this.props.slickProps?.slidesToShow
+    ) {
+      this.setState({ slidesToShow: this.getBreakpointSlidesToShow() });
+    }
+  }
+
   componentWillUnmount() {
     window.removeEventListener('resize', this.handleResize);
     this.handleResize.cancel();

--- a/packages/widgets/src/components/Carousel.tsx
+++ b/packages/widgets/src/components/Carousel.tsx
@@ -118,8 +118,6 @@ export class CarouselComponent extends React.Component<CarouselProps> {
                     <style type="text/css">{slickStyles}</style>
                   )}
                   <Slider
-                    {...this.props.slickProps}
-                    slidesToShow={this.state.slidesToShow}
                     responsive={this.props.responsive}
                     ref={this.sliderRef}
                     afterChange={slide => {
@@ -168,6 +166,8 @@ export class CarouselComponent extends React.Component<CarouselProps> {
                         />
                       </div>
                     }
+                    {...this.props.slickProps}
+                    slidesToShow={this.state.slidesToShow}
                   >
                     {/* todo: children.forEach hmm insert block inside */}
                     {this.props.useChildrenForSlides

--- a/packages/widgets/src/components/Carousel.tsx
+++ b/packages/widgets/src/components/Carousel.tsx
@@ -37,7 +37,26 @@ export class CarouselComponent extends React.Component<CarouselProps> {
   private _errors?: Error[];
   private _logs?: string[];
 
+  state = { slidesToShow: 1 };
+
+  private getBreakpointSlidesToShow(): number {
+    const { responsive, slickProps } = this.props;
+    if (typeof window === 'undefined' || !responsive?.length) {
+      return slickProps?.slidesToShow ?? 1;
+    }
+    const sorted = [...responsive]
+      .filter(r => r.breakpoint != null)
+      .sort((a, b) => a.breakpoint - b.breakpoint);
+    const matched = sorted.find(r => window.innerWidth <= r.breakpoint);
+    if (matched?.settings && typeof matched.settings === 'object') {
+      return (matched.settings as Settings).slidesToShow ?? slickProps?.slidesToShow ?? 1;
+    }
+    return slickProps?.slidesToShow ?? 1;
+  }
+
   componentDidMount() {
+    this.setState({ slidesToShow: this.getBreakpointSlidesToShow() });
+
     setTimeout(() => {
       this.divRef.current?.dispatchEvent(
         new CustomEvent('builder:carousel:load', {
@@ -79,6 +98,7 @@ export class CarouselComponent extends React.Component<CarouselProps> {
                     <style type="text/css">{slickStyles}</style>
                   )}
                   <Slider
+                    slidesToShow={this.state.slidesToShow}
                     responsive={this.props.responsive}
                     ref={this.sliderRef}
                     afterChange={slide => {


### PR DESCRIPTION
## Description

When a carousel is configured to show 3 cards on desktop, 2 on tablet and 1 on phone, it always shows 1 card on the first page load on desktop. Resizing the browser window and back would fix it, but a hard refresh would reproduce it again.

**Root Cause:**
The carousel uses `react-slick` under the hood. `react-slick` starts with an internal default of `slidesToShow: 1` and only figures out the correct number after mounting, by registering CSS media query listeners (via `enquire.js`). Since no explicit `slidesToShow` prop was being passed to the slider, it always painted 1 card first before correcting itself.

**Fix:**
On mount (`componentDidMount`), we now read `window.innerWidth` and match it against the configured responsive breakpoints to compute the correct `slidesToShow` for the current viewport. This value is passed directly to the slider as a prop, so the correct card count is applied as soon as the page becomes interactive.

_Screenshot_
https://www.loom.com/share/4925ee12bde34a78956742e9fe72936e


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized carousel UI behavior in the widgets package; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **desktop first paint** showing only one carousel card when responsive settings call for more (e.g. 3 on desktop). `react-slick` was left to default `slidesToShow: 1` until its media-query listeners ran after mount.
> 
> `CarouselComponent` now **derives `slidesToShow` from `window.innerWidth` and the `responsive` breakpoints** (falling back to `slickProps.slidesToShow`), stores it in state, and passes **`slidesToShow` explicitly** into `Slider` so the first interactive render matches the viewport. A **debounced `resize` listener** keeps that value in sync; **prop changes** to `responsive` or `slickProps.slidesToShow` trigger a recalc; **unmount** removes the listener and cancels debounce.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e6656526232204fa7c6dcbfce0664c34d2a7607. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->