### PR TITLE
fix[gen2][abTests]: ENG-12786 stop injecting duplicate A/B test init scripts on pages with multiple Content components

### DIFF
--- a/.changeset/ab-test-init-script-dedupe.md
+++ b/.changeset/ab-test-init-script-dedupe.md
@@ -1,0 +1,12 @@
+---
+"@builder.io/sdk-angular": patch
+"@builder.io/sdk-react-nextjs": patch
+"@builder.io/sdk-qwik": patch
+"@builder.io/sdk-react": patch
+"@builder.io/sdk-react-native": patch
+"@builder.io/sdk-solid": patch
+"@builder.io/sdk-svelte": patch
+"@builder.io/sdk-vue": patch
+---
+
+Stop injecting duplicate inline A/B test scripts on pages with multiple Content components. The `window.builderIoAbTest` / `window.builderIoRenderContent` init script is now only emitted when a Content actually renders A/B variants, and the definition is idempotent and self-removing on hydration targets. This avoids the duplication without the client-side DOM mutation that caused the previous hydration regression.

--- a/packages/sdks-tests/src/e2e-tests/ab-test.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/ab-test.spec.ts
@@ -24,7 +24,8 @@ const assertInitVariantsScriptCount = async (
 ) => {
   if (skip || !response) return;
   const html = await response.text();
-  const count = (html.match(/data-id="builderio-init-variants-fns"/g) || []).length;
+  // Quote-agnostic: React/Vue render `data-id="..."` while Svelte renders it unquoted.
+  const count = (html.match(/data-id=["']?builderio-init-variants-fns["'\s>]/g) || []).length;
   expect(count).toBe(expectedCount);
 };
 

--- a/packages/sdks-tests/src/e2e-tests/ab-test.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/ab-test.spec.ts
@@ -1,6 +1,6 @@
-import type { Browser } from '@playwright/test';
+import type { Browser, Response } from '@playwright/test';
 import { expect } from '@playwright/test';
-import { checkIsGen1React, checkIsRN, test } from '../helpers/index.js';
+import { checkIsGen1React, checkIsRN, isSSRFramework, test } from '../helpers/index.js';
 import {
   cloneContent,
   launchEmbedderAndWaitForSdk,
@@ -9,6 +9,24 @@ import {
 import { CONTENT as AB_TEST_CONTENT } from '../specs/ab-test.js';
 
 const SELECTOR = 'div[builder-content-id]';
+
+/**
+ * Counts the A/B-test init scripts (`builderio-init-variants-fns`) in the SSR
+ * response body. We read the raw response rather than the live DOM because on
+ * hydration targets the script self-removes after hydration. It is emitted once
+ * per Content that renders A/B variants, so a page with one A/B-tested content
+ * ships exactly one (and zero when no content has variants).
+ */
+const assertInitVariantsScriptCount = async (
+  response: Response | null,
+  expectedCount: number,
+  { skip = false } = {}
+) => {
+  if (skip || !response) return;
+  const html = await response.text();
+  const count = (html.match(/data-id="builderio-init-variants-fns"/g) || []).length;
+  expect(count).toBe(expectedCount);
+};
 
 const createContextWithCookies = async ({
   cookies,
@@ -91,6 +109,7 @@ test.describe('A/B tests', () => {
         baseURL,
         packageName,
         browser,
+        sdk,
       }) => {
         const { page } = await initializeAbTest(
           {
@@ -124,7 +143,10 @@ test.describe('A/B tests', () => {
           await route.continue();
         });
 
-        await page.goto('/ab-test', { waitUntil: 'networkidle' });
+        const response = await page.goto('/ab-test', { waitUntil: 'networkidle' });
+        await assertInitVariantsScriptCount(response, 1, {
+          skip: checkIsGen1React(sdk) || !isSSRFramework(packageName),
+        });
 
         expect(trackCalls).toBe(1);
 
@@ -138,6 +160,7 @@ test.describe('A/B tests', () => {
         baseURL,
         packageName,
         browser,
+        sdk,
       }) => {
         const { page } = await initializeAbTest(
           {
@@ -164,7 +187,10 @@ test.describe('A/B tests', () => {
           await route.continue();
         });
 
-        await page.goto('/ab-test', { waitUntil: 'networkidle' });
+        const response = await page.goto('/ab-test', { waitUntil: 'networkidle' });
+        await assertInitVariantsScriptCount(response, 1, {
+          skip: checkIsGen1React(sdk) || !isSSRFramework(packageName),
+        });
 
         expect(trackCalls).toBe(1);
 
@@ -195,6 +221,7 @@ test.describe('A/B tests', () => {
         baseURL,
         packageName,
         browser,
+        sdk,
       }) => {
         const { page } = await initializeAbTest(
           {
@@ -208,7 +235,10 @@ test.describe('A/B tests', () => {
             cookieValue: CONTENT_ID,
           }
         );
-        await page.goto('/symbol-ab-test');
+        const response = await page.goto('/symbol-ab-test');
+        await assertInitVariantsScriptCount(response, 1, {
+          skip: checkIsGen1React(sdk) || !isSSRFramework(packageName),
+        });
 
         await expect(page.getByText(TEXTS.DEFAULT_CONTENT).locator('visible=true')).toBeVisible();
         await expect(
@@ -224,6 +254,7 @@ test.describe('A/B tests', () => {
         baseURL,
         packageName,
         browser,
+        sdk,
       }) => {
         const { page } = await initializeAbTest(
           {
@@ -238,7 +269,10 @@ test.describe('A/B tests', () => {
           }
         );
 
-        await page.goto('/symbol-ab-test');
+        const response = await page.goto('/symbol-ab-test');
+        await assertInitVariantsScriptCount(response, 1, {
+          skip: checkIsGen1React(sdk) || !isSSRFramework(packageName),
+        });
 
         await expect(page.getByText(TEXTS.VARIANT_1).locator('visible=true')).toBeVisible();
         await expect(

--- a/packages/sdks/src/components/content-variants/content-variants.lite.tsx
+++ b/packages/sdks/src/components/content-variants/content-variants.lite.tsx
@@ -91,11 +91,6 @@ export default function ContentVariants(props: VariantsProviderProps) {
   return (
     <>
       <Show when={!props.isNestedRender && TARGET !== 'reactNative'}>
-        <InlinedScript
-          scriptStr={getInitVariantsFnsScriptString()}
-          id="builderio-init-variants-fns"
-          nonce={props.nonce || ''}
-        />
         {SDKS_SUPPORTING_PERSONALIZATION.includes(TARGET) && (
           <InlinedScript
             nonce={props.nonce || ''}
@@ -105,6 +100,12 @@ export default function ContentVariants(props: VariantsProviderProps) {
         )}
       </Show>
       <Show when={state.shouldRenderVariants}>
+        {/* Emit window.builderIoAbTest/builderIoRenderContent only when variants render; idempotent + self-removing to avoid duplicate defs and hydration mismatches. */}
+        <InlinedScript
+          scriptStr={getInitVariantsFnsScriptString()}
+          id="builderio-init-variants-fns"
+          nonce={props.nonce || ''}
+        />
         <InlinedStyles
           id="builderio-variants"
           styles={state.hideVariantsStyleString}

--- a/packages/sdks/src/components/content-variants/helpers.ts
+++ b/packages/sdks/src/components/content-variants/helpers.ts
@@ -70,8 +70,20 @@ const isAngularSDK = TARGET === 'angular';
 const isHydrationTarget = getIsHydrationTarget(TARGET);
 
 export const getInitVariantsFnsScriptString = () => `
-  window.${UPDATE_COOKIES_AND_STYLES_SCRIPT_NAME} = ${UPDATE_COOKIES_AND_STYLES_SCRIPT}
-  window.${UPDATE_VARIANT_VISIBILITY_SCRIPT_FN_NAME} = ${UPDATE_VARIANT_VISIBILITY_SCRIPT}
+  (function() {
+    if (!window.${UPDATE_COOKIES_AND_STYLES_SCRIPT_NAME}) {
+      window.${UPDATE_COOKIES_AND_STYLES_SCRIPT_NAME} = ${UPDATE_COOKIES_AND_STYLES_SCRIPT};
+    }
+    if (!window.${UPDATE_VARIANT_VISIBILITY_SCRIPT_FN_NAME}) {
+      window.${UPDATE_VARIANT_VISIBILITY_SCRIPT_FN_NAME} = ${UPDATE_VARIANT_VISIBILITY_SCRIPT};
+    }${
+      isHydrationTarget
+        ? `
+    var thisScriptEl = document.currentScript;
+    if (thisScriptEl) { thisScriptEl.remove(); }`
+        : ''
+    }
+  })();
   `;
 
 export const getUpdateCookieAndStylesScript = (


### PR DESCRIPTION
## Description

The Gen 2 React SDK injects the full `window.builderIoAbTest / window.builderIoRenderContent` definition as an inline <script> once per <Content> component, even on pages that have no A/B tests. On pages with several Content regions (header, body, footer…) this ships multiple identical ~4KB scripts. 

JTI saw 11 copies per page.

**Fix:**
- Only emit the init script when a Content actually renders A/B variants (gate it behind shouldRenderVariants). Pages with no A/B tests now emit it zero times.
- Make the script idempotent `(if (!window.builderIoAbTest) { … })` so repeated definitions never re-run and self-removing on hydration targets, matching how the SDK's existing A/B scripts already behave.

Re-added the e2e assertion that the revert removed, counting init scripts in the SSR response (the script self-removes from the live DOM, so we check the response body). Asserts the realistic post-fix counts.

**Note:**
This eliminates the duplication for the reported case and reduces A/B pages to one init per A/B-tested Content (defined once at runtime). Collapsing to a single tag per page regardless of A/B count requires cross-component coordination and is being tracked as a separate PR, since that touches the same hydration-sensitive path that caused the prior revert.

**JIRA Ticket:**
https://builder-io.atlassian.net/browse/ENG-12786

_Screenshot_
Clip of the issue:
https://clips.agent-native.com/r/9yBuG521T6eu

Clip of the fix:
https://clips.agent-native.com/r/JtAevmePWpKT


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inline script placement and hydration-target self-removal on the A/B SSR path, which is historically sensitive, though the fix deliberately avoids reintroducing the prior DOM-mutation regression.
> 
> **Overview**
> **Stops shipping duplicate `builderio-init-variants-fns` inline scripts** when a page has multiple `<Content>` regions. The `window.builderIoAbTest` / `window.builderIoRenderContent` init block is **moved out of the always-on path** and **only rendered when `shouldRenderVariants` is true**, so non–A/B content no longer injects it.
> 
> The init script string is now wrapped in an **idempotent IIFE** (assign globals only if missing) and on React/React Native hydration targets **removes itself via `document.currentScript`** after running, avoiding repeat definitions and the client-side DOM tweaks that previously caused hydration issues.
> 
> **E2E:** SSR A/B tests count `builderio-init-variants-fns` in the **raw navigation response** (not the live DOM) and expect **one** script for pages with a single A/B-tested content; Gen1 React and non-SSR frameworks skip the assertion.
> 
> Patch changeset across Gen2 SDK packages documents the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03df10b9db3f6a46ee812e33bd9dfa25b3769025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->