### PR TITLE
chore[widgets][tslib]: upgrade tslib version from 1.10.0 to 2.1.0

### DIFF
--- a/packages/widgets/package-lock.json
+++ b/packages/widgets/package-lock.json
@@ -15,7 +15,7 @@
         "react-loadable": "^5.5.0",
         "react-masonry-component": "^6.2.1",
         "react-slick": "^0.31.0",
-        "tslib": "^1.10.0"
+        "tslib": "^2.1.0"
       },
       "devDependencies": {
         "@builder.io/block-publish": "^1.1.2",
@@ -862,6 +862,13 @@
         "node-fetch": "^2.3.0",
         "tslib": "^1.10.0"
       }
+    },
+    "node_modules/@builder.io/sdk/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -5409,13 +5416,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@swc/helpers/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -5855,13 +5855,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/@yarn-tool/resolve-package/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/acorn": {
       "version": "8.14.0",
@@ -9708,12 +9701,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/inquirer/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
     },
     "node_modules/into-stream": {
       "version": "6.0.0",
@@ -18474,13 +18461,6 @@
         "tslib": "^2"
       }
     },
-    "node_modules/path-is-network-drive/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -18506,13 +18486,6 @@
       "dependencies": {
         "tslib": "^2"
       }
-    },
-    "node_modules/path-strip-sep/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -19696,13 +19669,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/rollup-plugin-typescript2/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/rollup-pluginutils": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
@@ -19758,6 +19724,13 @@
       "engines": {
         "npm": ">=2.0.0"
       }
+    },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -20993,9 +20966,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/tslint": {
@@ -21205,6 +21178,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/tslint/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/tsutils": {
       "version": "2.29.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
@@ -21217,6 +21197,13 @@
       "peerDependencies": {
         "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
       }
+    },
+    "node_modules/tsutils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -21473,13 +21460,6 @@
         "path-strip-sep": "^1.0.18",
         "tslib": "^2"
       }
-    },
-    "node_modules/upath2/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -167,7 +167,7 @@
     "react-loadable": "^5.5.0",
     "react-masonry-component": "^6.2.1",
     "react-slick": "^0.31.0",
-    "tslib": "^1.10.0"
+    "tslib": "^2.1.0"
   },
   "gitHead": "4d96fbc32864698afbb355ab991c6d90be991951"
 }


### PR DESCRIPTION
## Description

`@builder.io/widgets` declared "tslib": "^1.10.0" in its dependencies, but the compiled output (builder-widgets.es5.js) imports __spreadArray which is a helper that only exists in tslib 2.1+. This meant customers whose project resolved to tslib 1.x would get a blocking build error when installing the package.

At some point, the TypeScript version in this package was upgraded past 4.2. From TypeScript 4.2 onwards, array spread syntax ([...arr]) compiles to `__spreadArray` instead of the older `__spread` helper. The tslib version was never updated alongside the TypeScript upgrade, causing the declared dependency to fall out of sync with what the compiled output actually needs.

This PR bumps "tslib": "^1.10.0" → "^2.1.0" so the declared dependency correctly reflects the minimum version required. tslib 2.x is fully backward compatible. So, no breaking changes expected for existing consumers.

Related JIRA Ticket: https://builder-io.atlassian.net/browse/ENG-12838

_Screenshot_
https://www.loom.com/share/25fbbd0846ec4e4d80ab56381594afc3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency declaration and lockfile only; tslib 2.x is backward compatible and does not change application logic.
> 
> **Overview**
> Aligns `@builder.io/widgets`’s declared **`tslib`** dependency with what its compiled ES5 bundle actually needs after a TypeScript upgrade.
> 
> **`tslib`** is bumped from **`^1.10.0`** to **`^2.1.0`** in `package.json`, with the lockfile updated so the hoisted install resolves to **2.8.1** while older transitive packages keep nested **1.14.1** copies where required. This fixes consumer build failures when npm/yarn hoisted **tslib 1.x** even though the widgets output relies on **`__spreadArray`** (introduced in tslib 2.1+).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2229411ef87728aa08868b1fd7cc8df796fc218d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->