### PR TITLE
feat: ENG-12701 add editor-controlled image sizes with Gen 2 responsive loading parity

### DIFF
--- a/.changeset/real-poets-beam.md
+++ b/.changeset/real-poets-beam.md
@@ -1,0 +1,12 @@
+---
+"@builder.io/react": patch
+"@builder.io/sdk-angular": patch
+"@builder.io/sdk-react-nextjs": patch
+"@builder.io/sdk-qwik": patch
+"@builder.io/sdk-react": patch
+"@builder.io/sdk-solid": patch
+"@builder.io/sdk-svelte": patch
+"@builder.io/sdk-vue": patch
+---
+
+Exposed the existing Image `sizes` field and fixed responsive source selection in Gen 2 SDKs.

--- a/packages/react/src/blocks/Image.tsx
+++ b/packages/react/src/blocks/Image.tsx
@@ -593,7 +593,9 @@ export const Image = withBuilder(ImageComponent, {
     {
       name: 'sizes',
       type: 'string',
-      hideFromUI: true,
+      advanced: true,
+      helperText:
+        'The sizes attribute for responsive images, e.g. "(max-width: 600px) 100vw, 50vw"',
     },
     {
       name: 'srcset',

--- a/packages/sdks-tests/src/e2e-tests/blocks.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/blocks.spec.ts
@@ -137,6 +137,28 @@ test.describe('Blocks', () => {
       }
     });
 
+    test('Image sizes attribute', async ({ page, sdk }) => {
+      test.skip(checkIsRN(sdk));
+
+      await page.goto('/image');
+
+      const images = page.locator('.builder-image');
+      const sources = page.locator('picture source');
+      const sizes = '(max-width: 638px) 98vw, (max-width: 998px) 49vw, 71vw';
+
+      await expect(images.first()).toHaveAttribute('sizes', sizes);
+      await expect(sources.first()).toHaveAttribute('sizes', sizes);
+      await expect(images.nth(1)).toHaveAttribute('sizes', 'auto');
+      await expect(sources.nth(1)).toHaveAttribute('sizes', 'auto');
+
+      await page.goto('/image-high-priority');
+
+      await expect(images.nth(1)).toHaveAttribute('sizes', 'auto');
+      await expect(sources.nth(1)).toHaveAttribute('sizes', 'auto');
+      await expect(images.nth(3)).not.toHaveAttribute('sizes');
+      await expect(sources.nth(3)).not.toHaveAttribute('sizes');
+    });
+
     test('Image high priority', async ({ page, sdk, packageName }) => {
       test.skip(checkIsRN(sdk));
       test.skip(

--- a/packages/sdks-tests/src/e2e-tests/blocks.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/blocks.spec.ts
@@ -144,7 +144,7 @@ test.describe('Blocks', () => {
 
       const images = page.locator('.builder-image');
       const sources = page.locator('picture source');
-      const sizes = '(max-width: 638px) 98vw, (max-width: 998px) 49vw, 71vw';
+      const sizes = /\(max-width: 638px\) 98vw,\s+\(max-width: 998px\) 49vw,\s+71vw/;
 
       await expect(images.first()).toHaveAttribute('sizes', sizes);
       await expect(sources.first()).toHaveAttribute('sizes', sizes);

--- a/packages/sdks-tests/src/e2e-tests/blocks.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/blocks.spec.ts
@@ -148,15 +148,22 @@ test.describe('Blocks', () => {
 
       await expect(images.first()).toHaveAttribute('sizes', sizes);
       await expect(sources.first()).toHaveAttribute('sizes', sizes);
-      await expect(images.nth(1)).toHaveAttribute('sizes', 'auto');
-      await expect(sources.nth(1)).toHaveAttribute('sizes', 'auto');
+
+      const automaticSizes = checkIsGen1React(sdk) ? 'auto, 100vw' : 'auto';
+      await expect(images.nth(1)).toHaveAttribute('sizes', automaticSizes);
+      await expect(sources.nth(1)).toHaveAttribute('sizes', automaticSizes);
 
       await page.goto('/image-high-priority');
 
-      await expect(images.nth(1)).toHaveAttribute('sizes', 'auto');
-      await expect(sources.nth(1)).toHaveAttribute('sizes', 'auto');
-      await expect(images.nth(3)).not.toHaveAttribute('sizes');
-      await expect(sources.nth(3)).not.toHaveAttribute('sizes');
+      await expect(images.nth(1)).toHaveAttribute('sizes', automaticSizes);
+      await expect(sources.nth(1)).toHaveAttribute('sizes', automaticSizes);
+      if (checkIsGen1React(sdk)) {
+        await expect(images.nth(3)).toHaveAttribute('sizes', '100vw');
+        await expect(sources.nth(3)).toHaveAttribute('sizes', '100vw');
+      } else {
+        await expect(images.nth(3)).not.toHaveAttribute('sizes');
+        await expect(sources.nth(3)).not.toHaveAttribute('sizes');
+      }
     });
 
     test('Image high priority', async ({ page, sdk, packageName }) => {

--- a/packages/sdks-tests/src/specs/image.ts
+++ b/packages/sdks-tests/src/specs/image.ts
@@ -80,7 +80,6 @@ export const CONTENT = {
             lazy: false,
             fitContent: true,
             lockAspectRatio: false,
-            sizes: '(max-width: 638px) 98vw, (max-width: 998px) 49vw, 71vw',
             image:
               'https://cdn.builder.io/api/v1/image/assets%2F89d6bbb44070475d9580fd22f21ef8f1%2F1ab2f86b7c5447ad9b99cb039165c15e',
             height: 1245,
@@ -283,7 +282,6 @@ export const CONTENT_2 = {
             lazy: false,
             fitContent: true,
             lockAspectRatio: false,
-            sizes: '(max-width: 638px) 98vw, (max-width: 998px) 49vw, 71vw',
             image:
               'https://cdn.builder.io/api/v1/image/assets%2F89d6bbb44070475d9580fd22f21ef8f1%2F1ab2f86b7c5447ad9b99cb039165c15e',
             height: 1245,
@@ -361,7 +359,6 @@ export const CONTENT_2 = {
             lazy: false,
             fitContent: true,
             lockAspectRatio: false,
-            sizes: '(max-width: 638px) 98vw, (max-width: 998px) 49vw, 71vw',
             image:
               'https://cdn.builder.io/api/v1/image/assets%2F89d6bbb44070475d9580fd22f21ef8f1%2F1ab2f86b7c5447ad9b99cb039165c15e',
             height: 1245,

--- a/packages/sdks/src/blocks/image/component-info.ts
+++ b/packages/sdks/src/blocks/image/component-info.ts
@@ -143,7 +143,9 @@ export const componentInfo: ComponentInfo = {
     {
       name: 'sizes',
       type: 'string',
-      hideFromUI: true,
+      advanced: true,
+      helperText:
+        'The sizes attribute for responsive images, e.g. "(max-width: 600px) 100vw, 50vw"',
     },
     {
       name: 'srcset',

--- a/packages/sdks/src/blocks/image/image.lite.tsx
+++ b/packages/sdks/src/blocks/image/image.lite.tsx
@@ -55,6 +55,10 @@ export default function Image(props: ImageProps) {
       }
     },
 
+    get sizesToUse(): string | undefined {
+      return props.sizes || (props.highPriority ? undefined : 'auto');
+    },
+
     get aspectRatioCss():
       | (Pick<JSX.CSS, 'position' | 'height' | 'width' | 'left' | 'top'> & {
           position: 'absolute';
@@ -86,7 +90,11 @@ export default function Image(props: ImageProps) {
     <>
       <picture>
         <Show when={state.webpSrcSet}>
-          <source srcset={state.webpSrcSet} type="image/webp" />
+          <source
+            srcset={state.webpSrcSet}
+            sizes={state.sizesToUse}
+            type="image/webp"
+          />
         </Show>
         <img
           loading={props.highPriority ? 'eager' : 'lazy'}
@@ -109,7 +117,7 @@ export default function Image(props: ImageProps) {
           src={props.image}
           // TODO: memoize on image on client
           srcset={state.srcSetToUse}
-          sizes={props.sizes}
+          sizes={state.sizesToUse}
         />
       </picture>
 


### PR DESCRIPTION
## Description
- Enabled the existing Image 'sizes' field in the editor
- Updated Gen2 SDKs to apply it to both the image and its source tag.
- Also added support for sizes = auto for the lazy loaded images for gen2.

**Link to JIRA ticket (if applicable):**
https://builder-io.atlassian.net/browse/ENG-12701

**Screenshot/Clip**
Clip - https://clips.agent-native.com/share/hbtCPViNlE8T?ref=clip_share

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Image markup and editor field visibility; they may shift which CDN widths browsers pick but do not touch auth, data, or core app logic.
> 
> **Overview**
> **Exposes the Image block’s `sizes` option in the visual editor** (advanced field with helper text) across Gen 1 React and Gen 2 SDK component metadata, so authors can set responsive `sizes` without hiding it behind `hideFromUI`.
> 
> **Gen 2 Image rendering** now centralizes `sizes` in `sizesToUse`: use the configured `sizes` when set; otherwise lazy images get `sizes="auto"` and **high-priority images omit `sizes`**. The same value is applied to both the `<img>` and the WebP `<source>`, fixing cases where `srcset` selection ignored `sizes` on the picture source.
> 
> **Tests:** new Playwright coverage for explicit `sizes`, lazy `auto` (Gen 1: `auto, 100vw` vs Gen 2: `auto`), and high-priority behavior; fixture content was adjusted so only the first image carries explicit `sizes` for those scenarios. Patch changeset bumps all affected SDK packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8403f77ced504a08a781721a9b7eacc20766ac30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->