### PR TITLE
Fix origin validation bypass in postMessage trust checks

### DIFF
--- a/.changeset/secure-editor-message-origins.md
+++ b/.changeset/secure-editor-message-origins.md
@@ -1,0 +1,14 @@
+---
+'@builder.io/react': patch
+'@builder.io/sdk': patch
+'@builder.io/sdk-angular': patch
+'@builder.io/sdk-qwik': patch
+'@builder.io/sdk-react': patch
+'@builder.io/sdk-react-native': patch
+'@builder.io/sdk-react-nextjs': patch
+'@builder.io/sdk-solid': patch
+'@builder.io/sdk-svelte': patch
+'@builder.io/sdk-vue': patch
+---
+
+Validate visual editor message origins with exact trusted hostnames and reject malformed or non-HTTP origins.

--- a/packages/core/src/builder.class.test.ts
+++ b/packages/core/src/builder.class.test.ts
@@ -22,6 +22,18 @@ describe('Builder', () => {
     Builder.registerTrustedHost('example.com');
     expect(Builder.isTrustedHost('example.com')).toBe(true);
   });
+
+  test('trusted message origins', () => {
+    expect(Builder.isTrustedHostForEvent({ origin: 'https://builder.io' })).toBe(true);
+    expect(Builder.isTrustedHostForEvent({ origin: 'http://localhost:1234' })).toBe(true);
+    expect(Builder.isTrustedHostForEvent({ origin: 'https://evil-builder.io.attacker.com' })).toBe(
+      false
+    );
+    expect(Builder.isTrustedHostForEvent({ origin: 'https://notlocalhost:1234x' })).toBe(false);
+    expect(Builder.isTrustedHostForEvent({ origin: 'javascript://builder.io' })).toBe(false);
+    expect(Builder.isTrustedHostForEvent({ origin: 'not a URL' })).toBe(false);
+    expect(Builder.isTrustedHostForEvent({ origin: 'null' })).toBe(false);
+  });
 });
 
 describe('serializeIncludingFunctions', () => {

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -1096,12 +1096,20 @@ export class Builder {
     return isTrusted;
   }
 
-  static isTrustedHostForEvent(event: MessageEvent) {
-    if (event.origin === 'null') {
+  static isTrustedHostForEvent(event: { origin: string }) {
+    if (!/^https?:\/\//i.test(event.origin)) {
       return false;
     }
-    const url = parse(event.origin);
-    return url.hostname && Builder.isTrustedHost(url.hostname);
+
+    try {
+      const url = parse(event.origin);
+      return (
+        (url.protocol === 'http:' || url.protocol === 'https:') &&
+        Boolean(url.hostname && Builder.isTrustedHost(url.hostname))
+      );
+    } catch {
+      return false;
+    }
   }
 
   static runAction(action: Action | string) {
@@ -1165,7 +1173,7 @@ export class Builder {
   // work but is async...
   static isEditing = Boolean(
     isIframe &&
-      ((document.referrer && document.referrer.match(/builder\.io|localhost:1234/)) ||
+      ((document.referrer && Builder.isTrustedHostForEvent({ origin: document.referrer })) ||
         location.search.indexOf('builder.frameEditing=') !== -1)
   );
 

--- a/packages/react/src/components/builder-block.component.tsx
+++ b/packages/react/src/components/builder-block.component.tsx
@@ -253,6 +253,9 @@ export class BuilderBlock extends React.Component<
   }
 
   onWindowMessage = (event: MessageEvent) => {
+    const isTrusted = Builder.isTrustedHostForEvent(event);
+    if (!isTrusted) return;
+
     const message = event.data;
     if (!message) {
       return;

--- a/packages/react/test/builder-block.test.tsx
+++ b/packages/react/test/builder-block.test.tsx
@@ -1,0 +1,28 @@
+jest.mock(
+  'src/functions/extract-localized-values',
+  () => ({ containsLocalizedValues: () => false, extractLocalizedValues: () => ({}) }),
+  { virtual: true }
+);
+
+import { Builder } from '@builder.io/sdk';
+import { BuilderBlock } from '../src/components/builder-block.component';
+
+describe('BuilderBlock', () => {
+  test('ignores messages from untrusted origins', () => {
+    const block = new BuilderBlock({ block: { id: 'block-id' } as any });
+    const event = {
+      origin: 'https://evil-builder.io.attacker.com',
+      data: {
+        type: 'builder.patchUpdates',
+        data: { data: { 'block-id': [{ op: 'add', path: '/bindings/x', value: 'alert(1)' }] } },
+      },
+    } as MessageEvent;
+    const trustedHostSpy = jest.spyOn(Builder, 'isTrustedHostForEvent').mockReturnValue(false);
+    const setStateSpy = jest.spyOn(block, 'setState');
+
+    block.onWindowMessage(event);
+
+    expect(trustedHostSpy).toHaveBeenCalledWith(event);
+    expect(setStateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sdks/src/functions/is-from-trusted-host.test.ts
+++ b/packages/sdks/src/functions/is-from-trusted-host.test.ts
@@ -44,7 +44,22 @@ describe('isFromTrustedHost', () => {
     ).toBe(true);
   });
 
-  test('when origin is not a URL', () => {
+  test('spoofed trusted hostnames', () => {
+    expect(
+      isFromTrustedHost(undefined, {
+        origin: 'https://evil-builder.io.attacker.com',
+      })
+    ).toBe(false);
+    expect(
+      isFromTrustedHost(undefined, { origin: 'https://notlocalhost:1234x' })
+    ).toBe(false);
+  });
+
+  test('when origin is not an HTTP URL', () => {
     expect(isFromTrustedHost(undefined, { origin: 'foo' })).toBe(false);
+    expect(
+      isFromTrustedHost(undefined, { origin: 'javascript://builder.io' })
+    ).toBe(false);
+    expect(isFromTrustedHost(undefined, { origin: 'null' })).toBe(false);
   });
 });

--- a/packages/sdks/src/functions/is-from-trusted-host.ts
+++ b/packages/sdks/src/functions/is-from-trusted-host.ts
@@ -10,17 +10,22 @@ export function isFromTrustedHost(
   trustedHosts: string[] | undefined,
   e: { origin: string }
 ): boolean {
-  if (!e.origin.startsWith('http') && !e.origin.startsWith('https')) {
+  let url: URL;
+  try {
+    url = new URL(e.origin);
+  } catch {
     return false;
   }
-  const url = new URL(e.origin),
-    hostname = url.hostname;
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return false;
+  }
 
   return (
     (trustedHosts || DEFAULT_TRUSTED_HOSTS).findIndex((trustedHost) =>
       trustedHost.startsWith('*.')
-        ? hostname.endsWith(trustedHost.slice(1))
-        : trustedHost === hostname
+        ? url.hostname.endsWith(trustedHost.slice(1))
+        : trustedHost === url.hostname
     ) > -1
   );
 }


### PR DESCRIPTION
## Description

Fixes a security issue reported by a customer where `postMessage` origin/referrer validation could be bypassed using spoofed or lookalike hostnames, potentially allowing untrusted windows to send messages (including block bindings that get executed as code) to Builder-rendered pages.

Specifically:

- **`packages/core/src/builder.class.ts`**: `Builder.isTrustedHostForEvent` previously parsed the origin without strictly validating the protocol/format, and `Builder.isEditing` used an unanchored regex (`/builder\.io|localhost:1234/`) against `document.referrer`, which would match spoofed hostnames like `evil-builder.io.attacker.com` or `notlocalhost:1234x`. This has been fixed by:
  - Requiring the origin to match `^https?:\/\//i` before parsing.
  - Validating the parsed protocol is `http:`/`https:` and the hostname is trusted via `Builder.isTrustedHost`.
  - Replacing the unanchored regex check in `isEditing` with a call to `Builder.isTrustedHostForEvent`, reusing the same validated logic.

- **`packages/react/src/components/builder-block.component.tsx`**: `BuilderBlock.onWindowMessage` did not validate the message origin at all, unlike `BuilderContent.onWindowMessage`. Added an origin check using `Builder.isTrustedHostForEvent(event)` at the top of the handler, returning early if the origin isn't trusted, matching the existing pattern used by `BuilderContent`.

- **`packages/sdks/src/functions/is-from-trusted-host.ts`**: `isFromTrustedHost` used `startsWith('http')`/`startsWith('https')` checks and did not guard against malformed URLs throwing during `new URL(...)`. Updated to safely parse the URL in a try/catch, return `false` on parse failure, and explicitly validate the protocol is `http:` or `https:` before checking the hostname against the trusted hosts list. This applies the same fix to the Gen2 SDKs.

### Tests

- Added/updated tests in `packages/core/src/builder.class.test.ts`, `packages/react/test/builder-block.test.tsx` (new), and `packages/sdks/src/functions/is-from-trusted-host.test.ts` covering spoofed hostnames (e.g. `evil-builder.io.attacker.com`, `notlocalhost:1234x`), non-HTTP origins (e.g. `javascript://builder.io`), the literal string `"null"`, and non-URL strings — asserting these are all correctly rejected as untrusted.


**JIRA**
https://builder-io.atlassian.net/browse/ENG-13357

---

<a href="https://builder.io/app/projects/b29d4bc79bfe480fb3f0/classic-seed-fvi4jqvb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://b29d4bc79bfe480fb3f0-classic-seed-fvi4jqvb.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4724`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b29d4bc79bfe480fb3f0</projectId>-->
<!--<branchName>classic-seed-fvi4jqvb</branchName>-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security fix for editor postMessage handling and code-binding updates; incorrect validation could break legitimate editing or leave XSS vectors open.
> 
> **Overview**
> Closes a **postMessage origin bypass** where spoofed hostnames or malformed origins could be treated as trusted, allowing untrusted pages to send editor messages (including `builder.patchUpdates` that apply bindings executed as code).
> 
> **`Builder.isTrustedHostForEvent`** now requires `^https?://`, parses the origin in a try/catch, enforces `http:`/`https:` protocol, and checks the hostname with **`Builder.isTrustedHost`** (exact match, not substring). **`Builder.isEditing`** drops the unanchored `/builder\.io|localhost:1234/` referrer regex in favor of the same helper.
> 
> **`BuilderBlock.onWindowMessage`** adds an early **`isTrustedHostForEvent`** guard (aligned with other editor listeners). Gen2 **`isFromTrustedHost`** mirrors the same parse/protocol/hostname rules.
> 
> Tests cover lookalike domains, non-HTTP schemes, and invalid origins; a changeset patches all affected SDK packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7f5de7509ad1c674bbb0279c1e95257d2cf64d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->