### PR TITLE
chore[widgets]: ENG-12838 bump widgets from 2.1.2 to 2.1.3

### DIFF
--- a/packages/widgets/package-lock.json
+++ b/packages/widgets/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@builder.io/widgets",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "@emotion/core": ">=10",

--- a/packages/widgets/package-lock.json
+++ b/packages/widgets/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/widgets",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/widgets",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "",
   "keywords": [],
   "main": "dist/builder-widgets.cjs.js",


### PR DESCRIPTION
## Description

Version bump up PR for widgets package from 2.1.2 to 2.1.3

Related PR: https://github.com/BuilderIO/builder/pull/4655

_Screenshot_
NA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata change with no runtime or dependency updates in this PR.
> 
> **Overview**
> Bumps **`@builder.io/widgets`** from **2.1.2** to **2.1.3** in `packages/widgets/package.json` and the root package entry in `package-lock.json`. There are no dependency, script, or source changes in this diff—only the published package version metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eff781485dd5c94516dd06f67a23ee197f107097. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->