### PR TITLE
chore[utils][smartling]: Bump up versions for utils and smartling plugin

### DIFF
--- a/packages/utils/package-lock.json
+++ b/packages/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/utils",
-  "version": "1.1.29",
+  "version": "1.1.30",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/utils",
-      "version": "1.1.29",
+      "version": "1.1.30",
       "dependencies": {
         "@types/lodash": "^4.14.182",
         "lodash": "^4.17.21",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/utils",
-  "version": "1.1.29",
+  "version": "1.1.30",
   "description": "Utils for working with Builder.io content",
   "main": "./dist/index.js",
   "scripts": {

--- a/plugins/smartling/package-lock.json
+++ b/plugins/smartling/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@builder.io/plugin-smartling",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-smartling",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "@builder.io/utils": "1.1.29",
+        "@builder.io/utils": "1.1.30",
         "fast-json-stable-stringify": "^2.1.0",
         "lodash": "^4.17.21",
         "object-hash": "^3.0.0",
@@ -1487,9 +1487,9 @@
       }
     },
     "node_modules/@builder.io/utils": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/@builder.io/utils/-/utils-1.1.29.tgz",
-      "integrity": "sha512-NYP1ZEXyZouLf9zFUAH9Hw/uxkz8VU213YcZfOE5jSmOZtcfWMztZo1/8G6pJM112qSw6m85Jd+BLQIsz6UhpQ==",
+      "version": "1.1.30",
+      "resolved": "https://registry.npmjs.org/@builder.io/utils/-/utils-1.1.30.tgz",
+      "integrity": "sha512-EP13COE3EEpfg2lIMLRDh2TSqgzH454lhWJuAN7cUPDjqc5MMgaXyhLQXG8T2tHI5bdy1s5eN6Q7fXIUdDcMCg==",
       "dependencies": {
         "@types/lodash": "^4.14.182",
         "lodash": "^4.17.21",
@@ -18340,39 +18340,6 @@
         "rc": "cli.js"
       }
     },
-    "node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
     "node_modules/react-event-listener": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.6.tgz",
@@ -19318,18 +19285,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
-    },
-    "node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
     },
     "node_modules/semantic-release": {
       "version": "21.0.1",
@@ -23444,9 +23399,9 @@
       }
     },
     "@builder.io/utils": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/@builder.io/utils/-/utils-1.1.29.tgz",
-      "integrity": "sha512-NYP1ZEXyZouLf9zFUAH9Hw/uxkz8VU213YcZfOE5jSmOZtcfWMztZo1/8G6pJM112qSw6m85Jd+BLQIsz6UhpQ==",
+      "version": "1.1.30",
+      "resolved": "https://registry.npmjs.org/@builder.io/utils/-/utils-1.1.30.tgz",
+      "integrity": "sha512-EP13COE3EEpfg2lIMLRDh2TSqgzH454lhWJuAN7cUPDjqc5MMgaXyhLQXG8T2tHI5bdy1s5eN6Q7fXIUdDcMCg==",
       "requires": {
         "@types/lodash": "^4.14.182",
         "lodash": "^4.17.21",
@@ -24853,8 +24808,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "7.0.1",
@@ -31310,8 +31264,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "29.4.3",
@@ -32092,15 +32045,13 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
       "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jss-global": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
       "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jss-nested": {
       "version": "6.0.1",
@@ -32126,8 +32077,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
       "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jss-vendor-prefixer": {
       "version": "7.0.0",
@@ -33166,15 +33116,13 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.4.0.tgz",
       "integrity": "sha512-bRuZp3C0itgLKHu/VNxi66DN/XVkQG7xtoBVWxpvC5FhAqbOCP21+nPhULjnzEqd7xBMybp6KwytdUpZKEgpIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "mobx-state-tree": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.1.5.tgz",
       "integrity": "sha512-jugIic0PYWW+nzzYfp4RUy9dec002Z778OC6KzoOyBHnqxupK9iPCsUJYkHjmNRHjZ8E4Z7qQpsKV3At/ntGVw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "modify-values": {
       "version": "1.0.1",
@@ -36061,31 +36009,6 @@
         "strip-json-comments": "~2.0.1"
       }
     },
-    "react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      }
-    },
-    "react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      }
-    },
     "react-event-listener": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.6.tgz",
@@ -36841,17 +36764,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
-    },
-    "scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
     },
     "semantic-release": {
       "version": "21.0.1",

--- a/plugins/smartling/package.json
+++ b/plugins/smartling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-smartling",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "keywords": [],
   "main": "dist/plugin.system.js",
@@ -125,7 +125,7 @@
     "typescript": "^3.0.3"
   },
   "dependencies": {
-    "@builder.io/utils": "1.1.29",
+    "@builder.io/utils": "1.1.30",
     "fast-json-stable-stringify": "^2.1.0",
     "lodash": "^4.17.21",
     "object-hash": "^3.0.0",


### PR DESCRIPTION
## Description

Version bump up for utils package from 1.1.29 to 1.1.30 and smartling plugin from 0.1.0 to 0.1.1. 

_Screenshot_
NA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and lockfile-only changes with no runtime code modifications in the diff.
> 
> **Overview**
> **Release prep only:** bumps `@builder.io/utils` from **1.1.29** to **1.1.30** and `@builder.io/plugin-smartling` from **0.1.0** to **0.1.1**, with matching updates in each package’s `package-lock.json`.
> 
> The Smartling plugin’s dependency on `@builder.io/utils` is updated to **1.1.30**. The Smartling lockfile also reflects routine npm lockfile normalization (e.g. trimmed peer entries and empty `requires` blocks)—no application source changes appear in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b217e4e54fbd788c83414cdb3f8dad2adb449242. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->