### PR TITLE
fix[widgets][Carousel]: ENG-11356 fix runtime issue related to tslib dep

### DIFF
--- a/packages/widgets/src/components/Carousel.tsx
+++ b/packages/widgets/src/components/Carousel.tsx
@@ -45,7 +45,7 @@ export class CarouselComponent extends React.Component<CarouselProps> {
     if (typeof window === 'undefined' || !responsive?.length) {
       return slickProps?.slidesToShow ?? 1;
     }
-    const sorted = [...responsive]
+    const sorted = responsive.slice()
       .filter(r => r.breakpoint != null)
       .sort((a, b) => a.breakpoint - b.breakpoint);
     const matched = sorted.find(r => window.innerWidth <= r.breakpoint);


### PR DESCRIPTION
## Description

Our fix added this line in Carousel.tsx:
`const sorted = [...responsive]`

Related PR: https://github.com/BuilderIO/builder/pull/4641

The [...responsive] array spread syntax gets compiled by TypeScript into a helper function called `__spreadArray`. This helper only exists in tslib version `2.x` and above.

The `@builder.io/widgets` package declares its tslib requirement as "^1.10.0" which is too old and doesn't have `__spreadArray`. So when the customer installs the package and their project resolves to tslib 1.x, the built file tries to import a function that doesn't exist, hence the error. 

_Screenshot_
https://www.loom.com/share/f5502caf05284281af3284450101ea5c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line equivalent shallow copy in breakpoint logic; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a **runtime failure** in the widgets Carousel when customer projects resolve **tslib 1.x**.
> 
> `getBreakpointSlidesToShow` previously copied `responsive` with `[...responsive]`, which TypeScript lowers to tslib’s **`__spreadArray`** (tslib **2+** only). `@builder.io/widgets` still allows **tslib ^1.10.0**, so installs on 1.x could throw at runtime after the related carousel change (ENG-11356 / prior PR).
> 
> The copy is now **`responsive.slice()`**, which keeps the same shallow-copy behavior for sort/filter without that helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0acb5d034273d1fbcbe4656aa5a606980f55b7f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->