### PR TITLE
Revert "fix: Duplicate inline A/B test scripts injected when multiple Content components render on the same page (#4552)"

### DIFF
--- a/.changeset/neat-bugs-rest.md
+++ b/.changeset/neat-bugs-rest.md
@@ -1,0 +1,12 @@
+---
+"@builder.io/sdk-angular": patch
+"@builder.io/sdk-react-nextjs": patch
+"@builder.io/sdk-qwik": patch
+"@builder.io/sdk-react": patch
+"@builder.io/sdk-react-native": patch
+"@builder.io/sdk-solid": patch
+"@builder.io/sdk-svelte": patch
+"@builder.io/sdk-vue": patch
+---
+
+revert dedupe inline A/B test script fix

--- a/packages/sdks-tests/src/e2e-tests/ab-test.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/ab-test.spec.ts
@@ -1,4 +1,4 @@
-import type { Browser, Page } from '@playwright/test';
+import type { Browser } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { checkIsGen1React, checkIsRN, test } from '../helpers/index.js';
 import {
@@ -9,11 +9,6 @@ import {
 import { CONTENT as AB_TEST_CONTENT } from '../specs/ab-test.js';
 
 const SELECTOR = 'div[builder-content-id]';
-
-const assertSingleInitVariantsScript = async (page: Page, { skip = false } = {}) => {
-  if (skip) return;
-  await expect(page.locator('script[data-id="builderio-init-variants-fns"]')).toHaveCount(1);
-};
 
 const createContextWithCookies = async ({
   cookies,
@@ -96,7 +91,6 @@ test.describe('A/B tests', () => {
         baseURL,
         packageName,
         browser,
-        sdk,
       }) => {
         const { page } = await initializeAbTest(
           {
@@ -131,7 +125,6 @@ test.describe('A/B tests', () => {
         });
 
         await page.goto('/ab-test', { waitUntil: 'networkidle' });
-        await assertSingleInitVariantsScript(page, { skip: checkIsGen1React(sdk) });
 
         expect(trackCalls).toBe(1);
 
@@ -145,7 +138,6 @@ test.describe('A/B tests', () => {
         baseURL,
         packageName,
         browser,
-        sdk,
       }) => {
         const { page } = await initializeAbTest(
           {
@@ -173,7 +165,6 @@ test.describe('A/B tests', () => {
         });
 
         await page.goto('/ab-test', { waitUntil: 'networkidle' });
-        await assertSingleInitVariantsScript(page, { skip: checkIsGen1React(sdk) });
 
         expect(trackCalls).toBe(1);
 
@@ -204,7 +195,6 @@ test.describe('A/B tests', () => {
         baseURL,
         packageName,
         browser,
-        sdk,
       }) => {
         const { page } = await initializeAbTest(
           {
@@ -219,7 +209,6 @@ test.describe('A/B tests', () => {
           }
         );
         await page.goto('/symbol-ab-test');
-        await assertSingleInitVariantsScript(page, { skip: checkIsGen1React(sdk) });
 
         await expect(page.getByText(TEXTS.DEFAULT_CONTENT).locator('visible=true')).toBeVisible();
         await expect(
@@ -235,7 +224,6 @@ test.describe('A/B tests', () => {
         baseURL,
         packageName,
         browser,
-        sdk,
       }) => {
         const { page } = await initializeAbTest(
           {
@@ -251,7 +239,6 @@ test.describe('A/B tests', () => {
         );
 
         await page.goto('/symbol-ab-test');
-        await assertSingleInitVariantsScript(page, { skip: checkIsGen1React(sdk) });
 
         await expect(page.getByText(TEXTS.VARIANT_1).locator('visible=true')).toBeVisible();
         await expect(

--- a/packages/sdks/src/components/content-variants/content-variants.lite.tsx
+++ b/packages/sdks/src/components/content-variants/content-variants.lite.tsx
@@ -22,7 +22,6 @@ import {
   getInitVariantsFnsScriptString,
   getUpdateCookieAndStylesScript,
   getVariants,
-  removeDuplicateScript,
 } from './helpers.js';
 
 useMetadata({
@@ -79,7 +78,7 @@ export default function ContentVariants(props: VariantsProviderProps) {
         .map((value) => `.variant-${value.testVariationId} { display: none; } `)
         .join('');
     },
-    get defaultContent(): ContentVariantsPrps['content'] {
+    get defaultContent() {
       return state.shouldRenderVariants
         ? { ...props.content, testVariationId: props.content?.id }
         : handleABTestingSync({
@@ -93,29 +92,17 @@ export default function ContentVariants(props: VariantsProviderProps) {
     <>
       <Show when={!props.isNestedRender && TARGET !== 'reactNative'}>
         <InlinedScript
-          scriptStr={removeDuplicateScript(
-            'builderio-init-variants-fns',
-            getInitVariantsFnsScriptString()
-          )}
+          scriptStr={getInitVariantsFnsScriptString()}
           id="builderio-init-variants-fns"
           nonce={props.nonce || ''}
         />
-      </Show>
-      <Show
-        when={
-          !props.isNestedRender &&
-          TARGET !== 'reactNative' &&
-          SDKS_SUPPORTING_PERSONALIZATION.includes(TARGET)
-        }
-      >
-        <InlinedScript
-          nonce={props.nonce || ''}
-          scriptStr={removeDuplicateScript(
-            'builderio-init-personalization-variants-fns',
-            getInitPersonalizationVariantsFnsScriptString()
-          )}
-          id="builderio-init-personalization-variants-fns"
-        />
+        {SDKS_SUPPORTING_PERSONALIZATION.includes(TARGET) && (
+          <InlinedScript
+            nonce={props.nonce || ''}
+            scriptStr={getInitPersonalizationVariantsFnsScriptString()}
+            id="builderio-init-personalization-variants-fns"
+          />
+        )}
       </Show>
       <Show when={state.shouldRenderVariants}>
         <InlinedStyles

--- a/packages/sdks/src/components/content-variants/helpers.ts
+++ b/packages/sdks/src/components/content-variants/helpers.ts
@@ -69,38 +69,6 @@ const isAngularSDK = TARGET === 'angular';
 
 const isHydrationTarget = getIsHydrationTarget(TARGET);
 
-export const removeDuplicateScript = (id: string, scriptStr: string) => `
-  (function() {
-    var selector = 'script[data-id="${id}"]';
-    var scriptKey = '__builderioScriptInitialized_${id}';
-    var observerKey = '__builderioScriptObserver_${id}';
-
-    // Synchronously remove any duplicates already in the DOM
-    var existing = document.querySelectorAll(selector);
-    existing.forEach(function(script, index) {
-      if (index > 0) {
-        script.parentNode && script.parentNode.removeChild(script);
-      }
-    });
-
-    // Watch for duplicates added later (e.g. RSC streaming chunks)
-    if (!window[observerKey] && typeof MutationObserver !== 'undefined') {
-      window[observerKey] = new MutationObserver(function() {
-        var all = document.querySelectorAll(selector);
-        for (var i = 1; i < all.length; i++) {
-          all[i].parentNode && all[i].parentNode.removeChild(all[i]);
-        }
-      });
-      window[observerKey].observe(document.documentElement, { childList: true, subtree: true });
-    }
-
-    if (!window[scriptKey]) {
-      window[scriptKey] = true;
-      ${scriptStr}
-    }
-  })();
-`;
-
 export const getInitVariantsFnsScriptString = () => `
   window.${UPDATE_COOKIES_AND_STYLES_SCRIPT_NAME} = ${UPDATE_COOKIES_AND_STYLES_SCRIPT}
   window.${UPDATE_VARIANT_VISIBILITY_SCRIPT_FN_NAME} = ${UPDATE_VARIANT_VISIBILITY_SCRIPT}


### PR DESCRIPTION
This reverts commit ee26917a7991daa8429f1690c219686ba5a37fe5.

## Description

Removing inline A/B test script causes hydration issue in gen 2 sdks.
JIRA ticket : https://builder-io.atlassian.net/browse/ENG-12531

_Screenshot_
If relevant, add a screenshot or two of the changes you made.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Restores prior A/B inline script behavior across all SDKs; duplicate scripts on multi-Content pages may return, but hydration for Gen 2 is the intended tradeoff.
> 
> **Overview**
> **Reverts** the change that wrapped inline A/B and personalization init scripts with `removeDuplicateScript` (DOM cleanup + `MutationObserver` + run-once guards). Gen 2 SDKs were **hydration-breaking** with that approach ([ENG-12531](https://builder-io.atlassian.net/browse/ENG-12531)).
> 
> `ContentVariants` again emits the **raw** `getInitVariantsFnsScriptString()` / personalization script strings on `InlinedScript`, and personalization is gated with an inline `SDKS_SUPPORTING_PERSONALIZATION` check instead of a separate `Show` block. The **`removeDuplicateScript` helper is deleted** from `helpers.ts`.
> 
> E2E coverage no longer asserts a **single** `script[data-id="builderio-init-variants-fns"]` per page. A **patch changeset** applies across all published SDK packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 607ca53ace1a2b45d8d318135c871ea1c75db3e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[ENG-12531]: https://builder-io.atlassian.net/browse/ENG-12531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ