### PR TITLE
Update PR template to include Jira Ticket and Clip

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,5 +2,8 @@
 
 Add a short description of what changes you made, why you made them, and any other context that you think might be helpful for someone to better understand what is contained in this pull request. This sort of information is useful for people reviewing the code, as well as anyone from the future trying to understand why changes were made or why a bug started happening.
 
-_Screenshot_
-If relevant, add a screenshot or two of the changes you made.
+**Link to JIRA ticket (if applicable):**
+https://builder-io.atlassian.net/browse/...
+
+**Screenshot/Clip**
+If relevant, add a screenshot or clip of the changes you made.


### PR DESCRIPTION
## Description

Update PR template to include Jira Ticket and Clip

_Screenshot_
NA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the PR template with no runtime or product behavior impact.
> 
> **Overview**
> Updates the default pull request template so authors can link **JIRA tickets** and attach **screenshots or clips** in a consistent place.
> 
> The old italic screenshot placeholder is replaced with a **Link to JIRA ticket** block (Builder.io Atlassian URL placeholder) and a **Screenshot/Clip** heading with wording that mentions clips, not only screenshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aebd31a0c098aaad04b9949654a3c2a48ab08116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->