### PR TITLE
fix[angular][gen2]: Gen 2 Angular SDK text block edits revert in Visual Editor live preview

### DIFF
--- a/.changeset/angular-stale-content-remerge.md
+++ b/.changeset/angular-stale-content-remerge.md
@@ -1,0 +1,11 @@
+---
+'@builder.io/sdk-angular': patch
+---
+
+Fix: edits made in the Visual Editor no longer revert to the initially rendered content.
+
+The `props.content` update hook is compiled to an Angular `effect()` that tracks every
+signal read in its body instead of the declared dependency list. Any unrelated context
+update therefore re-ran the hook and re-merged the original page-load `props.content`
+over content received from the editor. Guard the merge with a `prevContent` check, the
+same pattern already used by the neighbouring `props.data` and `props.locale` hooks.

--- a/packages/sdks/src/components/content/components/enable-editor.lite.tsx
+++ b/packages/sdks/src/components/content/components/enable-editor.lite.tsx
@@ -90,6 +90,7 @@ export default function EnableEditor(props: BuilderEditorProps) {
   const state = useStore({
     prevData: null as Dictionary<any> | null,
     prevLocale: '',
+    prevContent: null as BuilderContent | null,
     mergeNewRootState(newData: Dictionary<any>, editType?: EditType) {
       const combinedState = {
         ...props.builderContextSignal.value.rootState,
@@ -344,7 +345,17 @@ export default function EnableEditor(props: BuilderEditorProps) {
               state.runHttpRequests();
             });
           }
+          /**
+           * Angular compiles this hook into an `effect()` that tracks every signal
+           * read in its body rather than the declared `[props.content]` deps. Without
+           * this guard, unrelated context updates re-merge the stale `props.content`
+           * over edits made in the Visual Editor.
+           */
+          if (state.prevContent === props.content) {
+            return;
+          }
           state.mergeNewContent(props.content);
+          state.prevContent = props.content;
         }
       },
       default: () => {


### PR DESCRIPTION
## Description

Text edits made in the Visual Editor were reverting to the content from the initial page render. Depending on the entry, this showed up in one of two ways: the edit never appeared at all, or it appeared and then vanished as soon as you clicked out of or hovered over the block. 

The edit was always saved correctly, only the live preview was wrong, and a refresh showed the right text.

**Root cause:**
In `enable-editor.lite.tsx` there's a hook that re-merges props.content whenever it changes:
`onUpdate(() => { ...; state.mergeNewContent(props.content); }, [props.content]);`

On every other SDK the [props.content] dependency list means this runs only when the entry actually changes. Angular compiles it to an effect(), which tracks every signal read inside the body and ignores the declared deps. Because mergeNewContent reads `builderContextSignal` internally, the hook ended up depending on the very thing it writes, so any unrelated context update re-ran it and merged the original page-load props.content back over the editor's changes. props.content is spread last in the merge, so the stale copy always won, including `data.blocks`.

**Fix:**
Guard the merge with a `prevContent` reference check so it only runs when `props.content` genuinely changed. This is the same pattern the two neighbouring hooks (`props.data` and `props.locale`) already use, for exactly the same reason, so this one was simply missed.

The change is inside the existing `angular:` branch of the `useTarget`, so no other SDK's generated output changes.

**Link to JIRA ticket (if applicable):**
https://builder-io.atlassian.net/browse/ENG-13417

**Screenshot/Clip**
Before:
https://clips.agent-native.com/share/8DnXDACWosxp

After dev release:
https://clips.agent-native.com/share/af2ChL52J8eS?ref=clip_share&dashboard_redirect=1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, Angular-only guard in shared Mitosis source; editing/preview behavior elsewhere is untouched.
> 
> **Overview**
> Fixes **Gen 2 Angular** live preview where text and other block edits in the Visual Editor snapped back to the initially rendered content.
> 
> In `enable-editor.lite.tsx`, the Angular path for the `props.content` `onUpdate` hook now tracks **`prevContent`** and skips `mergeNewContent` when `props.content` is unchanged. Mitosis turns that hook into an Angular `effect()` that re-runs on any signal read in the body—not only when `props.content` changes—so unrelated context updates were repeatedly merging the original page-load `props.content` over editor-driven context. The same guard pattern already used for **`props.data`** and **`props.locale`** is applied here; non-Angular targets are unchanged.
> 
> A patch changeset documents the fix for **`@builder.io/sdk-angular`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 921c478da5f1cc959a20c53bad9e111a58244c76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->