### PR TITLE
chore[scripts]: refactor dependabot PR and alert scripts for improved functionality and clarity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ Pods/
 *.stTheme.cache
 *.sublime-workspace
 *.sublime-project
+
+.builder/plans

--- a/scripts/clean-dependabot-merger.mjs
+++ b/scripts/clean-dependabot-merger.mjs
@@ -6,12 +6,22 @@ $.verbose = true;
 
 const query = await question('Enter a query to filter PRs by: ');
 
+const limitAnswer = await question('How many PRs to fetch? [30]: ');
+const limit = Number(limitAnswer.trim()) || 30;
+
+const offsetAnswer = await question('How many PRs to skip (offset)? [0]: ');
+const offset = Number(offsetAnswer.trim()) || 0;
+
 const getPrs = async (extra = '') => {
+  // Only pass query/extra as search terms when non-empty; gh rejects empty terms.
+  const searchTerms = [query, extra].filter(Boolean);
+  // gh has no offset flag, so fetch offset+limit results and slice off the offset.
+  const fetchCount = offset + limit;
   const prsStr =
-    await $`gh search prs ${query} ${extra} --state=open --repo=builder --owner=BuilderIO --app=dependabot --json=url,number,title`;
+    await $`gh search prs ${searchTerms} --state=open --repo=BuilderIO/builder --app=dependabot --sort=created --order=asc --limit=${fetchCount} --json=url,number,title,updatedAt`;
 
   /**
-   * @type {Array<{url: string, number: number, title: string}>}
+   * @type {Array<{url: string, number: number, title: string, updatedAt: string}>}
    */
   const prs = JSON.parse(prsStr.stdout);
 
@@ -19,7 +29,7 @@ const getPrs = async (extra = '') => {
 
   // exclude `BuilderIO/builder-internal` PRs
   const cleanedPrs = prs.filter(pr => pr.url.includes('BuilderIO/builder/pull'));
-  return cleanedPrs;
+  return cleanedPrs.slice(offset, offset + limit);
 };
 
 const mergePrs = async () => {

--- a/scripts/clean-dependabot-merger.mjs
+++ b/scripts/clean-dependabot-merger.mjs
@@ -27,9 +27,9 @@ const getPrs = async (extra = '') => {
 
   console.log(prsStr, prs);
 
-  // exclude `BuilderIO/builder-internal` PRs
-  const cleanedPrs = prs.filter(pr => pr.url.includes('BuilderIO/builder/pull'));
-  return cleanedPrs.slice(offset, offset + limit);
+  // Apply offset/limit on the raw, globally-ordered results so the window
+  // matches the sort order.
+  return prs.slice(offset, offset + limit);
 };
 
 const mergePrs = async () => {
@@ -64,7 +64,7 @@ const messageDependabot = async (command = 'rebase') => {
 const closePrs = async () => {
   const prs = await getPrs();
   for (const pr of prs) {
-    echo`\nclosing PR: ${pr.url}: ${pr.title}`;
+    echo`closing PR: ${pr.url}: ${pr.title}`;
     try {
       await $`gh pr close ${pr.number}`;
     } catch (error) {

--- a/scripts/clean-dependabot-merger.mjs
+++ b/scripts/clean-dependabot-merger.mjs
@@ -61,10 +61,25 @@ const messageDependabot = async (command = 'rebase') => {
   }
 };
 
+const closePrs = async () => {
+  const prs = await getPrs();
+  for (const pr of prs) {
+    echo`\nclosing PR: ${pr.url}: ${pr.title}`;
+    try {
+      await $`gh pr close ${pr.number}`;
+    } catch (error) {
+      echo`ERROR closing PR: ${pr.url}: ${pr.title}`;
+      echo`ERROR: ${error}`;
+    }
+  }
+};
+
 const main = async () => {
-  const action = await question('What do you want to do? [merge/msg]: ');
+  const action = await question('What do you want to do? [merge/msg/close]: ');
   if (action === 'merge') {
     await mergePrs();
+  } else if (action === 'close') {
+    await closePrs();
   } else if (action === 'msg') {
     // get msg from user
     const command = await question('What do you want to say to dependabot? [rebase]: ');

--- a/scripts/clear-dependabot-alerts.mjs
+++ b/scripts/clear-dependabot-alerts.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env zx
+
+/**
+ * This script uses the gh CLI to dismiss open Dependabot security alerts for the
+ * BuilderIO/builder repo (e.g. the ones at
+ * https://github.com/BuilderIO/builder/security/dependabot).
+ *
+ * It asks the user for:
+ * - a severity to filter by (low/moderate/high/critical, or all)
+ * - a dismiss reason
+ * - lists all matching open alerts and asks the user to confirm
+ * - dismisses each alert
+ *
+ * NOTE: dismissing only hides the alert, it does not fix the dependency.
+ */
+
+import { question } from 'zx';
+import { echo } from 'zx/experimental';
+
+const REPO = 'BuilderIO/builder';
+
+// GitHub-accepted dismiss reasons for Dependabot alerts.
+const DISMISS_REASONS = ['tolerable_risk', 'no_bandwidth', 'not_used', 'inaccurate', 'fix_started'];
+
+console.log('Welcome to the BuilderIO/builder Dependabot alert cleaner!');
+
+async function getSeverity() {
+  const answer = await question(
+    'Which severity to dismiss? [low/moderate/high/critical/all] (moderate): '
+  );
+  const severity = answer.trim().toLowerCase() || 'moderate';
+  const valid = ['low', 'moderate', 'high', 'critical', 'all'];
+  if (!valid.includes(severity)) {
+    throw new Error(`Invalid severity "${severity}". Choose one of: ${valid.join(', ')}`);
+  }
+  return severity;
+}
+
+async function getDismissReason() {
+  const answer = await question(
+    `Dismiss reason? [${DISMISS_REASONS.join('/')}] (tolerable_risk): `
+  );
+  const reason = answer.trim().toLowerCase() || 'tolerable_risk';
+  if (!DISMISS_REASONS.includes(reason)) {
+    throw new Error(`Invalid reason "${reason}". Choose one of: ${DISMISS_REASONS.join(', ')}`);
+  }
+  return reason;
+}
+
+/**
+ * @returns {Promise<Array<{number: number, html_url: string, dependency: object, security_advisory: object}>>}
+ */
+const getAlerts = async severity => {
+  const path =
+    severity === 'all'
+      ? `/repos/${REPO}/dependabot/alerts?state=open&per_page=100`
+      : `/repos/${REPO}/dependabot/alerts?state=open&severity=${severity}&per_page=100`;
+
+  // --paginate follows the Link headers; --slurp merges pages into one array.
+  const alertsStr = await $`gh api --paginate --slurp ${path}`;
+
+  /**
+   * @type {Array<Array<object>> | Array<object>}
+   */
+  const parsed = JSON.parse(alertsStr.stdout);
+
+  // --slurp yields an array of page-arrays; flatten to a single list.
+  return parsed.flat();
+};
+
+const dismissAlert = async (alert, reason) => {
+  const name = alert.dependency?.package?.name ?? 'unknown';
+  console.log(`Dismissing alert #${alert.number} (${name})...`);
+  try {
+    await $`gh api --method PATCH /repos/${REPO}/dependabot/alerts/${alert.number} -f state=dismissed -f dismissed_reason=${reason}`;
+    console.log(`Dismissed alert #${alert.number}.`);
+  } catch (e) {
+    console.log(`Error dismissing alert #${alert.number}.`);
+    console.log(e);
+  }
+};
+
+async function main() {
+  const severity = await getSeverity();
+  const reason = await getDismissReason();
+
+  const alerts = await getAlerts(severity);
+
+  console.log(`Found ${alerts.length} open ${severity} alert(s):`);
+  alerts.forEach(alert => {
+    const name = alert.dependency?.package?.name ?? 'unknown';
+    const sev = alert.security_advisory?.severity ?? '?';
+    const summary = alert.security_advisory?.summary ?? '';
+    console.log(`#${alert.number} [${sev}] ${name} || ${summary}`);
+  });
+
+  if (alerts.length === 0) {
+    echo`No matching alerts found, nothing to do`;
+    return;
+  }
+
+  const confirm = await question(
+    `Dismiss these ${alerts.length} alert(s) as "${reason}"? (yes/no): `
+  );
+
+  if (confirm !== 'yes') {
+    throw new Error(`Script aborted.`);
+  }
+
+  // Dismiss sequentially to stay friendly with the API rate limit.
+  for (const alert of alerts) {
+    await dismissAlert(alert, reason);
+  }
+}
+
+main();

--- a/scripts/merge-dependabot-prs.mjs
+++ b/scripts/merge-dependabot-prs.mjs
@@ -1,31 +1,20 @@
 #!/usr/bin/env zx
 
 /**
- * This script uses the octokit SDK to approve & merge all open dependabot PRs for this BuilderIO/builder repo.
- * It asks the user for:
- * - a query to filter the PRs by
- * - lists all PRs that match the query, how many there are, and asks the user to confirm
- * - approves all PRs
- * - merges all PRs
+ * This script uses the gh CLI to process all open dependabot PRs for the
+ * BuilderIO/builder repo. It asks the user for a query to filter the PRs by,
+ * then for each matching PR it:
+ * - reviews (lists them and asks the user to confirm)
+ * - approves
+ * - enables auto-merge (squash, merges once CI passes)
+ * - asks Dependabot to rebase (refreshes against main so CI re-runs and the
+ *   queued auto-merge can fire)
  */
 
-import Octokit from '@octokit/rest';
 import { question } from 'zx';
 import { echo } from 'zx/experimental';
 
-// load the GITHUB_TOKEN_X from .env file
-require('dotenv').config();
-
-// authenticate Octokit with a personal access token
-const octokit = new Octokit({
-  auth: process.env.GITHUB_TOKEN_X,
-});
-
 console.log('Welcome to the BuilderIO/builder dependabot PR merger!');
-
-if (!process.env.GITHUB_TOKEN_X) {
-  throw new Error(`GITHUB_TOKEN_X not found in .env file`);
-}
 
 let query = '';
 async function getQuery() {
@@ -33,225 +22,147 @@ async function getQuery() {
   query = await question('Enter a query to filter PRs by: ');
 }
 
-const getPRs = async ({ isApproved }) => {
-  const getQuery = isApproved =>
-    `repo:BuilderIO/builder is:open state:open author:app/dependabot type:pr ${query} in:title `;
-  const { data: pullRequests } = await octokit.search.issuesAndPullRequests({
-    q: getQuery(isApproved),
-    per_page: 100,
-  });
+/**
+ * @returns {Promise<Array<{url: string, number: number, title: string}>>}
+ */
+const getPRs = async () => {
+  // Only pass the query as a search term when non-empty; gh rejects empty terms.
+  const searchTerms = [query].filter(Boolean);
+  const prsStr =
+    await $`gh search prs ${searchTerms} --repo=BuilderIO/builder --app=dependabot --state=open --limit=100 --json=url,number,title`;
 
-  return pullRequests;
+  /**
+   * @type {Array<{url: string, number: number, title: string}>}
+   */
+  const prs = JSON.parse(prsStr.stdout);
+
+  // exclude PRs from other org repos
+  return prs.filter(pr => pr.url.includes('BuilderIO/builder/pull'));
 };
 
 /**
- *
- * @param {Octokit.SearchIssuesAndPullRequestsResponseItemsItem} pr
+ * Lists the matching PRs and asks the user to confirm before any action.
+ * @returns {Promise<Array<{url: string, number: number, title: string}>>}
  */
-const autoMerge = async pr => {
-  try {
-    await $`gh pr review ${pr.number} --approve`;
-    // enable auto-merge
-    await $`gh pr merge ${pr.number} --auto --squash`;
-    console.log(`Enabled auto-merge for ${pr.html_url}.`);
-  } catch (e) {
-    console.log(`Error auto-merging ${pr.html_url}.`);
-    // print details
-    console.log(e);
-  }
-};
+async function review() {
+  const prs = await getPRs();
 
-async function approve() {
-  // List all unapproved PRs that match the query
-  const unapprovedPullRequests = await getPRs({ isApproved: false });
-
-  console.log(
-    `Found ${unapprovedPullRequests.total_count} unapproved pull requests matching the query:`
-  );
-  unapprovedPullRequests.items.forEach(pr => {
-    console.log(`${pr.html_url} || ${pr.title}`);
+  console.log(`Found ${prs.length} open dependabot pull requests matching the query:`);
+  prs.forEach(pr => {
+    console.log(`${pr.url} || ${pr.title}`);
   });
 
-  if (unapprovedPullRequests.total_count === 0) {
-    echo`No unapproved PRs found, skipping approval step`;
-    return;
+  if (prs.length === 0) {
+    echo`No PRs found, nothing to do`;
+    return [];
   }
 
-  // Confirm with the user
-  let confirm = await question(
-    `Are you sure you want to approve these ${unapprovedPullRequests.total_count} pull requests? (yes/no): `
-  );
-
-  if (confirm !== 'yes') {
-    throw new Error(`Script aborted.`);
-  }
-
-  /**
-   *
-   * @param {Octokit.SearchIssuesAndPullRequestsResponseItemsItem} pr
-   */
-  const processPr = async pr => {
-    autoMerge(pr);
-    // approve the PR and print appropriate message
-    console.log(`Approving ${pr.html_url}...`);
-
-    const resp = await octokit.pulls.createReview({
-      owner: 'BuilderIO',
-      repo: 'builder',
-      pull_number: pr.number,
-      event: 'APPROVE',
-    });
-    if (resp.status >= 300) {
-      console.log(`Error approving ${pr.html_url}.`);
-      // print details
-      console.log(resp);
-    } else {
-      console.log(`Approved ${pr.html_url}.`);
-    }
-  };
-
-  await Promise.all(unapprovedPullRequests.items.map(processPr));
-}
-
-async function merge() {
-  // List all unapproved PRs that match the query
-  const approvedPullRequests = await getPRs({ isApproved: true });
-
-  console.log(
-    `Found ${approvedPullRequests.total_count} approved pull requests matching the query: `
-  );
-  approvedPullRequests.items.forEach(pr => {
-    console.log(`${pr.html_url} || ${pr.title}`);
-  });
-
-  if (approvedPullRequests.total_count === 0) {
-    throw new Error(`No approved PRs found, aborting`);
-  }
-
-  // Confirm with the user
   const confirm = await question(
-    `Are you sure you want to merge these ${approvedPullRequests.total_count} pull requests? (yes/no): `
+    `Approve, enable auto-merge, and rebase these ${prs.length} pull requests? (yes/no): `
   );
 
   if (confirm !== 'yes') {
     throw new Error(`Script aborted.`);
   }
 
-  let hasError = false;
+  return prs;
+}
 
-  /**
-   * @type {Octokit.SearchIssuesAndPullRequestsResponseItemsItem[]}
-   */
-  const dependabotRebasePRs = [];
-
-  const mergePr = async pr => {
-    // merge the PR and print appropriate message
-    console.log(`Merging ${pr.html_url}`);
+async function approve(prs) {
+  const approvePr = async pr => {
+    console.log(`Approving ${pr.url}...`);
     try {
-      const resp = await octokit.pulls.merge({
-        owner: 'BuilderIO',
-        repo: 'builder',
-        pull_number: pr.number,
-        merge_method: 'squash',
-      });
-      if (resp.status >= 300) {
-        hasError = true;
-        console.log(`Error merging ${pr.html_url}`);
-        // print details
-        console.log(resp);
-      } else {
-        console.log(`Merged ${pr.html_url}`);
-      }
+      await $`gh pr review ${pr.number} --approve`;
+      console.log(`Approved ${pr.url}.`);
     } catch (e) {
-      hasError = true;
-      console.log(`Error merging ${pr.html_url}`);
-      // print details
+      console.log(`Error approving ${pr.url}.`);
       console.log(e);
-      if (e.message.includes('Pull Request is not mergeable')) {
-        dependabotRebasePRs.push(pr);
-      }
     }
   };
 
-  // Merge all PRs
-  await Promise.all(approvedPullRequests.items.map(mergePr));
+  await Promise.all(prs.map(approvePr));
+}
 
-  if (dependabotRebasePRs.length > 0) {
-    console.log(`The following PRs need to be rebased by Dependabot: `);
-    dependabotRebasePRs.forEach(pr => {
-      console.log(`${pr.html_url} || ${pr.title}`);
-    });
-
-    const confirm = await question(
-      `Would you like to ask Dependabot to rebase these PRs? (yes/no): `
-    );
-
-    if (confirm === 'yes') {
-      for (const pr of dependabotRebasePRs) {
-        await rebaseDependabot(pr.html_url);
-      }
+async function enableAutoMerge(prs) {
+  const autoMergePr = async pr => {
+    console.log(`Enabling auto-merge for ${pr.url}...`);
+    try {
+      // queues the squash-merge until CI passes
+      await $`gh pr merge ${pr.number} --auto --squash`;
+      console.log(`Auto-merge enabled for ${pr.url}.`);
+    } catch (e) {
+      console.log(`Error enabling auto-merge for ${pr.url}.`);
+      console.log(e);
     }
-  }
+  };
 
-  if (hasError) {
-    // ask them if they want to try again
-    const confirm = await question(
-      `There was an error merging some PRs, would you like to try again? (yes/no): `
-    );
+  await Promise.all(prs.map(autoMergePr));
+}
 
-    if (confirm === 'yes') {
-      await merge();
+async function forceMerge(prs) {
+  // Merge sequentially: each squash merge advances `main`, so parallel merges
+  // race and fail with "Base branch was modified".
+  for (const pr of prs) {
+    console.log(`Force-merging ${pr.url}...`);
+    // one retry for the base-branch race
+    for (let attempt = 1; attempt <= 2; attempt++) {
+      try {
+        // --admin bypasses required checks/reviews and merges immediately
+        await $`gh pr merge ${pr.number} --admin --squash`;
+        console.log(`Force-merged ${pr.url}.`);
+        break;
+      } catch (e) {
+        const output = `${e.stderr ?? ''} ${e.message ?? ''}`;
+        if (attempt === 1 && output.includes('Base branch was modified')) {
+          console.log(`Base branch changed, retrying ${pr.url}...`);
+          continue;
+        }
+        console.log(`Error force-merging ${pr.url}.`);
+        console.log(e);
+        break;
+      }
     }
   }
 }
 
+async function rebaseAll(prs) {
+  for (const pr of prs) {
+    await rebaseDependabot(pr.number);
+  }
+}
+
 /**
- * sends a PR comment `@dependabot rebase` to the PR URL
+ * comments `@dependabot rebase` on the given PR number
  */
-async function rebaseDependabot(prUrl) {
-  console.log(`Asking Dependabot to rebase: ${prUrl}`);
-  const prNumber = prUrl.split('/').pop();
-  const resp = await octokit.issues.createComment({
-    owner: 'BuilderIO',
-    repo: 'builder',
-    issue_number: prNumber,
-    body: '@dependabot rebase',
-  });
-  if (resp.status >= 500) {
-    console.log(`Error rebasing ${prUrl}`);
-    // print details
-    console.log(resp);
-  } else {
-    console.log(`Rebased ${prUrl}`);
+async function rebaseDependabot(prNumber) {
+  console.log(`Asking Dependabot to rebase: ${prNumber}`);
+  try {
+    await $`gh pr comment ${prNumber} --body="@dependabot rebase"`;
+    console.log(`Rebased ${prNumber}`);
+  } catch (e) {
+    console.log(`Error rebasing ${prNumber}`);
+    console.log(e);
   }
 }
 
 async function main() {
   await getQuery();
-  await approve();
-  // await merge();
-}
+  const prs = await review();
+  if (prs.length === 0) {
+    return;
+  }
+  const mode = await question(
+    'Force merge now (admin, bypasses CI) or auto-merge when CI passes? [force/auto]: '
+  );
 
-async function workflowStuff() {
-  let x = null;
-  octokit.actions
-    .listRepoWorkflowRuns({ owner: 'BuilderIO', repo: 'builder', branch: 'main' })
-    .then(k => (x = k));
+  await approve(prs);
 
-  const cancelWorkflowRun2 = async workflow => {
-    try {
-      await octokit.request('POST /repos/BuilderIO/builder/actions/runs/{run_id}/cancel', {
-        run_id: workflow.id,
-      });
-      console.log('cancelled workflow:', workflow.id);
-    } catch (error) {
-      console.error('could not cancel workflow:', workflow.id);
-    }
-  };
-
-  octokit
-    .request('GET /repos/BuilderIO/builder/actions/runs?status=queued&branch=main&per_page=10')
-    .then(x => x.data.workflow_runs.map(cancelWorkflowRun2));
+  if (mode === 'force') {
+    await forceMerge(prs);
+  } else {
+    await enableAutoMerge(prs);
+    await rebaseAll(prs);
+  }
 }
 
 main();


### PR DESCRIPTION
## Description

Helps me quickly resolve dependabot PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Maintainer-only scripts, but the new **admin force-merge** path can bypass required checks, and bulk alert dismissal can hide real security issues if misused.
> 
> **Overview**
> **Dependabot PR workflows** are reworked around the **`gh` CLI** (no more `GITHUB_TOKEN_X` / Octokit in `merge-dependabot-prs.mjs`). The main merger now lists matching open Dependabot PRs, asks for confirmation, approves them, then either **queues squash auto-merge + `@dependabot rebase`** or **force-merges sequentially with `--admin --squash`** (bypassing CI, with a retry when the base branch moves). Dead workflow-cancel code is removed.
> 
> **`clean-dependabot-merger.mjs`** gains **limit/offset** paging (`sort=created`, slice after fetch), fixes **`gh search prs`** usage (non-empty terms, explicit `BuilderIO/builder` repo), and a **`close`** action alongside merge/msg.
> 
> A new **`clear-dependabot-alerts.mjs`** interactively fetches open Dependabot alerts by severity via **`gh api`**, confirms, and dismisses them with a chosen GitHub reason (documented as hiding alerts, not fixing deps).
> 
> **`.gitignore`** adds **`.builder/plans`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e59fb284feb40f50272de3c5957e8eee5bbe91ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->