### PR TITLE
fix(ci): align workflow Node.js version with package engines

### DIFF
--- a/.github/workflows/lint-and-commit.yml
+++ b/.github/workflows/lint-and-commit.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24.x'
+          node-version: '22.x'
 
       - name: 📥 Monorepo install
         uses: ./.github/actions/yarn-nm-install

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '24.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: 📥 Monorepo install

--- a/.github/workflows/react-native-sdk-test-remote.yml
+++ b/.github/workflows/react-native-sdk-test-remote.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24.x'
+          node-version: '22.x'
 
       - name: 📥 Monorepo install
         uses: ./.github/actions/yarn-nm-install


### PR DESCRIPTION
## Why
Package metadata declares `engines.node` / `volta.node` / `.nvmrc` as `22`, but CI workflows still pin `node-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `node-version` pins so they satisfy `22` (using `22` where a concrete pin is needed).

- `.github/workflows/lint-and-commit.yml`
  - `node-version: '24.x'` → `node-version: '22.x'`
- `.github/workflows/publish-sdks.yml`
  - `node-version: '24.x'` → `node-version: '22.x'`
- `.github/workflows/react-native-sdk-test-remote.yml`
  - `node-version: '24.x'` → `node-version: '22.x'`

## Test plan
- [ ] Package `engines.node` / `volta.node` / `.nvmrc` is still `22`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only Node version pins with no application or runtime logic changes.
> 
> **Overview**
> **Aligns three GitHub Actions workflows with the repo’s Node 22 target** by changing `setup-node` from `node-version: '24.x'` to `'22.x'`.
> 
> Affected workflows: auto lint/commit (`lint-and-commit.yml`), SDK publish (`publish-sdks.yml`), and React Native remote E2E (`react-native-sdk-test-remote.yml`). This brings them in line with `ci.yml` and package `engines` / `.nvmrc` expectations so those jobs no longer run on Node 24.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 724dbd4fc690f792f6e387e7079df45701cc2b4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->