### PR TITLE
chore[widgets][Carousel]: ENG-11356 bump widgets from 2.1.1 to 2.1.2

### DIFF
--- a/packages/widgets/package-lock.json
+++ b/packages/widgets/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/widgets",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/widgets",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/core": ">=10",

--- a/packages/widgets/package-lock.json
+++ b/packages/widgets/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@builder.io/widgets",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "@emotion/core": ">=10",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/widgets",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "",
   "keywords": [],
   "main": "dist/builder-widgets.cjs.js",


### PR DESCRIPTION
## Description

Version bump up PR for widgets package from 2.1.1 to 2.1.2

Related PR: https://github.com/BuilderIO/builder/pull/4649

_Screenshot_
NA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata change with no runtime or API code in the diff.
> 
> **Overview**
> Bumps **`@builder.io/widgets`** from **2.1.1** to **2.1.2** in `package.json` and syncs the root package entry in `package-lock.json` (including aligning the lockfile’s previously mismatched `2.1.0` metadata with **2.1.2**).
> 
> There are **no source or widget implementation changes** in this diff—only the version metadata for publishing the patch release (Carousel-related fixes are expected to ship via the linked upstream PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 078558bf2f31384917a2aa8fd29c1ce2d213f7d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->