### PR TITLE
fix[smartling]: ENG-13241 Smartling plugin not sending list fields with localized subfields to translation jobs

### DIFF
--- a/packages/utils/src/translation-helpers.test.ts
+++ b/packages/utils/src/translation-helpers.test.ts
@@ -1304,6 +1304,107 @@ test('applyTranslation ignores a non-string flat value echoed back for a localiz
   expect((result.data!.blocks as any)[0].meta.translated).toBeUndefined();
 });
 
+// A localized subfield whose payload is an object of plain strings, rather than a string.
+const objectPayloadContent = (): BuilderContent => ({
+  data: {
+    blocks: [
+      {
+        '@type': '@builder.io/sdk:Element',
+        id: 'builder-objectpayload',
+        meta: { localizedTextInputs: ['cards'] },
+        component: {
+          name: 'CardList',
+          options: {
+            cards: {
+              '@type': localizedType,
+              Default: [
+                {
+                  sku: 'SKU-1',
+                  details: {
+                    '@type': localizedType,
+                    Default: { heading: 'Card heading', body: 'Card body' },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    ],
+  },
+});
+
+test('getTranslateableFields extracts plain strings inside a localized object-valued subfield', () => {
+  const result = getTranslateableFields(objectPayloadContent(), 'en-US', 'instructions');
+
+  expect(result).toEqual({
+    'blocks.builder-objectpayload#cards#0#details#heading': {
+      value: 'Card heading',
+      instructions: 'instructions',
+    },
+    'blocks.builder-objectpayload#cards#0#details#body': {
+      value: 'Card body',
+      instructions: 'instructions',
+    },
+  });
+
+  // `sku` sits outside the localized subfield, so it is still not sent
+  expect(Object.keys(result).some(key => key.includes('sku'))).toBe(false);
+});
+
+test('applyTranslation writes into the locale branch of a localized object-valued subfield', () => {
+  const translation = {
+    'blocks.builder-objectpayload#cards#0#details#heading': { value: 'Karten-Überschrift' },
+    'blocks.builder-objectpayload#cards#0#details#body': { value: 'Kartentext' },
+  };
+
+  const result = applyTranslation(objectPayloadContent(), translation, 'de-DE', 'en-US');
+  const cards = (result.data!.blocks as any)[0].component.options.cards;
+  const details = cards['de-DE'][0].details;
+
+  // Translation lands inside the nested LocalizedValue's locale branch...
+  expect(details['de-DE']).toEqual({ heading: 'Karten-Überschrift', body: 'Kartentext' });
+  // ...not as stray keys on the wrapper itself
+  expect(details.heading).toBeUndefined();
+  expect(details.body).toBeUndefined();
+  // ...and the source payload is preserved
+  expect(details.Default).toEqual({ heading: 'Card heading', body: 'Card body' });
+});
+
+test('getTranslateableFields honours deeper localized markers over unmarked siblings', () => {
+  const content: BuilderContent = {
+    data: {
+      blocks: [
+        {
+          '@type': '@builder.io/sdk:Element',
+          id: 'builder-mixed',
+          meta: { localizedTextInputs: ['details'] },
+          component: {
+            name: 'Mixed',
+            options: {
+              details: {
+                '@type': localizedType,
+                Default: {
+                  heading: 'Unmarked heading',
+                  sub: { '@type': localizedType, Default: 'Marked sub' },
+                },
+              },
+            },
+          },
+        },
+      ],
+    },
+  };
+
+  const result = getTranslateableFields(content, 'en-US', 'instructions');
+
+  // Where the payload carries its own localized markers we honour them, matching how
+  // unmarked siblings are skipped at the top level. `heading` is intentionally omitted.
+  expect(result).toEqual({
+    'blocks.builder-mixed#details#sub': { value: 'Marked sub', instructions: 'instructions' },
+  });
+});
+
 test('getTranslateableFields falls back to string leaves when a localized list has no localized subfields', () => {
   const content: BuilderContent = {
     data: {

--- a/packages/utils/src/translation-helpers.test.ts
+++ b/packages/utils/src/translation-helpers.test.ts
@@ -1161,3 +1161,181 @@ test('applyTranslation uses sourceLocaleId as the base when it differs from Defa
   expect(localizedItems.Default).toHaveLength(1);
   expect(localizedItems['en-US']).toHaveLength(2);
 });
+
+// A registered custom component whose list input is `localized: true` AND whose subFields
+// are `localized: true`. The list input is a LocalizedValue wrapping an array of items,
+// each mixing localized subfields with plain ones.
+const productGridContent = (): BuilderContent => ({
+  data: {
+    blocks: [
+      {
+        '@type': '@builder.io/sdk:Element',
+        '@version': 2,
+        id: 'builder-productgrid',
+        meta: {
+          localizedTextInputs: ['products'],
+        },
+        component: {
+          name: 'ProductGrid',
+          options: {
+            products: {
+              '@type': localizedType,
+              Default: [
+                {
+                  currency: 'USD',
+                  rating: 4.9,
+                  ratingCount: 10,
+                  imageSrc: 'https://cdn.builder.io/api/v1/image/watch.png',
+                  id: { '@type': localizedType, Default: 'prod-001' },
+                  title: { '@type': localizedType, Default: 'Smart Fitness Watch new' },
+                  description: { '@type': localizedType, Default: 'Water-resistant smartwatch' },
+                },
+                {
+                  currency: 'USD',
+                  rating: 5,
+                  ratingCount: 40,
+                  imageSrc: 'https://cdn.builder.io/api/v1/image/headphones.png',
+                  id: { '@type': localizedType, Default: 'prod-002' },
+                  title: { '@type': localizedType, Default: 'Wireless Headphones' },
+                  description: { '@type': localizedType, Default: 'Premium over-ear headphones' },
+                },
+              ],
+            },
+          },
+        },
+      },
+    ],
+  },
+});
+
+test('getTranslateableFields extracts localized subfields of a localized list input on a custom component', () => {
+  const result = getTranslateableFields(productGridContent(), 'en-US', 'instructions');
+
+  expect(result).toEqual({
+    'blocks.builder-productgrid#products#0#id': {
+      value: 'prod-001',
+      instructions: 'instructions',
+    },
+    'blocks.builder-productgrid#products#0#title': {
+      value: 'Smart Fitness Watch new',
+      instructions: 'instructions',
+    },
+    'blocks.builder-productgrid#products#0#description': {
+      value: 'Water-resistant smartwatch',
+      instructions: 'instructions',
+    },
+    'blocks.builder-productgrid#products#1#id': {
+      value: 'prod-002',
+      instructions: 'instructions',
+    },
+    'blocks.builder-productgrid#products#1#title': {
+      value: 'Wireless Headphones',
+      instructions: 'instructions',
+    },
+    'blocks.builder-productgrid#products#1#description': {
+      value: 'Premium over-ear headphones',
+      instructions: 'instructions',
+    },
+  });
+});
+
+test('getTranslateableFields does not send non-localized siblings of a localized list input', () => {
+  const result = getTranslateableFields(productGridContent(), 'en-US', 'instructions');
+  const values = Object.values(result).map(entry => entry.value);
+
+  expect(values).not.toContain('USD');
+  expect(values).not.toContain('https://cdn.builder.io/api/v1/image/watch.png');
+  expect(Object.keys(result).some(key => key.includes('currency'))).toBe(false);
+  expect(Object.keys(result).some(key => key.includes('imageSrc'))).toBe(false);
+  expect(Object.keys(result).some(key => key.includes('rating'))).toBe(false);
+});
+
+test('applyTranslation writes localized list subfields back into the target locale', () => {
+  const content = productGridContent();
+  const translation = {
+    'blocks.builder-productgrid#products#0#id': { value: 'prod-001' },
+    'blocks.builder-productgrid#products#0#title': { value: 'Intelligente Fitnessuhr' },
+    'blocks.builder-productgrid#products#0#description': { value: 'Wasserfeste Smartwatch' },
+    'blocks.builder-productgrid#products#1#id': { value: 'prod-002' },
+    'blocks.builder-productgrid#products#1#title': { value: 'Kabellose Kopfhörer' },
+    'blocks.builder-productgrid#products#1#description': { value: 'Premium Over-Ear-Kopfhörer' },
+  };
+
+  const result = applyTranslation(content, translation, 'de-DE', 'en-US');
+  const products = (result.data!.blocks as any)[0].component.options.products;
+
+  // Nested LocalizedValue structure is preserved, with the locale added alongside Default
+  expect(products['de-DE'][0].title).toEqual({
+    '@type': localizedType,
+    Default: 'Smart Fitness Watch new',
+    'de-DE': 'Intelligente Fitnessuhr',
+  });
+  expect(products['de-DE'][1].description).toEqual({
+    '@type': localizedType,
+    Default: 'Premium over-ear headphones',
+    'de-DE': 'Premium Over-Ear-Kopfhörer',
+  });
+
+  // Non-localized siblings are carried over untouched
+  expect(products['de-DE'][0].currency).toBe('USD');
+  expect(products['de-DE'][0].rating).toBe(4.9);
+
+  // The source payload is not mutated
+  expect(products.Default[0].title).toEqual({
+    '@type': localizedType,
+    Default: 'Smart Fitness Watch new',
+  });
+
+  expect((result.data!.blocks as any)[0].meta.translated).toBe(true);
+});
+
+test('applyTranslation ignores a non-string flat value echoed back for a localized list input', () => {
+  const content = productGridContent();
+  const untranslatedEcho = {
+    'blocks.builder-productgrid#products': {
+      value: [{ title: { '@type': localizedType, Default: 'Smart Fitness Watch new' } }] as any,
+    },
+  };
+
+  const result = applyTranslation(content, untranslatedEcho, 'de-DE', 'en-US');
+  const products = (result.data!.blocks as any)[0].component.options.products;
+
+  expect(products['de-DE']).toBeUndefined();
+  expect((result.data!.blocks as any)[0].meta.translated).toBeUndefined();
+});
+
+test('getTranslateableFields falls back to string leaves when a localized list has no localized subfields', () => {
+  const content: BuilderContent = {
+    data: {
+      blocks: [
+        {
+          '@type': '@builder.io/sdk:Element',
+          id: 'builder-plainlist',
+          meta: { localizedTextInputs: ['items'] },
+          component: {
+            name: 'PlainList',
+            options: {
+              items: {
+                '@type': localizedType,
+                Default: [{ label: 'First label' }, { label: 'Second label' }],
+              },
+            },
+          },
+        },
+      ],
+    },
+  };
+
+  const result = getTranslateableFields(content, 'en-US', 'instructions');
+
+  expect(result).toEqual({
+    'blocks.builder-plainlist#items#0#label': {
+      value: 'First label',
+      instructions: 'instructions',
+    },
+    'blocks.builder-plainlist#items#1#label': {
+      value: 'Second label',
+      instructions: 'instructions',
+    },
+  });
+});

--- a/packages/utils/src/translation-helpers.test.ts
+++ b/packages/utils/src/translation-helpers.test.ts
@@ -1288,20 +1288,32 @@ test('applyTranslation writes localized list subfields back into the target loca
   expect((result.data!.blocks as any)[0].meta.translated).toBe(true);
 });
 
-test('applyTranslation ignores a non-string flat value echoed back for a localized list input', () => {
-  const content = productGridContent();
-  // Smartling returns the payload byte-identical when it contains no textValue/htmlValue
-  const sourcePayload = (productGridContent().data!.blocks as any)[0].component.options.products
-    .Default;
-  const untranslatedEcho = {
-    'blocks.builder-productgrid#products': { value: sourcePayload as any },
-  };
+const flatObjectResponse = () => ({
+  'blocks.builder-productgrid#products': {
+    value: (productGridContent().data!.blocks as any)[0].component.options.products.Default as any,
+  },
+});
 
-  const result = applyTranslation(content, untranslatedEcho, 'de-DE', 'en-US');
+test('applyTranslation ignores a flat object response when the provider echoes the payload', () => {
+  const content = productGridContent();
+
+  const result = applyTranslation(content, flatObjectResponse(), 'de-DE', 'en-US', {
+    providerEchoesSourcePayload: true,
+  });
   const products = (result.data!.blocks as any)[0].component.options.products;
 
   expect(products['de-DE']).toBeUndefined();
   expect((result.data!.blocks as any)[0].meta.translated).toBeUndefined();
+});
+
+test('applyTranslation writes a flat object response from a provider that translates it', () => {
+  const content = productGridContent();
+
+  const result = applyTranslation(content, flatObjectResponse(), 'de-DE', 'en-US');
+  const products = (result.data!.blocks as any)[0].component.options.products;
+
+  expect(products['de-DE']).toHaveLength(2);
+  expect((result.data!.blocks as any)[0].meta.translated).toBe(true);
 });
 
 test('applyTranslation keeps source text on nested leaves that received no translation', () => {

--- a/packages/utils/src/translation-helpers.test.ts
+++ b/packages/utils/src/translation-helpers.test.ts
@@ -1162,9 +1162,8 @@ test('applyTranslation uses sourceLocaleId as the base when it differs from Defa
   expect(localizedItems['en-US']).toHaveLength(2);
 });
 
-// A registered custom component whose list input is `localized: true` AND whose subFields
-// are `localized: true`. The list input is a LocalizedValue wrapping an array of items,
-// each mixing localized subfields with plain ones.
+// Custom component with `localized: true` on both the list input and its subFields:
+// a LocalizedValue wrapping items that mix localized subfields with plain ones.
 const productGridContent = (): BuilderContent => ({
   data: {
     blocks: [
@@ -1291,10 +1290,11 @@ test('applyTranslation writes localized list subfields back into the target loca
 
 test('applyTranslation ignores a non-string flat value echoed back for a localized list input', () => {
   const content = productGridContent();
+  // Smartling returns the payload byte-identical when it contains no textValue/htmlValue
+  const sourcePayload = (productGridContent().data!.blocks as any)[0].component.options.products
+    .Default;
   const untranslatedEcho = {
-    'blocks.builder-productgrid#products': {
-      value: [{ title: { '@type': localizedType, Default: 'Smart Fitness Watch new' } }] as any,
-    },
+    'blocks.builder-productgrid#products': { value: sourcePayload as any },
   };
 
   const result = applyTranslation(content, untranslatedEcho, 'de-DE', 'en-US');
@@ -1398,8 +1398,7 @@ test('getTranslateableFields honours deeper localized markers over unmarked sibl
 
   const result = getTranslateableFields(content, 'en-US', 'instructions');
 
-  // Where the payload carries its own localized markers we honour them, matching how
-  // unmarked siblings are skipped at the top level. `heading` is intentionally omitted.
+  // Own markers win, as unmarked siblings do at the top level; `heading` is omitted.
   expect(result).toEqual({
     'blocks.builder-mixed#details#sub': { value: 'Marked sub', instructions: 'instructions' },
   });

--- a/packages/utils/src/translation-helpers.test.ts
+++ b/packages/utils/src/translation-helpers.test.ts
@@ -1304,6 +1304,48 @@ test('applyTranslation ignores a non-string flat value echoed back for a localiz
   expect((result.data!.blocks as any)[0].meta.translated).toBeUndefined();
 });
 
+test('applyTranslation keeps source text on nested leaves that received no translation', () => {
+  const content: BuilderContent = {
+    data: {
+      blocks: [
+        {
+          '@type': '@builder.io/sdk:Element',
+          id: 'builder-partial',
+          meta: { localizedTextInputs: ['items'] },
+          component: {
+            name: 'PartialList',
+            options: {
+              items: {
+                '@type': localizedType,
+                Default: [
+                  {
+                    title: { '@type': localizedType, Default: 'Translated title' },
+                    badge: { '@type': localizedType, Default: '' },
+                    note: { '@type': localizedType, Default: 'Untranslated note' },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    },
+  };
+
+  const result = applyTranslation(
+    content,
+    { 'blocks.builder-partial#items#0#title': { value: 'Übersetzter Titel' } },
+    'de-DE',
+    'en-US'
+  );
+  const item = (result.data!.blocks as any)[0].component.options.items['de-DE'][0];
+
+  expect(item.title['de-DE']).toBe('Übersetzter Titel');
+  // Untranslated leaves keep a locale key, so the SDK does not resolve them to undefined
+  expect(item.note['de-DE']).toBe('Untranslated note');
+  expect(item.badge['de-DE']).toBe('');
+});
+
 // A localized subfield whose payload is an object of plain strings, rather than a string.
 const objectPayloadContent = (): BuilderContent => ({
   data: {

--- a/packages/utils/src/translation-helpers.ts
+++ b/packages/utils/src/translation-helpers.ts
@@ -255,7 +255,7 @@ function extractLocalizedLeaves(
   }
 
   if (value['@type'] === localizedType) {
-    const nested = value[sourceLocaleId] || value.Default;
+    const nested = value[sourceLocaleId] != null ? value[sourceLocaleId] : value.Default;
     const nestedInstructions = value.meta?.instructions || instructions;
     if (typeof nested === 'string') {
       if (nested) {

--- a/packages/utils/src/translation-helpers.ts
+++ b/packages/utils/src/translation-helpers.ts
@@ -447,6 +447,30 @@ export function getTranslateableFields(
   return results;
 }
 
+// Gives every nested LocalizedValue a locale branch seeded from the source. The SDK
+// resolves a missing locale key to undefined rather than falling back to Default, so
+// untranslated leaves would otherwise vanish while their plain-string siblings survive
+// the clone.
+function seedLocaleBranches(node: any, locale: string, sourceLocaleId?: string) {
+  if (Array.isArray(node)) {
+    node.forEach(item => seedLocaleBranches(item, locale, sourceLocaleId));
+    return;
+  }
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+  if (node['@type'] === localizedType) {
+    if (node[locale] === null || node[locale] === undefined) {
+      const source =
+        sourceLocaleId && node[sourceLocaleId] != null ? node[sourceLocaleId] : node.Default;
+      node[locale] = source == null ? source : JSON.parse(JSON.stringify(source));
+    }
+    seedLocaleBranches(node[locale], locale, sourceLocaleId);
+    return;
+  }
+  Object.values(node).forEach(value => seedLocaleBranches(value, locale, sourceLocaleId));
+}
+
 // Writes a translated leaf into a cloned payload, stepping through intermediate
 // LocalizedValue nodes into their locale branch. Without this, `details#heading` would land
 // on the wrapper next to `@type`/`Default` instead of in the data.
@@ -761,6 +785,7 @@ export function applyTranslation(
           }
 
           const localeValue = JSON.parse(JSON.stringify(sourceValue));
+          seedLocaleBranches(localeValue, locale, sourceLocaleId);
           compoundKeys.forEach(compoundKey => {
             const segments = compoundKey
               .slice(prefix.length)

--- a/packages/utils/src/translation-helpers.ts
+++ b/packages/utils/src/translation-helpers.ts
@@ -265,9 +265,18 @@ function extractLocalizedLeaves(
       return 1;
     }
     if (nested !== null && nested !== undefined) {
-      return (
-        1 + extractLocalizedLeaves(nested, basePath, results, nestedInstructions, sourceLocaleId)
+      // The payload is an object/array. Honour any deeper localized markers it carries;
+      // if it has none, the whole payload is the translatable unit.
+      const deeper = extractLocalizedLeaves(
+        nested,
+        basePath,
+        results,
+        nestedInstructions,
+        sourceLocaleId
       );
+      if (deeper === 0) {
+        extractNestedStrings(nested, basePath, results, nestedInstructions, sourceLocaleId);
+      }
     }
     return 1;
   }
@@ -440,6 +449,51 @@ export function getTranslateableFields(
   }
 
   return results;
+}
+
+// Writes a translated leaf into a cloned payload, stepping through any intermediate
+// LocalizedValue node into its locale branch (seeded from the source payload) rather than
+// treating the wrapper as the leaf. Without this, a path like `details#heading` would be
+// written onto the wrapper next to `@type`/`Default` instead of into the actual data.
+function setTranslatedLeaf({
+  payload,
+  segments,
+  value,
+  locale,
+  sourceLocaleId,
+}: {
+  payload: any;
+  segments: (string | number)[];
+  value: any;
+  locale: string;
+  sourceLocaleId?: string;
+}) {
+  let node = payload;
+
+  for (const segment of segments.slice(0, -1)) {
+    const child = node?.[segment];
+    if (child && typeof child === 'object' && child['@type'] === localizedType) {
+      if (child[locale] === null || child[locale] === undefined) {
+        const source =
+          sourceLocaleId && child[sourceLocaleId] != null ? child[sourceLocaleId] : child.Default;
+        child[locale] = JSON.parse(JSON.stringify(source ?? {}));
+      }
+      node = child[locale];
+    } else {
+      node = child;
+    }
+    if (node === null || node === undefined) {
+      return;
+    }
+  }
+
+  const leafSegment = segments[segments.length - 1];
+  const leaf = node?.[leafSegment];
+  if (leaf && typeof leaf === 'object' && leaf['@type'] === localizedType) {
+    node[leafSegment] = { ...leaf, [locale]: value };
+  } else if (node) {
+    node[leafSegment] = value;
+  }
 }
 
 export function applyTranslation(
@@ -698,19 +752,13 @@ export function applyTranslation(
               .slice(prefix.length)
               .split('#')
               .map((segment: string) => (/^\d+$/.test(segment) ? parseInt(segment, 10) : segment));
-            const existingLeaf = get(localeValue, segments);
-            if (
-              existingLeaf &&
-              typeof existingLeaf === 'object' &&
-              existingLeaf['@type'] === localizedType
-            ) {
-              set(localeValue, segments, {
-                ...existingLeaf,
-                [locale]: unescapeStringOrObject(translation[compoundKey].value),
-              });
-            } else {
-              set(localeValue, segments, unescapeStringOrObject(translation[compoundKey].value));
-            }
+            setTranslatedLeaf({
+              payload: localeValue,
+              segments,
+              value: unescapeStringOrObject(translation[compoundKey].value),
+              locale,
+              sourceLocaleId,
+            });
           });
 
           set(options, key, { ...(existing || {}), [locale]: localeValue });

--- a/packages/utils/src/translation-helpers.ts
+++ b/packages/utils/src/translation-helpers.ts
@@ -4,6 +4,7 @@ import omit from 'lodash/omit';
 import unescape from 'lodash/unescape';
 import set from 'lodash/set';
 import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
 
 export const localizedType = '@builder.io/core:LocalizedValue';
 
@@ -230,11 +231,9 @@ function extractNestedStrings(
   }
 }
 
-// Recursively walks an already-extracted LocalizedValue payload (array or object) and
-// records only the leaves that are themselves LocalizedValues, i.e. the subfields the
-// component schema explicitly marked `localized: true`. Returns how many LocalizedValue
-// nodes were found so callers can tell "no per-subfield localization" apart from
-// "localized subfields that happen to be empty".
+// Records only leaves that are themselves LocalizedValues, i.e. subfields marked
+// `localized: true`. Returns how many were found, so callers can tell "no per-subfield
+// localization" from "localized subfields that are empty".
 function extractLocalizedLeaves(
   value: any,
   basePath: string,
@@ -265,8 +264,7 @@ function extractLocalizedLeaves(
       return 1;
     }
     if (nested !== null && nested !== undefined) {
-      // The payload is an object/array. Honour any deeper localized markers it carries;
-      // if it has none, the whole payload is the translatable unit.
+      // Honour deeper localized markers; with none, the whole payload is the unit.
       const deeper = extractLocalizedLeaves(
         nested,
         basePath,
@@ -372,10 +370,8 @@ export function getTranslateableFields(
                 return;
               }
 
-              // Localized list/object input: emit one translation unit per string leaf.
-              // Prefer subfields explicitly marked localized; only when the payload has no
-              // nested LocalizedValues at all do we fall back to every string leaf, so that
-              // siblings like `currency` or an image URL are not sent for translation.
+              // One unit per string leaf. Marked subfields win; only a payload with none
+              // falls back to every string, keeping siblings like `currency` out of the job.
               const localizedLeaves = extractLocalizedLeaves(
                 valueToBeTranslated,
                 path,
@@ -451,10 +447,9 @@ export function getTranslateableFields(
   return results;
 }
 
-// Writes a translated leaf into a cloned payload, stepping through any intermediate
-// LocalizedValue node into its locale branch (seeded from the source payload) rather than
-// treating the wrapper as the leaf. Without this, a path like `details#heading` would be
-// written onto the wrapper next to `@type`/`Default` instead of into the actual data.
+// Writes a translated leaf into a cloned payload, stepping through intermediate
+// LocalizedValue nodes into their locale branch. Without this, `details#heading` would land
+// on the wrapper next to `@type`/`Default` instead of in the data.
 function setTranslatedLeaf({
   payload,
   segments,
@@ -718,20 +713,39 @@ export function applyTranslation(
           const flatKey = `blocks.${el.id}#${key}`;
           const existing = get(options, key);
 
-          // Flat keys only ever carry a translated string. Guarding on the type stops a
-          // non-string payload echoed back untranslated by Smartling from being written
-          // into the target locale and the block being marked as translated.
-          if (typeof translation[flatKey]?.value === 'string') {
+          const flatValue = translation[flatKey]?.value;
+          const writeFlatValue = () => {
             set(options, key, {
               ...(existing || {}),
-              [locale]: unescapeStringOrObject(translation[flatKey].value),
+              [locale]: unescapeStringOrObject(flatValue!),
             });
             markTranslated();
+          };
+
+          if (typeof flatValue === 'string') {
+            writeFlatValue();
             return;
           }
 
-          // Localized list/object input: leaves were extracted as `${flatKey}#0#title`.
-          // Clone the source payload, patch each leaf, then store it under the locale.
+          if (flatValue !== null && flatValue !== undefined) {
+            // Legacy jobs sent the whole payload under the flat key. Memsource translates
+            // nested strings and returns a real translation; Smartling only handles
+            // `textValue`/`htmlValue` and echoes it back unchanged, which would put source
+            // content in the target locale. Comparing against the source separates them —
+            // exact only when the payload has no `value`/`instructions` keys, which the
+            // Smartling transform rewrites.
+            const flatSource =
+              sourceLocaleId && existing?.[sourceLocaleId] != null
+                ? existing[sourceLocaleId]
+                : existing?.Default;
+            if (!isEqual(flatValue, flatSource)) {
+              writeFlatValue();
+              return;
+            }
+          }
+
+          // Leaves were extracted as `${flatKey}#0#title`: clone the source payload,
+          // patch each leaf, then store it under the locale.
           const prefix = `${flatKey}#`;
           const compoundKeys = Object.keys(translation).filter(k => k.startsWith(prefix));
           if (!compoundKeys.length) {

--- a/packages/utils/src/translation-helpers.ts
+++ b/packages/utils/src/translation-helpers.ts
@@ -230,6 +230,56 @@ function extractNestedStrings(
   }
 }
 
+// Recursively walks an already-extracted LocalizedValue payload (array or object) and
+// records only the leaves that are themselves LocalizedValues, i.e. the subfields the
+// component schema explicitly marked `localized: true`. Returns how many LocalizedValue
+// nodes were found so callers can tell "no per-subfield localization" apart from
+// "localized subfields that happen to be empty".
+function extractLocalizedLeaves(
+  value: any,
+  basePath: string,
+  results: TranslateableFields,
+  instructions: string,
+  sourceLocaleId: string
+): number {
+  if (Array.isArray(value)) {
+    return value.reduce(
+      (found: number, item, index) =>
+        found +
+        extractLocalizedLeaves(item, `${basePath}#${index}`, results, instructions, sourceLocaleId),
+      0
+    );
+  }
+
+  if (typeof value !== 'object' || value === null) {
+    return 0;
+  }
+
+  if (value['@type'] === localizedType) {
+    const nested = value[sourceLocaleId] || value.Default;
+    const nestedInstructions = value.meta?.instructions || instructions;
+    if (typeof nested === 'string') {
+      if (nested) {
+        results[basePath] = { value: nested, instructions: nestedInstructions };
+      }
+      return 1;
+    }
+    if (nested !== null && nested !== undefined) {
+      return (
+        1 + extractLocalizedLeaves(nested, basePath, results, nestedInstructions, sourceLocaleId)
+      );
+    }
+    return 1;
+  }
+
+  return Object.entries(value).reduce(
+    (found: number, [key, v]) =>
+      found +
+      extractLocalizedLeaves(v, `${basePath}#${key}`, results, instructions, sourceLocaleId),
+    0
+  );
+}
+
 export function getTranslateableFields(
   content: BuilderContent,
   sourceLocaleId: string,
@@ -299,11 +349,39 @@ export function getTranslateableFields(
             .forEach(inputKey => {
               const inputValue = get(el.component?.options || {}, inputKey);
               const valueToBeTranslated = inputValue?.[sourceLocaleId] || inputValue?.Default;
-              if (valueToBeTranslated) {
-                results[`blocks.${el.id}#${inputKey}`] = {
-                  instructions: el.meta?.instructions || defaultInstructions,
-                  value: valueToBeTranslated,
-                };
+              const instructions = el.meta?.instructions || defaultInstructions;
+              const path = `blocks.${el.id}#${inputKey}`;
+
+              if (typeof valueToBeTranslated === 'string') {
+                if (valueToBeTranslated) {
+                  results[path] = { instructions, value: valueToBeTranslated };
+                }
+                return;
+              }
+
+              if (valueToBeTranslated === null || valueToBeTranslated === undefined) {
+                return;
+              }
+
+              // Localized list/object input: emit one translation unit per string leaf.
+              // Prefer subfields explicitly marked localized; only when the payload has no
+              // nested LocalizedValues at all do we fall back to every string leaf, so that
+              // siblings like `currency` or an image URL are not sent for translation.
+              const localizedLeaves = extractLocalizedLeaves(
+                valueToBeTranslated,
+                path,
+                results,
+                instructions,
+                sourceLocaleId
+              );
+              if (localizedLeaves === 0) {
+                extractNestedStrings(
+                  valueToBeTranslated,
+                  path,
+                  results,
+                  instructions,
+                  sourceLocaleId
+                );
               }
             });
         }
@@ -568,25 +646,75 @@ export function applyTranslation(
         const keys = el.meta?.localizedTextInputs as string[];
         let options = el.component.options;
 
-        keys.forEach(key => {
-          if (translation[`blocks.${el.id}#${key}`]) {
-            set(options, key, {
-              ...(get(options, key) || {}),
-              [locale]: unescapeStringOrObject(translation[`blocks.${el.id}#${key}`].value),
-            });
+        const markTranslated = () => {
+          this.update({
+            ...el,
+            meta: {
+              ...el.meta,
+              translated: true,
+            },
+            component: {
+              ...el.component,
+              options,
+            },
+          });
+        };
 
-            this.update({
-              ...el,
-              meta: {
-                ...el.meta,
-                translated: true,
-              },
-              component: {
-                ...el.component,
-                options,
-              },
+        keys.forEach(key => {
+          const flatKey = `blocks.${el.id}#${key}`;
+          const existing = get(options, key);
+
+          // Flat keys only ever carry a translated string. Guarding on the type stops a
+          // non-string payload echoed back untranslated by Smartling from being written
+          // into the target locale and the block being marked as translated.
+          if (typeof translation[flatKey]?.value === 'string') {
+            set(options, key, {
+              ...(existing || {}),
+              [locale]: unescapeStringOrObject(translation[flatKey].value),
             });
+            markTranslated();
+            return;
           }
+
+          // Localized list/object input: leaves were extracted as `${flatKey}#0#title`.
+          // Clone the source payload, patch each leaf, then store it under the locale.
+          const prefix = `${flatKey}#`;
+          const compoundKeys = Object.keys(translation).filter(k => k.startsWith(prefix));
+          if (!compoundKeys.length) {
+            return;
+          }
+
+          const sourceValue =
+            sourceLocaleId && existing?.[sourceLocaleId] != null
+              ? existing[sourceLocaleId]
+              : existing?.Default;
+          if (sourceValue === null || sourceValue === undefined) {
+            return;
+          }
+
+          const localeValue = JSON.parse(JSON.stringify(sourceValue));
+          compoundKeys.forEach(compoundKey => {
+            const segments = compoundKey
+              .slice(prefix.length)
+              .split('#')
+              .map((segment: string) => (/^\d+$/.test(segment) ? parseInt(segment, 10) : segment));
+            const existingLeaf = get(localeValue, segments);
+            if (
+              existingLeaf &&
+              typeof existingLeaf === 'object' &&
+              existingLeaf['@type'] === localizedType
+            ) {
+              set(localeValue, segments, {
+                ...existingLeaf,
+                [locale]: unescapeStringOrObject(translation[compoundKey].value),
+              });
+            } else {
+              set(localeValue, segments, unescapeStringOrObject(translation[compoundKey].value));
+            }
+          });
+
+          set(options, key, { ...(existing || {}), [locale]: localeValue });
+          markTranslated();
         });
       }
     });

--- a/packages/utils/src/translation-helpers.ts
+++ b/packages/utils/src/translation-helpers.ts
@@ -4,7 +4,6 @@ import omit from 'lodash/omit';
 import unescape from 'lodash/unescape';
 import set from 'lodash/set';
 import get from 'lodash/get';
-import isEqual from 'lodash/isEqual';
 
 export const localizedType = '@builder.io/core:LocalizedValue';
 
@@ -231,9 +230,8 @@ function extractNestedStrings(
   }
 }
 
-// Records only leaves that are themselves LocalizedValues, i.e. subfields marked
-// `localized: true`. Returns how many were found, so callers can tell "no per-subfield
-// localization" from "localized subfields that are empty".
+// Records only leaves marked `localized: true`; returns the count so callers can tell
+// "no localized subfields" from "localized subfields that are empty".
 function extractLocalizedLeaves(
   value: any,
   basePath: string,
@@ -264,7 +262,7 @@ function extractLocalizedLeaves(
       return 1;
     }
     if (nested !== null && nested !== undefined) {
-      // Honour deeper localized markers; with none, the whole payload is the unit.
+      // Deeper localized markers win; with none, the whole payload is the unit.
       const deeper = extractLocalizedLeaves(
         nested,
         basePath,
@@ -355,7 +353,11 @@ export function getTranslateableFields(
             .filter(input => get(el.component?.options || {}, `${input}.@type`) === localizedType)
             .forEach(inputKey => {
               const inputValue = get(el.component?.options || {}, inputKey);
-              const valueToBeTranslated = inputValue?.[sourceLocaleId] || inputValue?.Default;
+              // Nullish, not truthy, so an explicitly blank source locale is honoured.
+              const valueToBeTranslated =
+                inputValue?.[sourceLocaleId] != null
+                  ? inputValue[sourceLocaleId]
+                  : inputValue?.Default;
               const instructions = el.meta?.instructions || defaultInstructions;
               const path = `blocks.${el.id}#${inputKey}`;
 
@@ -370,8 +372,8 @@ export function getTranslateableFields(
                 return;
               }
 
-              // One unit per string leaf. Marked subfields win; only a payload with none
-              // falls back to every string, keeping siblings like `currency` out of the job.
+              // One unit per string leaf; only a payload with no marked subfields falls
+              // back to every string, keeping siblings like `currency` out of the job.
               const localizedLeaves = extractLocalizedLeaves(
                 valueToBeTranslated,
                 path,
@@ -447,10 +449,9 @@ export function getTranslateableFields(
   return results;
 }
 
-// Gives every nested LocalizedValue a locale branch seeded from the source. The SDK
-// resolves a missing locale key to undefined rather than falling back to Default, so
-// untranslated leaves would otherwise vanish while their plain-string siblings survive
-// the clone.
+// Seeds every nested LocalizedValue with a locale branch from the source: the SDK
+// resolves a missing locale key to undefined rather than to Default, so untranslated
+// leaves would otherwise vanish.
 function seedLocaleBranches(node: any, locale: string, sourceLocaleId?: string) {
   if (Array.isArray(node)) {
     node.forEach(item => seedLocaleBranches(item, locale, sourceLocaleId));
@@ -472,8 +473,7 @@ function seedLocaleBranches(node: any, locale: string, sourceLocaleId?: string) 
 }
 
 // Writes a translated leaf into a cloned payload, stepping through intermediate
-// LocalizedValue nodes into their locale branch. Without this, `details#heading` would land
-// on the wrapper next to `@type`/`Default` instead of in the data.
+// LocalizedValue nodes into their locale branch instead of onto the wrapper itself.
 function setTranslatedLeaf({
   payload,
   segments,
@@ -519,7 +519,10 @@ export function applyTranslation(
   content: BuilderContent,
   translation: TranslateableFields,
   locale: string,
-  sourceLocaleId?: string
+  sourceLocaleId?: string,
+  // Set by callers whose provider echoes anything outside its declared paths back
+  // unchanged, so such a response is not a translation.
+  providerOptions?: { providerEchoesSourcePayload?: boolean }
 ) {
   let { blocks, blocksString, state, ...customFields } = content.data!;
 
@@ -751,25 +754,19 @@ export function applyTranslation(
             return;
           }
 
-          if (flatValue !== null && flatValue !== undefined) {
-            // Legacy jobs sent the whole payload under the flat key. Memsource translates
-            // nested strings and returns a real translation; Smartling only handles
-            // `textValue`/`htmlValue` and echoes it back unchanged, which would put source
-            // content in the target locale. Comparing against the source separates them —
-            // exact only when the payload has no `value`/`instructions` keys, which the
-            // Smartling transform rewrites.
-            const flatSource =
-              sourceLocaleId && existing?.[sourceLocaleId] != null
-                ? existing[sourceLocaleId]
-                : existing?.Default;
-            if (!isEqual(flatValue, flatSource)) {
-              writeFlatValue();
-              return;
-            }
+          // Legacy jobs sent the whole payload under the flat key. Write it only for
+          // providers that translate it, else source content lands in the target locale.
+          if (
+            flatValue !== null &&
+            flatValue !== undefined &&
+            !providerOptions?.providerEchoesSourcePayload
+          ) {
+            writeFlatValue();
+            return;
           }
 
-          // Leaves were extracted as `${flatKey}#0#title`: clone the source payload,
-          // patch each leaf, then store it under the locale.
+          // Leaves were extracted as `${flatKey}#0#title`: clone the source, patch each
+          // leaf, store under the locale.
           const prefix = `${flatKey}#`;
           const compoundKeys = Object.keys(translation).filter(k => k.startsWith(prefix));
           if (!compoundKeys.length) {


### PR DESCRIPTION
## Description
Custom components with a list input where both the list and its subfields are marked `localized: true` were never sent to Smartling.

Example registration that fails:
```
{
  name: "items",
  type: "list",
  localized: true,          // parent localized
  subFields: [
    { name: "title", type: "string", localized: true },   // and subfields localized
  ],
}
```

**Root Cause:**
When a list input is localized, its value is a LocalizedValue wrapper around the array:
`"products": { "@type": "LocalizedValue", "Default": [ { "title": { "@type": "LocalizedValue", ... } } ] }`

`getTranslateableFields` assumed the resolved value of a localized component input was always a string. For a list it got an array, and stored it as-is:
`"blocks.<id>#products": { "value": [ ...array... ] }`

Smartling's upload directives only treat */textValue and */htmlValue as translatable, and the transform in smartling.ts only converts value → textValue for strings. A non-string value produces neither, so Smartling extracted nothing.

**Fix:**
`getTranslateableFields` now branches on the resolved value's type:
- String → unchanged behavior.
- Array/object → walked by a new `extractLocalizedLeaves`, which records only nodes that are themselves `LocalizedValue`. Emits one translation unit per string, e.g. `blocks.<id>#products#0#title`.
- If a payload has no nested `LocalizedValue` at all, falls back to the existing `extractNestedStrings` so parent-only-localized lists keep working.

**Link to JIRA ticket (if applicable):**
https://builder-io.atlassian.net/browse/ENG-13241

**Screenshot/Clip**
https://clips.agent-native.com/r/dAt6OmtzAajd


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core translation extract/apply paths for all localized custom-component list payloads; behavior shifts for nested structures and provider echo handling, though coverage is extensive in tests.
> 
> **Overview**
> Fixes **Smartling** (and similar providers) skipping custom components whose list inputs are localized and contain **nested `LocalizedValue` subfields**—those payloads were previously emitted as a single non-string `value`, so nothing became translatable text.
> 
> **`getTranslateableFields`** now resolves localized component inputs by type: strings behave as before; arrays/objects are walked with new **`extractLocalizedLeaves`** so only marked localized nodes become per-leaf keys (e.g. `blocks.<id>#products#0#title`), excluding plain siblings like `currency`. Lists with no nested markers still fall back to **`extractNestedStrings`**. Source locale selection uses **nullish** checks so an explicit empty source locale is respected.
> 
> **`applyTranslation`** gains **`seedLocaleBranches`** and **`setTranslatedLeaf`** to clone source structure, write compound-key translations into nested locale branches, and **seed untranslated leaves** so the SDK does not resolve missing locale keys to `undefined`. Optional **`providerEchoesSourcePayload`** avoids treating echoed whole-array responses as real translations for legacy flat keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 217953fb84b2f9af8350973b71c74b107fbbbe8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->