### PR TITLE
fix[sdks]: merge root state from content update messages

### DIFF
--- a/.changeset/merge-root-state-on-content-update.md
+++ b/.changeset/merge-root-state-on-content-update.md
@@ -1,0 +1,12 @@
+---
+"@builder.io/sdk-react": patch
+"@builder.io/sdk-vue": patch
+"@builder.io/sdk-svelte": patch
+"@builder.io/sdk-react-native": patch
+"@builder.io/sdk-solid": patch
+"@builder.io/sdk-react-nextjs": patch
+"@builder.io/sdk-qwik": patch
+"@builder.io/sdk-angular": patch
+---
+
+Fix root state not updating when state is embedded in editor content update messages

--- a/packages/sdks/src/components/content/components/enable-editor.lite.tsx
+++ b/packages/sdks/src/components/content/components/enable-editor.lite.tsx
@@ -198,6 +198,9 @@ export default function EnableEditor(props: BuilderEditorProps) {
           },
           contentUpdate: (newContent, editType) => {
             state.mergeNewContent(newContent, editType);
+            if(newContent.data?.state) {
+              state.mergeNewRootState(newContent.data.state)
+            }  
           },
           stateUpdate: (newState, editType) => {
             state.mergeNewRootState(newState, editType);


### PR DESCRIPTION
## Description

When the visual editor sends a `contentUpdate` message that includes `newContent.data.state`, the SDK was previously ignoring that state and only syncing it via dedicated `stateUpdate` messages. This caused previews to drift when state was embedded inside the content payload.

This change calls `mergeNewRootState` with `newContent.data.state` inside the `contentUpdate` callback whenever that field is present, keeping root state in sync regardless of which message carries it.

_Screenshot_
N/A — editor/preview-mode only change with no visible UI difference.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor/preview-only path in shared enable-editor messaging; narrow conditional merge with no auth or data-pipeline changes.
> 
> **Overview**
> When the visual editor sends **`contentUpdate`** with **`newContent.data.state`**, the SDK now merges that into root state via **`mergeNewRootState`**, not only when a separate **`stateUpdate`** arrives.
> 
> This keeps editor/preview bindings in sync when state rides along with content payloads, avoiding preview drift. The change lives in the shared **`enable-editor.lite.tsx`** Mitosis source and is released as a patch across all framework SDK packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bdc9a98cb72f4c5423818aae39ecd04a122cdf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->