### PR TITLE
chore[deps]: Fix minimist prototype pollution alerts

### DIFF
--- a/examples/embed-starter-kit/plugin/package-lock.json
+++ b/examples/embed-starter-kit/plugin/package-lock.json
@@ -15201,10 +15201,11 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -15282,10 +15283,14 @@
       }
     },
     "node_modules/mkdirp/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mobx": {
       "version": "5.15.2",
@@ -26107,7 +26112,7 @@
           "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         },
         "ms": {
@@ -27713,8 +27718,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "7.0.1",
@@ -29379,15 +29383,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
       "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -31065,7 +31067,7 @@
         "inquirer": "8.2.5",
         "is-utf8": "^0.2.1",
         "lodash": "4.17.21",
-        "minimist": "1.2.7",
+        "minimist": "1.2.8",
         "strip-bom": "4.0.0",
         "strip-json-comments": "3.1.1"
       },
@@ -31638,7 +31640,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -31738,7 +31740,7 @@
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "request": "^2.88.0"
       }
     },
@@ -33856,7 +33858,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "0.2.4"
           }
         },
         "ms": {
@@ -34004,7 +34006,7 @@
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
-            "minimist": "^1.2.0",
+            "minimist": "1.2.8",
             "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
@@ -34262,7 +34264,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -34451,7 +34453,7 @@
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5",
+        "minimist": "1.2.8",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
@@ -34994,8 +34996,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ieee754": {
       "version": "1.1.13",
@@ -36939,14 +36940,12 @@
     "jss-default-unit": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
-      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg==",
-      "requires": {}
+      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg=="
     },
     "jss-global": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
-      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q==",
-      "requires": {}
+      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q=="
     },
     "jss-nested": {
       "version": "6.0.1",
@@ -36969,8 +36968,7 @@
     "jss-props-sort": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
-      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g==",
-      "requires": {}
+      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g=="
     },
     "jss-vendor-prefixer": {
       "version": "7.0.0",
@@ -37465,7 +37463,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         }
       }
@@ -38113,9 +38111,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "minimist-options": {
@@ -38173,13 +38171,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "0.2.4"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+          "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
           "dev": true
         }
       }
@@ -38200,8 +38198,7 @@
     "mobx-react-lite": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-1.5.2.tgz",
-      "integrity": "sha512-PyZmARqqWtpuQaAoHF5pKX7h6TKNLwq6vtovm4zZvG6sEbMRHHSqioGXSeQbpRmG8Kw8uln3q/W1yMO5IfL5Sg==",
-      "requires": {}
+      "integrity": "sha512-PyZmARqqWtpuQaAoHF5pKX7h6TKNLwq6vtovm4zZvG6sEbMRHHSqioGXSeQbpRmG8Kw8uln3q/W1yMO5IfL5Sg=="
     },
     "modify-values": {
       "version": "1.0.1",
@@ -41184,8 +41181,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.3",
@@ -41605,7 +41601,7 @@
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "strip-json-comments": "~2.0.1"
       }
     },
@@ -42377,7 +42373,7 @@
         "fb-watchman": "^2.0.0",
         "fsevents": "^1.2.3",
         "micromatch": "^3.1.4",
-        "minimist": "^1.1.1",
+        "minimist": "1.2.8",
         "walker": "~1.0.5",
         "watch": "~0.18.0"
       }
@@ -43863,7 +43859,7 @@
           "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "1.2.8"
           }
         },
         "loader-utils": {
@@ -44670,7 +44666,7 @@
           "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         },
         "semver": {
@@ -44749,7 +44745,7 @@
         "buffer-from": "^1.1.0",
         "diff": "^3.1.0",
         "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.5.6",
         "yn": "^2.0.0"
@@ -45376,7 +45372,7 @@
       "dev": true,
       "requires": {
         "exec-sh": "^0.2.0",
-        "minimist": "^1.2.0"
+        "minimist": "1.2.8"
       }
     },
     "watchpack": {
@@ -45457,7 +45453,7 @@
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "1.2.8"
           }
         }
       }
@@ -45572,7 +45568,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         },
         "loader-utils": {

--- a/examples/embed-starter-kit/plugin/package.json
+++ b/examples/embed-starter-kit/plugin/package.json
@@ -125,5 +125,9 @@
     "react": "^16.11.0",
     "react-dom": "^16.13.1",
     "react-quill": "^1.3.5"
+  },
+  "overrides": {
+    "minimist@<1": "0.2.4",
+    "minimist@1": "1.2.8"
   }
 }

--- a/examples/react-native/package-lock.json
+++ b/examples/react-native/package-lock.json
@@ -13058,9 +13058,13 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minipass": {
       "version": "7.1.2",
@@ -13594,11 +13598,6 @@
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/opencollective/node_modules/minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha512-7Wl+Jz+IGWuSdgsQEJ4JunV0si/iMhg42MnQQG6h1R6TNeVenp4U9x5CC5v/gYqz/fENLQITAWXidNtVL0NNbw=="
     },
     "node_modules/opencollective/node_modules/node-fetch": {
       "version": "1.6.3",
@@ -26365,9 +26364,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "minipass": {
       "version": "7.1.2",
@@ -26442,7 +26441,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "requires": {
-        "minimist": "^1.2.6"
+        "minimist": "1.2.8"
       }
     },
     "mkdirp-classic": {
@@ -26721,7 +26720,7 @@
         "babel-polyfill": "6.23.0",
         "chalk": "1.1.3",
         "inquirer": "3.0.6",
-        "minimist": "1.2.0",
+        "minimist": "1.2.8",
         "node-fetch": "1.6.3",
         "opn": "4.0.2"
       },
@@ -26752,11 +26751,6 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha512-7Wl+Jz+IGWuSdgsQEJ4JunV0si/iMhg42MnQQG6h1R6TNeVenp4U9x5CC5v/gYqz/fENLQITAWXidNtVL0NNbw=="
         },
         "node-fetch": {
           "version": "1.6.3",
@@ -27057,7 +27051,7 @@
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
         "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
+        "minimist": "1.2.8",
         "mkdirp-classic": "^0.5.3",
         "napi-build-utils": "^1.0.1",
         "node-abi": "^3.3.0",
@@ -27214,7 +27208,7 @@
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "strip-json-comments": "~2.0.1"
       }
     },

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -42,5 +42,9 @@
   },
   "private": true,
   "name": "react-native",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "overrides": {
+    "minimist@<1": "0.2.4",
+    "minimist@1": "1.2.8"
+  }
 }

--- a/plugins/async-dropdown/package-lock.json
+++ b/plugins/async-dropdown/package-lock.json
@@ -13998,10 +13998,11 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -14079,10 +14080,14 @@
       }
     },
     "node_modules/mkdirp/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mobx": {
       "version": "5.15.2",
@@ -25463,7 +25468,7 @@
       "dev": true,
       "requires": {
         "exec-sh": "^0.3.2",
-        "minimist": "^1.2.0"
+        "minimist": "1.2.8"
       }
     },
     "@colors/colors": {
@@ -29818,7 +29823,7 @@
         "inquirer": "8.2.5",
         "is-utf8": "^0.2.1",
         "lodash": "4.17.21",
-        "minimist": "1.2.7",
+        "minimist": "1.2.8",
         "strip-bom": "4.0.0",
         "strip-json-comments": "3.1.1"
       },
@@ -30414,7 +30419,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -30509,7 +30514,7 @@
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "request": "^2.88.0"
       }
     },
@@ -32368,7 +32373,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -32504,7 +32509,7 @@
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5",
+        "minimist": "1.2.8",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
@@ -34817,7 +34822,7 @@
           "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         }
       }
@@ -35457,9 +35462,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "minimist-options": {
@@ -35517,13 +35522,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "0.2.4"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+          "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
           "dev": true
         }
       }
@@ -38698,7 +38703,7 @@
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "1.2.8"
           }
         }
       }
@@ -38985,7 +38990,7 @@
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "strip-json-comments": "~2.0.1"
       }
     },
@@ -39548,7 +39553,7 @@
         "execa": "^1.0.0",
         "fb-watchman": "^2.0.0",
         "micromatch": "^3.1.4",
-        "minimist": "^1.1.1",
+        "minimist": "1.2.8",
         "walker": "~1.0.5"
       }
     },
@@ -41791,7 +41796,7 @@
         "buffer-from": "^1.1.0",
         "diff": "^3.1.0",
         "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.5.6",
         "yn": "^2.0.0"
@@ -42543,7 +42548,7 @@
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "1.2.8"
           }
         }
       }

--- a/plugins/async-dropdown/package.json
+++ b/plugins/async-dropdown/package.json
@@ -109,5 +109,9 @@
     "mustache": "^4.0.0",
     "react": "^16.11.0",
     "ses": "^0.6.4"
+  },
+  "overrides": {
+    "minimist@<1": "0.2.4",
+    "minimist@1": "1.2.8"
   }
 }

--- a/plugins/example-app-campaign-builder/package-lock.json
+++ b/plugins/example-app-campaign-builder/package-lock.json
@@ -10294,15 +10294,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/handlebars/node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/handlebars/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -14760,10 +14751,14 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minimist-options": {
       "version": "3.0.2",
@@ -14838,10 +14833,14 @@
       }
     },
     "node_modules/mkdirp/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mobx": {
       "version": "5.15.2",
@@ -22632,12 +22631,6 @@
         "node": ">=8.9.0"
       }
     },
-    "node_modules/style-loader/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/style-loader/node_modules/schema-utils": {
       "version": "2.6.6",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.6.tgz",
@@ -25377,12 +25370,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/webpack/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/webpack/node_modules/mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -25802,7 +25789,7 @@
           "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         },
         "ms": {
@@ -27358,8 +27345,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "7.0.1",
@@ -29080,15 +29066,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
       "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -30720,7 +30704,7 @@
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
         "lodash": "4.17.14",
-        "minimist": "1.2.0",
+        "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1"
@@ -31258,7 +31242,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -31358,7 +31342,7 @@
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "request": "^2.88.0"
       }
     },
@@ -33404,7 +33388,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "0.2.4"
           }
         },
         "ms": {
@@ -33552,7 +33536,7 @@
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
-            "minimist": "^1.2.0",
+            "minimist": "1.2.8",
             "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
@@ -33810,7 +33794,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -33999,19 +33983,13 @@
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5",
+        "minimist": "1.2.8",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-          "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -36370,14 +36348,12 @@
     "jss-default-unit": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
-      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg==",
-      "requires": {}
+      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg=="
     },
     "jss-global": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
-      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q==",
-      "requires": {}
+      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q=="
     },
     "jss-nested": {
       "version": "6.0.1",
@@ -36400,8 +36376,7 @@
     "jss-props-sort": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
-      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g==",
-      "requires": {}
+      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g=="
     },
     "jss-vendor-prefixer": {
       "version": "7.0.0",
@@ -36905,7 +36880,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         }
       }
@@ -37528,9 +37503,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "minimist-options": {
@@ -37588,13 +37563,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "0.2.4"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+          "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
           "dev": true
         }
       }
@@ -37615,8 +37590,7 @@
     "mobx-react-lite": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-1.5.2.tgz",
-      "integrity": "sha512-PyZmARqqWtpuQaAoHF5pKX7h6TKNLwq6vtovm4zZvG6sEbMRHHSqioGXSeQbpRmG8Kw8uln3q/W1yMO5IfL5Sg==",
-      "requires": {}
+      "integrity": "sha512-PyZmARqqWtpuQaAoHF5pKX7h6TKNLwq6vtovm4zZvG6sEbMRHHSqioGXSeQbpRmG8Kw8uln3q/W1yMO5IfL5Sg=="
     },
     "modify-values": {
       "version": "1.0.1",
@@ -41180,7 +41154,7 @@
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "strip-json-comments": "~2.0.1"
       }
     },
@@ -41947,7 +41921,7 @@
         "fb-watchman": "^2.0.0",
         "fsevents": "^1.2.3",
         "micromatch": "^3.1.4",
-        "minimist": "^1.1.1",
+        "minimist": "1.2.8",
         "walker": "~1.0.5",
         "watch": "~0.18.0"
       }
@@ -43403,7 +43377,7 @@
           "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "1.2.8"
           }
         },
         "loader-utils": {
@@ -43416,12 +43390,6 @@
             "emojis-list": "^3.0.0",
             "json5": "^2.1.2"
           }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
         },
         "schema-utils": {
           "version": "2.6.6",
@@ -44163,7 +44131,7 @@
           "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         },
         "semver": {
@@ -44242,7 +44210,7 @@
         "buffer-from": "^1.1.0",
         "diff": "^3.1.0",
         "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.5.6",
         "yn": "^2.0.0"
@@ -44875,7 +44843,7 @@
       "dev": true,
       "requires": {
         "exec-sh": "^0.2.0",
-        "minimist": "^1.2.0"
+        "minimist": "1.2.8"
       }
     },
     "watchpack": {
@@ -44941,19 +44909,13 @@
           "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "mkdirp": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "1.2.8"
           }
         }
       }
@@ -45068,7 +45030,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         },
         "loader-utils": {

--- a/plugins/example-app-campaign-builder/package.json
+++ b/plugins/example-app-campaign-builder/package.json
@@ -125,5 +125,9 @@
     "react": "^16.11.0",
     "react-dom": "^16.13.1",
     "react-quill": "^1.3.5"
+  },
+  "overrides": {
+    "minimist@<1": "0.2.4",
+    "minimist@1": "1.2.8"
   }
 }

--- a/plugins/example-app-simple/package-lock.json
+++ b/plugins/example-app-simple/package-lock.json
@@ -10302,15 +10302,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/handlebars/node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/handlebars/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -14768,10 +14759,14 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minimist-options": {
       "version": "3.0.2",
@@ -14846,10 +14841,14 @@
       }
     },
     "node_modules/mkdirp/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mobx": {
       "version": "5.15.2",
@@ -22640,12 +22639,6 @@
         "node": ">=8.9.0"
       }
     },
-    "node_modules/style-loader/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/style-loader/node_modules/schema-utils": {
       "version": "2.6.6",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.6.tgz",
@@ -25385,12 +25378,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/webpack/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/webpack/node_modules/mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -25810,7 +25797,7 @@
           "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         },
         "ms": {
@@ -27366,8 +27353,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "7.0.1",
@@ -29088,15 +29074,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
       "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -30728,7 +30712,7 @@
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
         "lodash": "4.17.14",
-        "minimist": "1.2.0",
+        "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1"
@@ -31266,7 +31250,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -31366,7 +31350,7 @@
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "request": "^2.88.0"
       }
     },
@@ -33432,7 +33416,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "0.2.4"
           }
         },
         "ms": {
@@ -33580,7 +33564,7 @@
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
-            "minimist": "^1.2.0",
+            "minimist": "1.2.8",
             "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
@@ -33838,7 +33822,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -34027,19 +34011,13 @@
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5",
+        "minimist": "1.2.8",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-          "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -36398,14 +36376,12 @@
     "jss-default-unit": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
-      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg==",
-      "requires": {}
+      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg=="
     },
     "jss-global": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
-      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q==",
-      "requires": {}
+      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q=="
     },
     "jss-nested": {
       "version": "6.0.1",
@@ -36428,8 +36404,7 @@
     "jss-props-sort": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
-      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g==",
-      "requires": {}
+      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g=="
     },
     "jss-vendor-prefixer": {
       "version": "7.0.0",
@@ -36933,7 +36908,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         }
       }
@@ -37556,9 +37531,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "minimist-options": {
@@ -37616,13 +37591,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "0.2.4"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+          "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
           "dev": true
         }
       }
@@ -37643,8 +37618,7 @@
     "mobx-react-lite": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-1.5.2.tgz",
-      "integrity": "sha512-PyZmARqqWtpuQaAoHF5pKX7h6TKNLwq6vtovm4zZvG6sEbMRHHSqioGXSeQbpRmG8Kw8uln3q/W1yMO5IfL5Sg==",
-      "requires": {}
+      "integrity": "sha512-PyZmARqqWtpuQaAoHF5pKX7h6TKNLwq6vtovm4zZvG6sEbMRHHSqioGXSeQbpRmG8Kw8uln3q/W1yMO5IfL5Sg=="
     },
     "modify-values": {
       "version": "1.0.1",
@@ -41208,7 +41182,7 @@
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "strip-json-comments": "~2.0.1"
       }
     },
@@ -41975,7 +41949,7 @@
         "fb-watchman": "^2.0.0",
         "fsevents": "^1.2.3",
         "micromatch": "^3.1.4",
-        "minimist": "^1.1.1",
+        "minimist": "1.2.8",
         "walker": "~1.0.5",
         "watch": "~0.18.0"
       }
@@ -43431,7 +43405,7 @@
           "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "1.2.8"
           }
         },
         "loader-utils": {
@@ -43444,12 +43418,6 @@
             "emojis-list": "^3.0.0",
             "json5": "^2.1.2"
           }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
         },
         "schema-utils": {
           "version": "2.6.6",
@@ -44191,7 +44159,7 @@
           "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         },
         "semver": {
@@ -44270,7 +44238,7 @@
         "buffer-from": "^1.1.0",
         "diff": "^3.1.0",
         "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.5.6",
         "yn": "^2.0.0"
@@ -44903,7 +44871,7 @@
       "dev": true,
       "requires": {
         "exec-sh": "^0.2.0",
-        "minimist": "^1.2.0"
+        "minimist": "1.2.8"
       }
     },
     "watchpack": {
@@ -44969,19 +44937,13 @@
           "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "mkdirp": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "1.2.8"
           }
         }
       }
@@ -45096,7 +45058,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         },
         "loader-utils": {

--- a/plugins/example-app-simple/package.json
+++ b/plugins/example-app-simple/package.json
@@ -125,5 +125,9 @@
     "react": "^16.11.0",
     "react-dom": "^16.13.1",
     "react-quill": "^1.3.5"
+  },
+  "overrides": {
+    "minimist@<1": "0.2.4",
+    "minimist@1": "1.2.8"
   }
 }

--- a/plugins/jodit-html-editor/package-lock.json
+++ b/plugins/jodit-html-editor/package-lock.json
@@ -7722,16 +7722,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "iconv-lite": "~0.4.13"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -10096,15 +10086,6 @@
       },
       "optionalDependencies": {
         "uglify-js": "^3.1.4"
-      }
-    },
-    "node_modules/handlebars/node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/handlebars/node_modules/source-map": {
@@ -14429,10 +14410,14 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minimist-options": {
       "version": "3.0.2",
@@ -14507,10 +14492,14 @@
       }
     },
     "node_modules/mkdirp/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/modify-values": {
       "version": "1.0.1",
@@ -22091,12 +22080,6 @@
         "node": ">=8.9.0"
       }
     },
-    "node_modules/style-loader/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/style-loader/node_modules/schema-utils": {
       "version": "2.6.6",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.6.tgz",
@@ -24802,12 +24785,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/webpack/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/webpack/node_modules/mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -25230,7 +25207,7 @@
           "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         },
         "ms": {
@@ -30060,7 +30037,7 @@
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
         "lodash": "4.17.14",
-        "minimist": "1.2.0",
+        "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1"
@@ -30598,7 +30575,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -30693,7 +30670,7 @@
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "request": "^2.88.0"
       }
     },
@@ -31395,16 +31372,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -32665,7 +32632,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "0.2.4"
           }
         },
         "ms": {
@@ -32813,7 +32780,7 @@
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
-            "minimist": "^1.2.0",
+            "minimist": "1.2.8",
             "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
@@ -33070,7 +33037,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -33250,19 +33217,13 @@
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5",
+        "minimist": "1.2.8",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-          "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -36041,7 +36002,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         }
       }
@@ -36665,9 +36626,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "minimist-options": {
@@ -36725,13 +36686,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "0.2.4"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+          "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
           "dev": true
         }
       }
@@ -40222,7 +40183,7 @@
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "strip-json-comments": "~2.0.1"
       }
     },
@@ -40927,7 +40888,7 @@
         "fb-watchman": "^2.0.0",
         "fsevents": "^1.2.3",
         "micromatch": "^3.1.4",
-        "minimist": "^1.1.1",
+        "minimist": "1.2.8",
         "walker": "~1.0.5",
         "watch": "~0.18.0"
       }
@@ -42371,7 +42332,7 @@
           "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "1.2.8"
           }
         },
         "loader-utils": {
@@ -42384,12 +42345,6 @@
             "emojis-list": "^3.0.0",
             "json5": "^2.1.2"
           }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
         },
         "schema-utils": {
           "version": "2.6.6",
@@ -43126,7 +43081,7 @@
           "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         },
         "semver": {
@@ -43205,7 +43160,7 @@
         "buffer-from": "^1.1.0",
         "diff": "^3.1.0",
         "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.5.6",
         "yn": "^2.0.0"
@@ -43825,7 +43780,7 @@
       "dev": true,
       "requires": {
         "exec-sh": "^0.2.0",
-        "minimist": "^1.2.0"
+        "minimist": "1.2.8"
       }
     },
     "watchpack": {
@@ -43891,19 +43846,13 @@
           "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "mkdirp": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "1.2.8"
           }
         }
       }
@@ -44018,7 +43967,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         },
         "loader-utils": {

--- a/plugins/jodit-html-editor/package.json
+++ b/plugins/jodit-html-editor/package.json
@@ -126,5 +126,9 @@
     "jodit-react": "^4.1.2",
     "react": "^16.11.0",
     "react-dom": "^16.13.1"
+  },
+  "overrides": {
+    "minimist@<1": "0.2.4",
+    "minimist@1": "1.2.8"
   }
 }

--- a/plugins/localized-preview/package-lock.json
+++ b/plugins/localized-preview/package-lock.json
@@ -10398,15 +10398,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/handlebars/node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/handlebars/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -15018,10 +15009,14 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minimist-options": {
       "version": "3.0.2",
@@ -15075,10 +15070,14 @@
       }
     },
     "node_modules/mkdirp/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/modify-values": {
       "version": "1.0.1",
@@ -19257,12 +19256,6 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/portfinder/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/portfinder/node_modules/mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -22484,12 +22477,6 @@
       "engines": {
         "node": ">=8.9.0"
       }
-    },
-    "node_modules/style-loader/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
     },
     "node_modules/style-loader/node_modules/schema-utils": {
       "version": "2.6.6",
@@ -25790,7 +25777,7 @@
           "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         },
         "ms": {
@@ -30798,7 +30785,7 @@
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
         "lodash": "4.17.14",
-        "minimist": "1.2.0",
+        "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1"
@@ -31297,7 +31284,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -31383,7 +31370,7 @@
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "request": "^2.88.0"
       }
     },
@@ -33292,7 +33279,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "0.2.4"
           }
         },
         "ms": {
@@ -33440,7 +33427,7 @@
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
-            "minimist": "^1.2.0",
+            "minimist": "1.2.8",
             "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
@@ -33699,7 +33686,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -33894,19 +33881,13 @@
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5",
+        "minimist": "1.2.8",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-          "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -36974,7 +36955,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         }
       }
@@ -37559,9 +37540,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "minimist-options": {
@@ -37601,13 +37582,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "0.2.4"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+          "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
           "dev": true
         }
       }
@@ -40577,19 +40558,13 @@
             "ms": "^2.1.1"
           }
         },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "mkdirp": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "1.2.8"
           }
         },
         "ms": {
@@ -40924,7 +40899,7 @@
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "strip-json-comments": "~2.0.1"
       }
     },
@@ -41624,7 +41599,7 @@
         "fb-watchman": "^2.0.0",
         "fsevents": "^1.2.3",
         "micromatch": "^3.1.4",
-        "minimist": "^1.1.1",
+        "minimist": "1.2.8",
         "walker": "~1.0.5",
         "watch": "~0.18.0"
       }
@@ -43041,7 +43016,7 @@
           "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "1.2.8"
           }
         },
         "loader-utils": {
@@ -43054,12 +43029,6 @@
             "emojis-list": "^3.0.0",
             "json5": "^2.1.2"
           }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
         },
         "schema-utils": {
           "version": "2.6.6",
@@ -43832,7 +43801,7 @@
           "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         },
         "semver": {
@@ -43911,7 +43880,7 @@
         "buffer-from": "^1.1.0",
         "diff": "^3.1.0",
         "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.5.6",
         "yn": "^2.0.0"
@@ -44491,7 +44460,7 @@
       "dev": true,
       "requires": {
         "exec-sh": "^0.2.0",
-        "minimist": "^1.2.0"
+        "minimist": "1.2.8"
       }
     },
     "watchpack": {

--- a/plugins/localized-preview/package.json
+++ b/plugins/localized-preview/package.json
@@ -124,5 +124,9 @@
   "peerDependencies": {
     "@material-ui/icons": "^4.11.2",
     "react": "^17.0.2"
+  },
+  "overrides": {
+    "minimist@<1": "0.2.4",
+    "minimist@1": "1.2.8"
   }
 }

--- a/plugins/phrase-conector/package-lock.json
+++ b/plugins/phrase-conector/package-lock.json
@@ -9169,12 +9169,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/handlebars/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/handlebars/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -14067,10 +14061,14 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minimist-options": {
       "version": "3.0.2",
@@ -14124,10 +14122,14 @@
       }
     },
     "node_modules/mkdirp/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mobx": {
       "version": "6.6.1",
@@ -27565,7 +27567,7 @@
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
         "lodash": "4.17.14",
-        "minimist": "1.2.0",
+        "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1"
@@ -28026,7 +28028,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -28100,7 +28102,7 @@
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "request": "^2.88.0"
       }
     },
@@ -29209,7 +29211,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -29328,19 +29330,13 @@
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5",
+        "minimist": "1.2.8",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -32964,9 +32960,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "minimist-options": {
@@ -33006,13 +33002,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "0.2.4"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+          "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
           "dev": true
         }
       }
@@ -35922,7 +35918,7 @@
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "strip-json-comments": "~2.0.1"
       }
     },
@@ -38103,7 +38099,7 @@
         "buffer-from": "^1.1.0",
         "diff": "^3.1.0",
         "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.5.6",
         "yn": "^2.0.0"

--- a/plugins/phrase-conector/package.json
+++ b/plugins/phrase-conector/package.json
@@ -132,5 +132,9 @@
     "object-hash": "^3.0.0",
     "traverse": "^0.6.6",
     "uuid": "^8.3.2"
+  },
+  "overrides": {
+    "minimist@<1": "0.2.4",
+    "minimist@1": "1.2.8"
   }
 }

--- a/plugins/rich-text/package-lock.json
+++ b/plugins/rich-text/package-lock.json
@@ -10202,15 +10202,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/handlebars/node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/handlebars/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -14560,10 +14551,14 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minimist-options": {
       "version": "3.0.2",
@@ -14638,10 +14633,14 @@
       }
     },
     "node_modules/mkdirp/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/modify-values": {
       "version": "1.0.1",
@@ -22345,12 +22344,6 @@
         "node": ">=8.9.0"
       }
     },
-    "node_modules/style-loader/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/style-loader/node_modules/schema-utils": {
       "version": "2.6.6",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.6.tgz",
@@ -25074,12 +25067,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/webpack/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/webpack/node_modules/mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -25507,7 +25494,7 @@
           "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         },
         "ms": {
@@ -30353,7 +30340,7 @@
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
         "lodash": "4.17.14",
-        "minimist": "1.2.0",
+        "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1"
@@ -30891,7 +30878,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -30991,7 +30978,7 @@
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "request": "^2.88.0"
       }
     },
@@ -33012,7 +32999,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "0.2.4"
           }
         },
         "ms": {
@@ -33160,7 +33147,7 @@
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
-            "minimist": "^1.2.0",
+            "minimist": "1.2.8",
             "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
@@ -33418,7 +33405,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -33607,19 +33594,13 @@
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5",
+        "minimist": "1.2.8",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-          "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -36417,7 +36398,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         }
       }
@@ -37040,9 +37021,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "minimist-options": {
@@ -37100,13 +37081,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "0.2.4"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+          "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
           "dev": true
         }
       }
@@ -40663,7 +40644,7 @@
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "strip-json-comments": "~2.0.1"
       }
     },
@@ -41384,7 +41365,7 @@
         "fb-watchman": "^2.0.0",
         "fsevents": "^1.2.3",
         "micromatch": "^3.1.4",
-        "minimist": "^1.1.1",
+        "minimist": "1.2.8",
         "walker": "~1.0.5",
         "watch": "~0.18.0"
       }
@@ -42846,7 +42827,7 @@
           "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "1.2.8"
           }
         },
         "loader-utils": {
@@ -42859,12 +42840,6 @@
             "emojis-list": "^3.0.0",
             "json5": "^2.1.2"
           }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
         },
         "schema-utils": {
           "version": "2.6.6",
@@ -43601,7 +43576,7 @@
           "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         },
         "semver": {
@@ -43680,7 +43655,7 @@
         "buffer-from": "^1.1.0",
         "diff": "^3.1.0",
         "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.5.6",
         "yn": "^2.0.0"
@@ -44305,7 +44280,7 @@
       "dev": true,
       "requires": {
         "exec-sh": "^0.2.0",
-        "minimist": "^1.2.0"
+        "minimist": "1.2.8"
       }
     },
     "watchpack": {
@@ -44371,19 +44346,13 @@
           "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "mkdirp": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "1.2.8"
           }
         }
       }
@@ -44498,7 +44467,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.8"
           }
         },
         "loader-utils": {

--- a/plugins/rich-text/package.json
+++ b/plugins/rich-text/package.json
@@ -123,5 +123,9 @@
     "react": "^16.11.0",
     "react-dom": "^16.13.1",
     "react-quill": "^1.3.5"
+  },
+  "overrides": {
+    "minimist@<1": "0.2.4",
+    "minimist@1": "1.2.8"
   }
 }

--- a/plugins/salesforce-commerce-api-plugin/package-lock.json
+++ b/plugins/salesforce-commerce-api-plugin/package-lock.json
@@ -3323,10 +3323,14 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minimist-options": {
       "version": "3.0.2",
@@ -3380,10 +3384,14 @@
       }
     },
     "node_modules/mkdirp/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/ms": {
       "version": "2.0.0",
@@ -6465,7 +6473,7 @@
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
         "lodash": "4.17.14",
-        "minimist": "1.2.0",
+        "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1"
@@ -6572,7 +6580,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -6603,7 +6611,7 @@
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "request": "^2.88.0"
       }
     },
@@ -7235,7 +7243,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -8151,9 +8159,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "minimist-options": {
@@ -8193,13 +8201,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "0.2.4"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+          "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
           "dev": true
         }
       }

--- a/plugins/salesforce-commerce-api-plugin/package.json
+++ b/plugins/salesforce-commerce-api-plugin/package.json
@@ -54,5 +54,9 @@
   "dependencies": {
     "@builder.io/plugin-tools": "0.0.5",
     "commerce-sdk-isomorphic": "2.1.0"
+  },
+  "overrides": {
+    "minimist@<1": "0.2.4",
+    "minimist@1": "1.2.8"
   }
 }

--- a/plugins/salesforce-einstein-api/package-lock.json
+++ b/plugins/salesforce-einstein-api/package-lock.json
@@ -9068,12 +9068,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/handlebars/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/handlebars/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -14115,10 +14109,14 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minimist-options": {
       "version": "3.0.2",
@@ -14172,10 +14170,14 @@
       }
     },
     "node_modules/mkdirp/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mobx": {
       "version": "5.15.7",
@@ -27583,7 +27585,7 @@
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
         "lodash": "4.17.14",
-        "minimist": "1.2.0",
+        "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1"
@@ -28029,7 +28031,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -28103,7 +28105,7 @@
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "request": "^2.88.0"
       }
     },
@@ -29225,7 +29227,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -29313,19 +29315,13 @@
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5",
+        "minimist": "1.2.8",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -33069,9 +33065,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "minimist-options": {
@@ -33111,13 +33107,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "0.2.4"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+          "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
           "dev": true
         }
       }
@@ -36045,7 +36041,7 @@
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "strip-json-comments": "~2.0.1"
       }
     },
@@ -38213,7 +38209,7 @@
         "buffer-from": "^1.1.0",
         "diff": "^3.1.0",
         "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.5.6",
         "yn": "^2.0.0"

--- a/plugins/salesforce-einstein-api/package.json
+++ b/plugins/salesforce-einstein-api/package.json
@@ -123,5 +123,9 @@
   "dependencies": {
     "@builder.io/commerce-plugin-tools": "^0.3.1-1",
     "commerce-sdk-isomorphic": "^1.7.0"
+  },
+  "overrides": {
+    "minimist@<1": "0.2.4",
+    "minimist@1": "1.2.8"
   }
 }

--- a/plugins/sfcc-sync/package-lock.json
+++ b/plugins/sfcc-sync/package-lock.json
@@ -8710,12 +8710,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/handlebars/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/handlebars/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -13528,10 +13522,14 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minimist-options": {
       "version": "3.0.2",
@@ -13585,10 +13583,14 @@
       }
     },
     "node_modules/mkdirp/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/modify-values": {
       "version": "1.0.1",
@@ -26547,7 +26549,7 @@
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
         "lodash": "4.17.14",
-        "minimist": "1.2.0",
+        "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1"
@@ -26993,7 +26995,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -27064,7 +27066,7 @@
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "request": "^2.88.0"
       }
     },
@@ -28140,7 +28142,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -28228,19 +28230,13 @@
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5",
+        "minimist": "1.2.8",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -31780,9 +31776,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "minimist-options": {
@@ -31822,13 +31818,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "0.2.4"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+          "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
           "dev": true
         }
       }
@@ -34722,7 +34718,7 @@
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "strip-json-comments": "~2.0.1"
       }
     },
@@ -36806,7 +36802,7 @@
         "buffer-from": "^1.1.0",
         "diff": "^3.1.0",
         "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.5.6",
         "yn": "^2.0.0"

--- a/plugins/sfcc-sync/package.json
+++ b/plugins/sfcc-sync/package.json
@@ -119,5 +119,9 @@
     "tslint-config-standard": "^8.0.1",
     "typedoc": "^0.12.0",
     "typescript": "^3.0.3"
+  },
+  "overrides": {
+    "minimist@<1": "0.2.4",
+    "minimist@1": "1.2.8"
   }
 }

--- a/plugins/shopify-demo/package-lock.json
+++ b/plugins/shopify-demo/package-lock.json
@@ -8552,12 +8552,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/handlebars/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/handlebars/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -13417,10 +13411,14 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minimist-options": {
       "version": "3.0.2",
@@ -13473,10 +13471,14 @@
       }
     },
     "node_modules/mkdirp/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mobx": {
       "version": "5.15.7",
@@ -23972,8 +23974,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "7.0.1",
@@ -26530,7 +26531,7 @@
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
         "lodash": "4.17.14",
-        "minimist": "1.2.0",
+        "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1"
@@ -26976,7 +26977,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -27050,7 +27051,7 @@
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "request": "^2.88.0"
       }
     },
@@ -28157,7 +28158,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -28245,19 +28246,13 @@
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5",
+        "minimist": "1.2.8",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -30117,8 +30112,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "29.4.3",
@@ -31862,9 +31856,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "minimist-options": {
@@ -31904,13 +31898,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "0.2.4"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+          "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
           "dev": true
         }
       }
@@ -34819,7 +34813,7 @@
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "strip-json-comments": "~2.0.1"
       }
     },
@@ -37011,7 +37005,7 @@
         "buffer-from": "^1.1.0",
         "diff": "^3.1.0",
         "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.5.6",
         "yn": "^2.0.0"

--- a/plugins/shopify-demo/package.json
+++ b/plugins/shopify-demo/package.json
@@ -124,5 +124,9 @@
     "@material-ui/core": "^3.9.2",
     "@material-ui/icons": "^1.1.1",
     "react": "^16.11.0"
+  },
+  "overrides": {
+    "minimist@<1": "0.2.4",
+    "minimist@1": "1.2.8"
   }
 }

--- a/plugins/shopify/package-lock.json
+++ b/plugins/shopify/package-lock.json
@@ -3308,10 +3308,14 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minimist-options": {
       "version": "3.0.2",
@@ -3365,10 +3369,14 @@
       }
     },
     "node_modules/mkdirp/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/ms": {
       "version": "2.0.0",
@@ -6343,7 +6351,7 @@
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
         "lodash": "4.17.14",
-        "minimist": "1.2.0",
+        "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1"
@@ -6450,7 +6458,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -6481,7 +6489,7 @@
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "request": "^2.88.0"
       }
     },
@@ -7119,7 +7127,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -8037,9 +8045,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "minimist-options": {
@@ -8079,13 +8087,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "0.2.4"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+          "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
           "dev": true
         }
       }

--- a/plugins/shopify/package.json
+++ b/plugins/shopify/package.json
@@ -102,5 +102,9 @@
   "dependencies": {
     "@builder.io/plugin-tools": "^0.0.3",
     "shopify-buy": "^3.0.4"
+  },
+  "overrides": {
+    "minimist@<1": "0.2.4",
+    "minimist@1": "1.2.8"
   }
 }

--- a/plugins/smartling/package-lock.json
+++ b/plugins/smartling/package-lock.json
@@ -9168,12 +9168,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/handlebars/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/handlebars/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -14096,10 +14090,14 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minimist-options": {
       "version": "3.0.2",
@@ -14153,10 +14151,14 @@
       }
     },
     "node_modules/mkdirp/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mobx": {
       "version": "6.6.1",
@@ -27602,7 +27604,7 @@
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
         "lodash": "4.17.14",
-        "minimist": "1.2.0",
+        "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1"
@@ -28063,7 +28065,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -28140,7 +28142,7 @@
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "request": "^2.88.0"
       }
     },
@@ -29260,7 +29262,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -29379,19 +29381,13 @@
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5",
+        "minimist": "1.2.8",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -33044,9 +33040,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "minimist-options": {
@@ -33086,13 +33082,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "0.2.4"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+          "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
           "dev": true
         }
       }
@@ -36005,7 +36001,7 @@
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "strip-json-comments": "~2.0.1"
       }
     },
@@ -38188,7 +38184,7 @@
         "buffer-from": "^1.1.0",
         "diff": "^3.1.0",
         "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.5.6",
         "yn": "^2.0.0"

--- a/plugins/smartling/package.json
+++ b/plugins/smartling/package.json
@@ -131,5 +131,9 @@
     "object-hash": "^3.0.0",
     "traverse": "^0.6.6",
     "uuid": "^8.3.2"
+  },
+  "overrides": {
+    "minimist@<1": "0.2.4",
+    "minimist@1": "1.2.8"
   }
 }

--- a/plugins/virtocommerce/package-lock.json
+++ b/plugins/virtocommerce/package-lock.json
@@ -13104,10 +13104,11 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -13139,10 +13140,14 @@
       }
     },
     "node_modules/mkdirp/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mobx": {
       "version": "5.15.7",
@@ -25945,7 +25950,7 @@
         "inquirer": "8.2.5",
         "is-utf8": "^0.2.1",
         "lodash": "4.17.21",
-        "minimist": "1.2.7",
+        "minimist": "1.2.8",
         "strip-bom": "4.0.0",
         "strip-json-comments": "3.1.1"
       },
@@ -26420,7 +26425,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -26488,7 +26493,7 @@
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "request": "^2.88.0"
       }
     },
@@ -27390,7 +27395,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -27477,7 +27482,7 @@
       "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5",
+        "minimist": "1.2.8",
         "neo-async": "^2.6.2",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
@@ -30932,9 +30937,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "minimist-options": {
@@ -30953,13 +30958,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "0.2.4"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+          "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
           "dev": true
         }
       }
@@ -33910,7 +33915,7 @@
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "strip-json-comments": "~2.0.1"
       }
     },
@@ -35775,7 +35780,7 @@
         "buffer-from": "^1.1.0",
         "diff": "^3.1.0",
         "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.5.6",
         "yn": "^2.0.0"

--- a/plugins/virtocommerce/package.json
+++ b/plugins/virtocommerce/package.json
@@ -123,5 +123,9 @@
   "dependencies": {
     "@builder.io/commerce-plugin-tools": "^0.2.1-4",
     "@moltin/sdk": "^8.8.1"
+  },
+  "overrides": {
+    "minimist@<1": "0.2.4",
+    "minimist@1": "1.2.8"
   }
 }

--- a/plugins/vtex/package-lock.json
+++ b/plugins/vtex/package-lock.json
@@ -9080,12 +9080,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/handlebars/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
     "node_modules/handlebars/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -14130,10 +14124,14 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minimist-options": {
       "version": "3.0.2",
@@ -14187,10 +14185,14 @@
       }
     },
     "node_modules/mkdirp/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+      "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mobx": {
       "version": "5.15.7",
@@ -27597,7 +27599,7 @@
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
         "lodash": "4.17.14",
-        "minimist": "1.2.0",
+        "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1"
@@ -28043,7 +28045,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -28117,7 +28119,7 @@
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "request": "^2.88.0"
       }
     },
@@ -29256,7 +29258,7 @@
             "camelcase-keys": "^4.0.0",
             "decamelize-keys": "^1.0.0",
             "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
+            "minimist": "1.2.8",
             "minimist-options": "^3.0.1",
             "normalize-package-data": "^2.3.4",
             "read-pkg-up": "^3.0.0",
@@ -29365,19 +29367,13 @@
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5",
+        "minimist": "1.2.8",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -33125,9 +33121,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "minimist-options": {
@@ -33167,13 +33163,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "0.2.4"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+          "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
           "dev": true
         }
       }
@@ -36091,7 +36087,7 @@
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "strip-json-comments": "~2.0.1"
       }
     },
@@ -38289,7 +38285,7 @@
         "buffer-from": "^1.1.0",
         "diff": "^3.1.0",
         "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
+        "minimist": "1.2.8",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.5.6",
         "yn": "^2.0.0"

--- a/plugins/vtex/package.json
+++ b/plugins/vtex/package.json
@@ -123,5 +123,9 @@
   "dependencies": {
     "@builder.io/commerce-plugin-tools": "^0.2.1-4",
     "@moltin/sdk": "^8.8.1"
+  },
+  "overrides": {
+    "minimist@<1": "0.2.4",
+    "minimist@1": "1.2.8"
   }
 }


### PR DESCRIPTION
## Description
Fixes below alerts:

| Alert | Project |
| --- | --- |
| [9957](https://github.com/BuilderIO/builder/security/dependabot/9957) | plugins/virtocommerce |
| [6091](https://github.com/BuilderIO/builder/security/dependabot/6091) | plugins/phrase-conector |
| [6090](https://github.com/BuilderIO/builder/security/dependabot/6090) | plugins/phrase-conector |
| [5957](https://github.com/BuilderIO/builder/security/dependabot/5957) | plugins/smartling |
| [5954](https://github.com/BuilderIO/builder/security/dependabot/5954) | plugins/smartling |
| [5955](https://github.com/BuilderIO/builder/security/dependabot/5955) | plugins/vtex |
| [5953](https://github.com/BuilderIO/builder/security/dependabot/5953) | plugins/vtex |
| [5951](https://github.com/BuilderIO/builder/security/dependabot/5951) | plugins/shopify |
| [5948](https://github.com/BuilderIO/builder/security/dependabot/5948) | plugins/shopify |
| [5903](https://github.com/BuilderIO/builder/security/dependabot/5903) | plugins/shopify-demo |
| [5902](https://github.com/BuilderIO/builder/security/dependabot/5902) | plugins/shopify-demo |
| [5901](https://github.com/BuilderIO/builder/security/dependabot/5901) | plugins/sfcc-sync |
| [5900](https://github.com/BuilderIO/builder/security/dependabot/5900) | plugins/sfcc-sync |
| [5897](https://github.com/BuilderIO/builder/security/dependabot/5897) | plugins/salesforce-einstein-api |
| [5896](https://github.com/BuilderIO/builder/security/dependabot/5896) | plugins/salesforce-einstein-api |
| [5895](https://github.com/BuilderIO/builder/security/dependabot/5895) | plugins/salesforce-commerce-api-plugin |
| [5894](https://github.com/BuilderIO/builder/security/dependabot/5894) | plugins/salesforce-commerce-api-plugin |
| [5859](https://github.com/BuilderIO/builder/security/dependabot/5859) | plugins/async-dropdown |
| [5823](https://github.com/BuilderIO/builder/security/dependabot/5823) | examples/react-native |

**Screenshot/Clip**
NA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile and override-only dependency security fix; no runtime application code changes.
> 
> **Overview**
> Addresses **Dependabot alerts** for prototype pollution in transitive **`minimist`** by adding npm **`overrides`** on affected example and plugin packages (`minimist@<1` → `0.2.4`, `minimist@1` → `1.2.8`).
> 
> Regenerated **`package-lock.json`** files so nested dependencies (e.g. under `mkdirp`, webpack tooling, commitizen) resolve to those patched versions instead of older `1.2.0`–`1.2.7` / `0.0.8` copies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9e7cebe72b5ac6e9761e63b27926e6d2c8789ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->