### PR TITLE
docs: update readme to remove gen2 warning

### DIFF
--- a/packages/sdks/output/react/README.md
+++ b/packages/sdks/output/react/README.md
@@ -1,7 +1,3 @@
-## NOTE
-
-At the moment, we are investigating some performance issues in our gen2 React SDK that prevent us from recommending it over the gen1 React SDK for all customer use-cases. Our team is actively working on these issues, and once they are resolved our recommendation will be to use the gen2 React SDK.
-
 # Builder.io React SDK v2
 
 This is the React v2 SDK, `@builder.io/sdk-react`. It is a complete rewrite of the React SDK, and has the following benefits:


### PR DESCRIPTION
Removing this warning as users are using this in production and we are installing the Gen2 version with our Builder agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no code, API, or runtime behavior impact.
> 
> **Overview**
> **Removes the prominent “NOTE” block** at the top of `packages/sdks/output/react/README.md` that told customers not to prefer the gen2 React SDK (`@builder.io/sdk-react`) over gen1 while performance issues were investigated.
> 
> The rest of the README is unchanged, including the v2 benefits list and the separate note about importing `@builder.io/sdk-react/edge` in serverless deployments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aece78d216e7b628b345932451adea42e6dc00bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->