### PR TITLE
chore[deps]: fix prototype pollution in lodash

### DIFF
--- a/examples/embed-starter-kit/plugin/package-lock.json
+++ b/examples/embed-starter-kit/plugin/package-lock.json
@@ -1373,12 +1373,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/cli/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -1405,12 +1399,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/ensure/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "7.6.0",
@@ -1465,12 +1453,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/lint/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/load": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.6.2.tgz",
@@ -1524,12 +1506,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/load/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/load/node_modules/parse-json": {
       "version": "4.0.0",
@@ -1606,12 +1582,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/resolve-extends/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
       "version": "5.0.0",
@@ -14374,9 +14344,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -26091,7 +26062,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -26218,7 +26189,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -26293,7 +26264,7 @@
         "@babel/helper-split-export-declaration": "^7.8.3",
         "@babel/template": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -26317,7 +26288,7 @@
       "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -26602,7 +26573,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -26979,7 +26950,7 @@
       "dev": true,
       "requires": {
         "find-cache-dir": "^2.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "make-dir": "^2.1.0",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.16"
@@ -27103,7 +27074,7 @@
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "7.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "meow": "5.0.0",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0"
@@ -27119,12 +27090,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.2.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -27146,15 +27111,7 @@
       "integrity": "sha512-pSUrNud5L/8y+cLWo3LEa8Ce4bAAR33xMderFUhuNPHj7TwpNS7L4ROMnhL4ZlCYRazCRDlnPaJLPikMoWThfA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/execute-rule": {
@@ -27195,15 +27152,7 @@
         "@commitlint/parse": "^7.6.0",
         "@commitlint/rules": "^7.6.0",
         "babel-runtime": "^6.23.0",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/load": {
@@ -27216,7 +27165,7 @@
         "@commitlint/resolve-extends": "^7.6.0",
         "babel-runtime": "^6.23.0",
         "cosmiconfig": "^5.2.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -27250,12 +27199,6 @@
             }
           }
         },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -27288,7 +27231,7 @@
       "requires": {
         "conventional-changelog-angular": "^1.3.3",
         "conventional-commits-parser": "^2.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/read": {
@@ -27311,17 +27254,11 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -27718,7 +27655,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "7.0.1",
@@ -27814,7 +27752,7 @@
         "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "micromatch": "^4.0.2"
       },
       "dependencies": {
@@ -27872,7 +27810,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -28238,7 +28176,7 @@
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mime": "^3.0.0",
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
@@ -28353,7 +28291,7 @@
         "aggregate-error": "^3.0.0",
         "execa": "^5.0.0",
         "fs-extra": "^11.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "4.18.1",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^6.0.0",
         "npm": "^8.3.0",
@@ -28562,7 +28500,7 @@
         "get-stream": "^6.0.0",
         "import-from": "^4.0.0",
         "into-stream": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
@@ -28611,7 +28549,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -29383,13 +29321,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
       "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -29632,7 +29572,7 @@
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "4.18.1"
       }
     },
     "async-each": {
@@ -29755,7 +29695,7 @@
         "convert-source-map": "^1.5.1",
         "debug": "^2.6.9",
         "json5": "^0.5.1",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "minimatch": "^3.0.4",
         "path-is-absolute": "^1.0.1",
         "private": "^0.1.8",
@@ -29782,7 +29722,7 @@
         "babel-types": "^6.26.0",
         "detect-indent": "^4.0.0",
         "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "source-map": "^0.5.7",
         "trim-right": "^1.0.1"
       },
@@ -29937,7 +29877,7 @@
         "babel-runtime": "^6.26.0",
         "core-js": "^2.5.0",
         "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.4.15"
       },
@@ -29981,7 +29921,7 @@
         "babel-traverse": "^6.26.0",
         "babel-types": "^6.26.0",
         "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "lodash": "4.18.1"
       }
     },
     "babel-traverse": {
@@ -29998,7 +29938,7 @@
         "debug": "^2.6.8",
         "globals": "^9.18.0",
         "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "lodash": "4.18.1"
       }
     },
     "babel-types": {
@@ -30009,7 +29949,7 @@
       "requires": {
         "babel-runtime": "^6.26.0",
         "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "to-fast-properties": "^1.0.3"
       },
       "dependencies": {
@@ -31066,7 +31006,7 @@
         "glob": "7.2.3",
         "inquirer": "8.2.5",
         "is-utf8": "^0.2.1",
-        "lodash": "4.17.21",
+        "lodash": "4.18.1",
         "minimist": "1.2.8",
         "strip-bom": "4.0.0",
         "strip-json-comments": "3.1.1"
@@ -31310,7 +31250,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "4.18.1",
         "meow": "^8.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -31624,7 +31564,7 @@
       "requires": {
         "is-text-path": "^1.0.0",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.2.1",
+        "lodash": "4.18.1",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^2.0.0",
@@ -34801,7 +34741,7 @@
       "requires": {
         "http-proxy": "^1.17.0",
         "is-glob": "^4.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "4.18.1",
         "micromatch": "^3.1.10"
       }
     },
@@ -34996,7 +34936,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ieee754": {
       "version": "1.1.13",
@@ -35118,7 +35059,7 @@
         "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "mute-stream": "0.0.8",
         "ora": "^5.4.1",
         "run-async": "^2.4.0",
@@ -36940,12 +36881,14 @@
     "jss-default-unit": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
-      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg=="
+      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg==",
+      "requires": {}
     },
     "jss-global": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
-      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q=="
+      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q==",
+      "requires": {}
     },
     "jss-nested": {
       "version": "6.0.1",
@@ -36968,7 +36911,8 @@
     "jss-props-sort": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
-      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g=="
+      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g==",
+      "requires": {}
     },
     "jss-vendor-prefixer": {
       "version": "7.0.0",
@@ -37479,9 +37423,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash-es": {
       "version": "4.17.21",
@@ -38198,7 +38142,8 @@
     "mobx-react-lite": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-1.5.2.tgz",
-      "integrity": "sha512-PyZmARqqWtpuQaAoHF5pKX7h6TKNLwq6vtovm4zZvG6sEbMRHHSqioGXSeQbpRmG8Kw8uln3q/W1yMO5IfL5Sg=="
+      "integrity": "sha512-PyZmARqqWtpuQaAoHF5pKX7h6TKNLwq6vtovm4zZvG6sEbMRHHSqioGXSeQbpRmG8Kw8uln3q/W1yMO5IfL5Sg==",
+      "requires": {}
     },
     "modify-values": {
       "version": "1.0.1",
@@ -38322,7 +38267,7 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "4.18.1"
       }
     },
     "node-fetch": {
@@ -41181,7 +41126,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.3",
@@ -41658,7 +41604,7 @@
       "requires": {
         "@types/quill": "1.3.10",
         "create-react-class": "^15.6.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "prop-types": "^15.5.10",
         "quill": "^1.3.7",
         "react-dom-factories": "^1.0.0"
@@ -42128,7 +42074,7 @@
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "4.18.1"
       }
     },
     "request-promise-native": {
@@ -44935,7 +44881,7 @@
         "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
         "highlight.js": "^9.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",

--- a/examples/embed-starter-kit/plugin/package.json
+++ b/examples/embed-starter-kit/plugin/package.json
@@ -127,6 +127,7 @@
     "react-quill": "^1.3.5"
   },
   "overrides": {
+    "lodash": "4.18.1",
     "minimist@<1": "0.2.4",
     "minimist@1": "1.2.8"
   }

--- a/plugins/async-dropdown/package-lock.json
+++ b/plugins/async-dropdown/package-lock.json
@@ -1343,12 +1343,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/cli/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -1375,12 +1369,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/ensure/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "7.6.0",
@@ -1444,12 +1432,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/lint/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/load": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.6.2.tgz",
@@ -1503,12 +1485,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/load/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/load/node_modules/parse-json": {
       "version": "4.0.0",
@@ -1585,12 +1561,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/resolve-extends/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
       "version": "5.0.0",
@@ -13182,10 +13152,11 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -24505,7 +24476,7 @@
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -24595,7 +24566,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.7.4",
         "@babel/types": "^7.7.4",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -24670,7 +24641,7 @@
         "@babel/helper-split-export-declaration": "^7.7.4",
         "@babel/template": "^7.7.4",
         "@babel/types": "^7.7.4",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -24694,7 +24665,7 @@
       "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -24970,7 +24941,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -25398,7 +25369,7 @@
       "dev": true,
       "requires": {
         "find-cache-dir": "^2.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "make-dir": "^2.1.0",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.16"
@@ -25491,7 +25462,7 @@
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "7.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "meow": "5.0.0",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0"
@@ -25507,12 +25478,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.2.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -25534,15 +25499,7 @@
       "integrity": "sha512-pSUrNud5L/8y+cLWo3LEa8Ce4bAAR33xMderFUhuNPHj7TwpNS7L4ROMnhL4ZlCYRazCRDlnPaJLPikMoWThfA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/execute-rule": {
@@ -25591,15 +25548,7 @@
         "@commitlint/parse": "^7.6.0",
         "@commitlint/rules": "^7.6.0",
         "babel-runtime": "^6.23.0",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/load": {
@@ -25612,7 +25561,7 @@
         "@commitlint/resolve-extends": "^7.6.0",
         "babel-runtime": "^6.23.0",
         "cosmiconfig": "^5.2.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -25646,12 +25595,6 @@
             }
           }
         },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -25684,7 +25627,7 @@
       "requires": {
         "conventional-changelog-angular": "^1.3.3",
         "conventional-commits-parser": "^2.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/read": {
@@ -25707,17 +25650,11 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -26406,7 +26343,7 @@
         "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "micromatch": "^4.0.2"
       },
       "dependencies": {
@@ -26464,7 +26401,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -26815,7 +26752,7 @@
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mime": "^3.0.0",
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
@@ -27167,7 +27104,7 @@
         "get-stream": "^6.0.0",
         "import-from": "^4.0.0",
         "into-stream": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
@@ -27216,7 +27153,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -27564,7 +27501,7 @@
         "css.escape": "^1.5.1",
         "jest-diff": "^25.1.0",
         "jest-matcher-utils": "^25.1.0",
-        "lodash": "^4.17.15",
+        "lodash": "4.18.1",
         "pretty-format": "^25.1.0",
         "redent": "^3.0.0"
       },
@@ -29822,7 +29759,7 @@
         "glob": "7.2.3",
         "inquirer": "8.2.5",
         "is-utf8": "^0.2.1",
-        "lodash": "4.17.21",
+        "lodash": "4.18.1",
         "minimist": "1.2.8",
         "strip-bom": "4.0.0",
         "strip-json-comments": "3.1.1"
@@ -30083,7 +30020,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "4.18.1",
         "meow": "^8.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -30403,7 +30340,7 @@
       "requires": {
         "is-text-path": "^1.0.0",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.2.1",
+        "lodash": "4.18.1",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^2.0.0",
@@ -32780,7 +32717,7 @@
       "requires": {
         "http-proxy": "^1.17.0",
         "is-glob": "^4.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "4.18.1",
         "micromatch": "^3.1.10"
       }
     },
@@ -33064,7 +33001,7 @@
         "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "mute-stream": "0.0.8",
         "ora": "^5.4.1",
         "run-async": "^2.4.0",
@@ -34838,9 +34775,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true
     },
     "lodash-es": {
@@ -35673,7 +35610,7 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "4.18.1"
       }
     },
     "node-fetch": {
@@ -38685,7 +38622,7 @@
           "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "dev": true,
           "requires": {
-            "lodash": "^4.17.14"
+            "lodash": "4.18.1"
           }
         },
         "debug": {
@@ -39306,7 +39243,7 @@
       "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.19"
+        "lodash": "4.18.1"
       }
     },
     "request-promise-native": {
@@ -40628,7 +40565,7 @@
           "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "dev": true,
           "requires": {
-            "lodash": "^4.17.14"
+            "lodash": "4.18.1"
           }
         }
       }
@@ -41962,7 +41899,7 @@
         "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
         "highlight.js": "^9.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",

--- a/plugins/async-dropdown/package.json
+++ b/plugins/async-dropdown/package.json
@@ -111,6 +111,7 @@
     "ses": "^0.6.4"
   },
   "overrides": {
+    "lodash": "4.18.1",
     "minimist@<1": "0.2.4",
     "minimist@1": "1.2.8"
   }

--- a/plugins/emporix/package-lock.json
+++ b/plugins/emporix/package-lock.json
@@ -1991,13 +1991,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@commitlint/config-conventional": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-7.6.0.tgz",
@@ -2017,13 +2010,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/ensure/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "7.6.0",
@@ -2082,13 +2068,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/lint/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@commitlint/load": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.6.2.tgz",
@@ -2106,13 +2085,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/load/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@commitlint/message": {
       "version": "7.6.0",
@@ -2171,13 +2143,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/resolve-extends/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@commitlint/rules": {
       "version": "7.6.0",
@@ -13739,9 +13704,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash._reinterpolate": {

--- a/plugins/emporix/package.json
+++ b/plugins/emporix/package.json
@@ -125,5 +125,8 @@
   },
   "dependencies": {
     "@builder.io/plugin-tools": "^0.0.6"
+  },
+  "overrides": {
+    "lodash": "4.18.1"
   }
 }

--- a/plugins/example-app-campaign-builder/package-lock.json
+++ b/plugins/example-app-campaign-builder/package-lock.json
@@ -1334,12 +1334,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/cli/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -1366,12 +1360,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/ensure/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "7.6.0",
@@ -1426,12 +1414,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/lint/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/load": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.6.2.tgz",
@@ -1485,12 +1467,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/load/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/load/node_modules/parse-json": {
       "version": "4.0.0",
@@ -1567,12 +1543,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/resolve-extends/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
       "version": "5.0.0",
@@ -6180,12 +6150,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/commitizen/node_modules/lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-      "dev": true
     },
     "node_modules/commitizen/node_modules/shelljs": {
       "version": "0.7.6",
@@ -13967,9 +13931,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -25768,7 +25733,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -25814,7 +25779,7 @@
       "requires": {
         "@babel/types": "^7.8.3",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "source-map": "^0.5.0"
       },
       "dependencies": {
@@ -25895,7 +25860,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -25965,7 +25930,7 @@
         "@babel/helper-split-export-declaration": "^7.8.3",
         "@babel/template": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -25989,7 +25954,7 @@
       "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -26269,7 +26234,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -26646,7 +26611,7 @@
       "dev": true,
       "requires": {
         "find-cache-dir": "^2.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "make-dir": "^2.1.0",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.16"
@@ -26703,7 +26668,7 @@
         "@babel/types": "^7.8.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       },
       "dependencies": {
         "debug": {
@@ -26735,7 +26700,7 @@
       "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -26769,7 +26734,7 @@
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "7.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "meow": "5.0.0",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0"
@@ -26785,12 +26750,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.2.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -26812,15 +26771,7 @@
       "integrity": "sha512-pSUrNud5L/8y+cLWo3LEa8Ce4bAAR33xMderFUhuNPHj7TwpNS7L4ROMnhL4ZlCYRazCRDlnPaJLPikMoWThfA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/execute-rule": {
@@ -26861,15 +26812,7 @@
         "@commitlint/parse": "^7.6.0",
         "@commitlint/rules": "^7.6.0",
         "babel-runtime": "^6.23.0",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/load": {
@@ -26882,7 +26825,7 @@
         "@commitlint/resolve-extends": "^7.6.0",
         "babel-runtime": "^6.23.0",
         "cosmiconfig": "^5.2.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -26916,12 +26859,6 @@
             }
           }
         },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -26954,7 +26891,7 @@
       "requires": {
         "conventional-changelog-angular": "^1.3.3",
         "conventional-commits-parser": "^2.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/read": {
@@ -26977,17 +26914,11 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -27345,7 +27276,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "7.0.1",
@@ -27448,7 +27380,7 @@
         "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "micromatch": "^4.0.2"
       },
       "dependencies": {
@@ -27506,7 +27438,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -27872,7 +27804,7 @@
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mime": "^3.0.0",
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
@@ -28245,7 +28177,7 @@
         "get-stream": "^6.0.0",
         "import-from": "^4.0.0",
         "into-stream": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
@@ -28294,7 +28226,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -29066,13 +28998,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
       "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -29314,7 +29248,7 @@
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "4.18.1"
       }
     },
     "async-each": {
@@ -29431,7 +29365,7 @@
         "convert-source-map": "^1.5.1",
         "debug": "^2.6.9",
         "json5": "^0.5.1",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "minimatch": "^3.0.4",
         "path-is-absolute": "^1.0.1",
         "private": "^0.1.8",
@@ -29458,7 +29392,7 @@
         "babel-types": "^6.26.0",
         "detect-indent": "^4.0.0",
         "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "source-map": "^0.5.7",
         "trim-right": "^1.0.1"
       },
@@ -29613,7 +29547,7 @@
         "babel-runtime": "^6.26.0",
         "core-js": "^2.5.0",
         "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.4.15"
       },
@@ -29657,7 +29591,7 @@
         "babel-traverse": "^6.26.0",
         "babel-types": "^6.26.0",
         "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "lodash": "4.18.1"
       }
     },
     "babel-traverse": {
@@ -29674,7 +29608,7 @@
         "debug": "^2.6.8",
         "globals": "^9.18.0",
         "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "lodash": "4.18.1"
       }
     },
     "babel-types": {
@@ -29685,7 +29619,7 @@
       "requires": {
         "babel-runtime": "^6.26.0",
         "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "to-fast-properties": "^1.0.3"
       },
       "dependencies": {
@@ -30703,7 +30637,7 @@
         "glob": "7.1.3",
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
-        "lodash": "4.17.14",
+        "lodash": "4.18.1",
         "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
@@ -30723,12 +30657,6 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.14",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-          "dev": true
         },
         "shelljs": {
           "version": "0.7.6",
@@ -30912,7 +30840,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "4.18.1",
         "meow": "^8.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -31226,7 +31154,7 @@
       "requires": {
         "is-text-path": "^1.0.0",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.2.1",
+        "lodash": "4.18.1",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^2.0.0",
@@ -34325,7 +34253,7 @@
       "requires": {
         "http-proxy": "^1.17.0",
         "is-glob": "^4.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "4.18.1",
         "micromatch": "^3.1.10"
       }
     },
@@ -34651,7 +34579,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.0",
         "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.1.0",
@@ -36348,12 +36276,14 @@
     "jss-default-unit": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
-      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg=="
+      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg==",
+      "requires": {}
     },
     "jss-global": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
-      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q=="
+      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q==",
+      "requires": {}
     },
     "jss-nested": {
       "version": "6.0.1",
@@ -36376,7 +36306,8 @@
     "jss-props-sort": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
-      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g=="
+      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g==",
+      "requires": {}
     },
     "jss-vendor-prefixer": {
       "version": "7.0.0",
@@ -36896,9 +36827,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash-es": {
       "version": "4.17.21",
@@ -37590,7 +37521,8 @@
     "mobx-react-lite": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-1.5.2.tgz",
-      "integrity": "sha512-PyZmARqqWtpuQaAoHF5pKX7h6TKNLwq6vtovm4zZvG6sEbMRHHSqioGXSeQbpRmG8Kw8uln3q/W1yMO5IfL5Sg=="
+      "integrity": "sha512-PyZmARqqWtpuQaAoHF5pKX7h6TKNLwq6vtovm4zZvG6sEbMRHHSqioGXSeQbpRmG8Kw8uln3q/W1yMO5IfL5Sg==",
+      "requires": {}
     },
     "modify-values": {
       "version": "1.0.1",
@@ -37708,7 +37640,7 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "4.18.1"
       }
     },
     "node-fetch": {
@@ -41211,7 +41143,7 @@
       "requires": {
         "@types/quill": "1.3.10",
         "create-react-class": "^15.6.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "prop-types": "^15.5.10",
         "quill": "^1.3.7",
         "react-dom-factories": "^1.0.0"
@@ -41681,7 +41613,7 @@
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "4.18.1"
       }
     },
     "request-promise-native": {
@@ -44400,7 +44332,7 @@
         "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
         "highlight.js": "^9.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",

--- a/plugins/example-app-campaign-builder/package.json
+++ b/plugins/example-app-campaign-builder/package.json
@@ -127,6 +127,7 @@
     "react-quill": "^1.3.5"
   },
   "overrides": {
+    "lodash": "4.18.1",
     "minimist@<1": "0.2.4",
     "minimist@1": "1.2.8"
   }

--- a/plugins/example-app-simple/package-lock.json
+++ b/plugins/example-app-simple/package-lock.json
@@ -1334,12 +1334,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/cli/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -1366,12 +1360,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/ensure/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "7.6.0",
@@ -1426,12 +1414,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/lint/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/load": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.6.2.tgz",
@@ -1485,12 +1467,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/load/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/load/node_modules/parse-json": {
       "version": "4.0.0",
@@ -1567,12 +1543,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/resolve-extends/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
       "version": "5.0.0",
@@ -6180,12 +6150,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/commitizen/node_modules/lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-      "dev": true
     },
     "node_modules/commitizen/node_modules/shelljs": {
       "version": "0.7.6",
@@ -13975,9 +13939,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -25776,7 +25741,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -25822,7 +25787,7 @@
       "requires": {
         "@babel/types": "^7.8.3",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "source-map": "^0.5.0"
       },
       "dependencies": {
@@ -25903,7 +25868,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -25973,7 +25938,7 @@
         "@babel/helper-split-export-declaration": "^7.8.3",
         "@babel/template": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -25997,7 +25962,7 @@
       "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -26277,7 +26242,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -26654,7 +26619,7 @@
       "dev": true,
       "requires": {
         "find-cache-dir": "^2.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "make-dir": "^2.1.0",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.16"
@@ -26711,7 +26676,7 @@
         "@babel/types": "^7.8.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       },
       "dependencies": {
         "debug": {
@@ -26743,7 +26708,7 @@
       "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -26777,7 +26742,7 @@
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "7.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "meow": "5.0.0",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0"
@@ -26793,12 +26758,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.2.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -26820,15 +26779,7 @@
       "integrity": "sha512-pSUrNud5L/8y+cLWo3LEa8Ce4bAAR33xMderFUhuNPHj7TwpNS7L4ROMnhL4ZlCYRazCRDlnPaJLPikMoWThfA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/execute-rule": {
@@ -26869,15 +26820,7 @@
         "@commitlint/parse": "^7.6.0",
         "@commitlint/rules": "^7.6.0",
         "babel-runtime": "^6.23.0",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/load": {
@@ -26890,7 +26833,7 @@
         "@commitlint/resolve-extends": "^7.6.0",
         "babel-runtime": "^6.23.0",
         "cosmiconfig": "^5.2.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -26924,12 +26867,6 @@
             }
           }
         },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -26962,7 +26899,7 @@
       "requires": {
         "conventional-changelog-angular": "^1.3.3",
         "conventional-commits-parser": "^2.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/read": {
@@ -26985,17 +26922,11 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -27353,7 +27284,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "7.0.1",
@@ -27456,7 +27388,7 @@
         "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "micromatch": "^4.0.2"
       },
       "dependencies": {
@@ -27514,7 +27446,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -27880,7 +27812,7 @@
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mime": "^3.0.0",
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
@@ -28253,7 +28185,7 @@
         "get-stream": "^6.0.0",
         "import-from": "^4.0.0",
         "into-stream": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
@@ -28302,7 +28234,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -29074,13 +29006,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
       "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -29322,7 +29256,7 @@
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "4.18.1"
       }
     },
     "async-each": {
@@ -29439,7 +29373,7 @@
         "convert-source-map": "^1.5.1",
         "debug": "^2.6.9",
         "json5": "^0.5.1",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "minimatch": "^3.0.4",
         "path-is-absolute": "^1.0.1",
         "private": "^0.1.8",
@@ -29466,7 +29400,7 @@
         "babel-types": "^6.26.0",
         "detect-indent": "^4.0.0",
         "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "source-map": "^0.5.7",
         "trim-right": "^1.0.1"
       },
@@ -29621,7 +29555,7 @@
         "babel-runtime": "^6.26.0",
         "core-js": "^2.5.0",
         "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.4.15"
       },
@@ -29665,7 +29599,7 @@
         "babel-traverse": "^6.26.0",
         "babel-types": "^6.26.0",
         "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "lodash": "4.18.1"
       }
     },
     "babel-traverse": {
@@ -29682,7 +29616,7 @@
         "debug": "^2.6.8",
         "globals": "^9.18.0",
         "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "lodash": "4.18.1"
       }
     },
     "babel-types": {
@@ -29693,7 +29627,7 @@
       "requires": {
         "babel-runtime": "^6.26.0",
         "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "to-fast-properties": "^1.0.3"
       },
       "dependencies": {
@@ -30711,7 +30645,7 @@
         "glob": "7.1.3",
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
-        "lodash": "4.17.14",
+        "lodash": "4.18.1",
         "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
@@ -30731,12 +30665,6 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.14",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-          "dev": true
         },
         "shelljs": {
           "version": "0.7.6",
@@ -30920,7 +30848,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "4.18.1",
         "meow": "^8.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -31234,7 +31162,7 @@
       "requires": {
         "is-text-path": "^1.0.0",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.2.1",
+        "lodash": "4.18.1",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^2.0.0",
@@ -34353,7 +34281,7 @@
       "requires": {
         "http-proxy": "^1.17.0",
         "is-glob": "^4.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "4.18.1",
         "micromatch": "^3.1.10"
       }
     },
@@ -34679,7 +34607,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.0",
         "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.1.0",
@@ -36376,12 +36304,14 @@
     "jss-default-unit": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
-      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg=="
+      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg==",
+      "requires": {}
     },
     "jss-global": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
-      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q=="
+      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q==",
+      "requires": {}
     },
     "jss-nested": {
       "version": "6.0.1",
@@ -36404,7 +36334,8 @@
     "jss-props-sort": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
-      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g=="
+      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g==",
+      "requires": {}
     },
     "jss-vendor-prefixer": {
       "version": "7.0.0",
@@ -36924,9 +36855,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash-es": {
       "version": "4.17.21",
@@ -37618,7 +37549,8 @@
     "mobx-react-lite": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-1.5.2.tgz",
-      "integrity": "sha512-PyZmARqqWtpuQaAoHF5pKX7h6TKNLwq6vtovm4zZvG6sEbMRHHSqioGXSeQbpRmG8Kw8uln3q/W1yMO5IfL5Sg=="
+      "integrity": "sha512-PyZmARqqWtpuQaAoHF5pKX7h6TKNLwq6vtovm4zZvG6sEbMRHHSqioGXSeQbpRmG8Kw8uln3q/W1yMO5IfL5Sg==",
+      "requires": {}
     },
     "modify-values": {
       "version": "1.0.1",
@@ -37736,7 +37668,7 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "4.18.1"
       }
     },
     "node-fetch": {
@@ -41239,7 +41171,7 @@
       "requires": {
         "@types/quill": "1.3.10",
         "create-react-class": "^15.6.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "prop-types": "^15.5.10",
         "quill": "^1.3.7",
         "react-dom-factories": "^1.0.0"
@@ -41709,7 +41641,7 @@
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "4.18.1"
       }
     },
     "request-promise-native": {
@@ -44428,7 +44360,7 @@
         "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
         "highlight.js": "^9.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",

--- a/plugins/example-app-simple/package.json
+++ b/plugins/example-app-simple/package.json
@@ -127,6 +127,7 @@
     "react-quill": "^1.3.5"
   },
   "overrides": {
+    "lodash": "4.18.1",
     "minimist@<1": "0.2.4",
     "minimist@1": "1.2.8"
   }

--- a/plugins/jodit-html-editor/package-lock.json
+++ b/plugins/jodit-html-editor/package-lock.json
@@ -1387,12 +1387,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/cli/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -1419,12 +1413,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/ensure/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "7.6.0",
@@ -1479,12 +1467,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/lint/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/load": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.6.2.tgz",
@@ -1538,12 +1520,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/load/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/load/node_modules/parse-json": {
       "version": "4.0.0",
@@ -1620,12 +1596,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/resolve-extends/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
       "version": "5.0.0",
@@ -6098,12 +6068,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/commitizen/node_modules/lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-      "dev": true
     },
     "node_modules/commitizen/node_modules/shelljs": {
       "version": "0.7.6",
@@ -10725,7 +10689,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -13625,10 +13589,11 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -20181,7 +20146,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/sane": {
       "version": "2.5.2",
@@ -25186,7 +25151,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -25313,7 +25278,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -25388,7 +25353,7 @@
         "@babel/helper-split-export-declaration": "^7.8.3",
         "@babel/template": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -25412,7 +25377,7 @@
       "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -25705,7 +25670,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -26082,7 +26047,7 @@
       "dev": true,
       "requires": {
         "find-cache-dir": "^2.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "make-dir": "^2.1.0",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.16"
@@ -26206,7 +26171,7 @@
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "7.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "meow": "5.0.0",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0"
@@ -26222,12 +26187,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.2.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -26249,15 +26208,7 @@
       "integrity": "sha512-pSUrNud5L/8y+cLWo3LEa8Ce4bAAR33xMderFUhuNPHj7TwpNS7L4ROMnhL4ZlCYRazCRDlnPaJLPikMoWThfA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/execute-rule": {
@@ -26298,15 +26249,7 @@
         "@commitlint/parse": "^7.6.0",
         "@commitlint/rules": "^7.6.0",
         "babel-runtime": "^6.23.0",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/load": {
@@ -26319,7 +26262,7 @@
         "@commitlint/resolve-extends": "^7.6.0",
         "babel-runtime": "^6.23.0",
         "cosmiconfig": "^5.2.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -26353,12 +26296,6 @@
             }
           }
         },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -26391,7 +26328,7 @@
       "requires": {
         "conventional-changelog-angular": "^1.3.3",
         "conventional-commits-parser": "^2.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/read": {
@@ -26414,17 +26351,11 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -26822,7 +26753,7 @@
         "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "micromatch": "^4.0.2"
       },
       "dependencies": {
@@ -26880,7 +26811,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -27246,7 +27177,7 @@
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mime": "^3.0.0",
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
@@ -27619,7 +27550,7 @@
         "get-stream": "^6.0.0",
         "import-from": "^4.0.0",
         "into-stream": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
@@ -27668,7 +27599,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -28662,7 +28593,7 @@
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "4.18.1"
       }
     },
     "async-each": {
@@ -28784,7 +28715,7 @@
         "convert-source-map": "^1.5.1",
         "debug": "^2.6.9",
         "json5": "^0.5.1",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "minimatch": "^3.0.4",
         "path-is-absolute": "^1.0.1",
         "private": "^0.1.8",
@@ -28811,7 +28742,7 @@
         "babel-types": "^6.26.0",
         "detect-indent": "^4.0.0",
         "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "source-map": "^0.5.7",
         "trim-right": "^1.0.1"
       },
@@ -28966,7 +28897,7 @@
         "babel-runtime": "^6.26.0",
         "core-js": "^2.5.0",
         "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.4.15"
       },
@@ -29013,7 +28944,7 @@
         "babel-traverse": "^6.26.0",
         "babel-types": "^6.26.0",
         "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "lodash": "4.18.1"
       }
     },
     "babel-traverse": {
@@ -29030,7 +28961,7 @@
         "debug": "^2.6.8",
         "globals": "^9.18.0",
         "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "lodash": "4.18.1"
       }
     },
     "babel-types": {
@@ -29041,7 +28972,7 @@
       "requires": {
         "babel-runtime": "^6.26.0",
         "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "to-fast-properties": "^1.0.3"
       },
       "dependencies": {
@@ -30036,7 +29967,7 @@
         "glob": "7.1.3",
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
-        "lodash": "4.17.14",
+        "lodash": "4.18.1",
         "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
@@ -30056,12 +29987,6 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.14",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-          "dev": true
         },
         "shelljs": {
           "version": "0.7.6",
@@ -30245,7 +30170,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "4.18.1",
         "meow": "^8.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -30559,7 +30484,7 @@
       "requires": {
         "is-text-path": "^1.0.0",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.2.1",
+        "lodash": "4.18.1",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^2.0.0",
@@ -33529,7 +33454,7 @@
       "requires": {
         "http-proxy": "^1.17.0",
         "is-glob": "^4.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "4.18.1",
         "micromatch": "^3.1.10"
       }
     },
@@ -33711,7 +33636,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -33843,7 +33768,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.0",
         "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.1.0",
@@ -36018,9 +35943,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true
     },
     "lodash-es": {
@@ -36813,7 +36738,7 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "4.18.1"
       }
     },
     "node-fetch": {
@@ -40647,7 +40572,7 @@
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "4.18.1"
       }
     },
     "request-promise-native": {
@@ -40874,7 +40799,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true
+      "dev": true
     },
     "sane": {
       "version": "2.5.2",
@@ -43350,7 +43275,7 @@
         "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
         "highlight.js": "^9.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",

--- a/plugins/jodit-html-editor/package.json
+++ b/plugins/jodit-html-editor/package.json
@@ -128,6 +128,7 @@
     "react-dom": "^16.13.1"
   },
   "overrides": {
+    "lodash": "4.18.1",
     "minimist@<1": "0.2.4",
     "minimist@1": "1.2.8"
   }

--- a/plugins/localized-preview/package-lock.json
+++ b/plugins/localized-preview/package-lock.json
@@ -1707,12 +1707,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/cli/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -1739,12 +1733,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/ensure/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "7.6.0",
@@ -1799,12 +1787,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/lint/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/load": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.6.2.tgz",
@@ -1858,12 +1840,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/load/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/load/node_modules/parse-json": {
       "version": "4.0.0",
@@ -1940,12 +1916,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/resolve-extends/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
       "version": "5.0.0",
@@ -6460,12 +6430,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/commitizen/node_modules/lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-      "dev": true
     },
     "node_modules/commitizen/node_modules/shelljs": {
       "version": "0.7.6",
@@ -14258,10 +14222,11 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
@@ -25756,7 +25721,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -25883,7 +25848,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -25958,7 +25923,7 @@
         "@babel/helper-split-export-declaration": "^7.8.3",
         "@babel/template": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -25982,7 +25947,7 @@
       "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -26275,7 +26240,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -26652,7 +26617,7 @@
       "dev": true,
       "requires": {
         "find-cache-dir": "^2.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "make-dir": "^2.1.0",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.16"
@@ -27019,7 +26984,7 @@
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "7.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "meow": "5.0.0",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0"
@@ -27035,12 +27000,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.2.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -27062,15 +27021,7 @@
       "integrity": "sha512-pSUrNud5L/8y+cLWo3LEa8Ce4bAAR33xMderFUhuNPHj7TwpNS7L4ROMnhL4ZlCYRazCRDlnPaJLPikMoWThfA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/execute-rule": {
@@ -27111,15 +27062,7 @@
         "@commitlint/parse": "^7.6.0",
         "@commitlint/rules": "^7.6.0",
         "babel-runtime": "^6.23.0",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/load": {
@@ -27132,7 +27075,7 @@
         "@commitlint/resolve-extends": "^7.6.0",
         "babel-runtime": "^6.23.0",
         "cosmiconfig": "^5.2.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -27166,12 +27109,6 @@
             }
           }
         },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -27204,7 +27141,7 @@
       "requires": {
         "conventional-changelog-angular": "^1.3.3",
         "conventional-commits-parser": "^2.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/read": {
@@ -27227,17 +27164,11 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -27754,7 +27685,7 @@
         "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "micromatch": "^4.0.2"
       },
       "dependencies": {
@@ -27812,7 +27743,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -28163,7 +28094,7 @@
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mime": "^3.0.0",
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
@@ -28527,7 +28458,7 @@
         "get-stream": "^6.0.0",
         "import-from": "^4.0.0",
         "into-stream": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
@@ -28576,7 +28507,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -29574,7 +29505,7 @@
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "4.18.1"
       }
     },
     "async-each": {
@@ -29691,7 +29622,7 @@
         "convert-source-map": "^1.5.1",
         "debug": "^2.6.9",
         "json5": "^0.5.1",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "minimatch": "^3.0.4",
         "path-is-absolute": "^1.0.1",
         "private": "^0.1.8",
@@ -29718,7 +29649,7 @@
         "babel-types": "^6.26.0",
         "detect-indent": "^4.0.0",
         "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "source-map": "^0.5.7",
         "trim-right": "^1.0.1"
       },
@@ -29873,7 +29804,7 @@
         "babel-runtime": "^6.26.0",
         "core-js": "^2.5.0",
         "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.4.15"
       },
@@ -29917,7 +29848,7 @@
         "babel-traverse": "^6.26.0",
         "babel-types": "^6.26.0",
         "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "lodash": "4.18.1"
       }
     },
     "babel-traverse": {
@@ -29934,7 +29865,7 @@
         "debug": "^2.6.8",
         "globals": "^9.18.0",
         "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "lodash": "4.18.1"
       }
     },
     "babel-types": {
@@ -29945,7 +29876,7 @@
       "requires": {
         "babel-runtime": "^6.26.0",
         "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "to-fast-properties": "^1.0.3"
       },
       "dependencies": {
@@ -30784,7 +30715,7 @@
         "glob": "7.1.3",
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
-        "lodash": "4.17.14",
+        "lodash": "4.18.1",
         "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
@@ -30804,12 +30735,6 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.14",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-          "dev": true
         },
         "shelljs": {
           "version": "0.7.6",
@@ -30969,7 +30894,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "4.18.1",
         "meow": "^8.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -31268,7 +31193,7 @@
       "requires": {
         "is-text-path": "^1.0.0",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.2.1",
+        "lodash": "4.18.1",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^2.0.0",
@@ -34189,7 +34114,7 @@
       "requires": {
         "http-proxy": "^1.17.0",
         "is-glob": "^4.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "4.18.1",
         "micromatch": "^3.1.10"
       }
     },
@@ -34491,7 +34416,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.0",
         "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.1.0",
@@ -36971,9 +36896,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true
     },
     "lodash-es": {
@@ -37695,7 +37620,7 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "4.18.1"
       }
     },
     "node-fetch": {
@@ -41378,7 +41303,7 @@
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "4.18.1"
       }
     },
     "request-promise-native": {
@@ -44058,7 +43983,7 @@
         "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
         "highlight.js": "^9.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",

--- a/plugins/localized-preview/package.json
+++ b/plugins/localized-preview/package.json
@@ -126,6 +126,7 @@
     "react": "^17.0.2"
   },
   "overrides": {
+    "lodash": "4.18.1",
     "minimist@<1": "0.2.4",
     "minimist@1": "1.2.8"
   }

--- a/plugins/multi-cloudinary/package-lock.json
+++ b/plugins/multi-cloudinary/package-lock.json
@@ -1338,12 +1338,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/cli/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -1370,12 +1364,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/ensure/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "7.6.0",
@@ -1439,12 +1427,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/lint/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/load": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.6.2.tgz",
@@ -1498,12 +1480,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/load/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/load/node_modules/parse-json": {
       "version": "4.0.0",
@@ -1580,12 +1556,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/resolve-extends/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
       "version": "5.0.0",
@@ -12426,10 +12396,11 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
@@ -22044,7 +22015,7 @@
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -22134,7 +22105,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.7.4",
         "@babel/types": "^7.7.4",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -22209,7 +22180,7 @@
         "@babel/helper-split-export-declaration": "^7.7.4",
         "@babel/template": "^7.7.4",
         "@babel/types": "^7.7.4",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -22233,7 +22204,7 @@
       "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -22509,7 +22480,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -22937,7 +22908,7 @@
       "dev": true,
       "requires": {
         "find-cache-dir": "^2.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "make-dir": "^2.1.0",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.16"
@@ -23030,7 +23001,7 @@
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "7.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "meow": "5.0.0",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0"
@@ -23046,12 +23017,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.2.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -23073,15 +23038,7 @@
       "integrity": "sha512-pSUrNud5L/8y+cLWo3LEa8Ce4bAAR33xMderFUhuNPHj7TwpNS7L4ROMnhL4ZlCYRazCRDlnPaJLPikMoWThfA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/execute-rule": {
@@ -23130,15 +23087,7 @@
         "@commitlint/parse": "^7.6.0",
         "@commitlint/rules": "^7.6.0",
         "babel-runtime": "^6.23.0",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/load": {
@@ -23151,7 +23100,7 @@
         "@commitlint/resolve-extends": "^7.6.0",
         "babel-runtime": "^6.23.0",
         "cosmiconfig": "^5.2.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -23185,12 +23134,6 @@
             }
           }
         },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -23223,7 +23166,7 @@
       "requires": {
         "conventional-changelog-angular": "^1.3.3",
         "conventional-commits-parser": "^2.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/read": {
@@ -23246,17 +23189,11 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -24057,7 +23994,7 @@
         "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "micromatch": "^4.0.2"
       },
       "dependencies": {
@@ -24115,7 +24052,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -24451,7 +24388,7 @@
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mime": "^3.0.0",
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
@@ -24782,7 +24719,7 @@
         "get-stream": "^6.0.0",
         "import-from": "^4.0.0",
         "into-stream": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
@@ -24831,7 +24768,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -26318,7 +26255,7 @@
         "dom-serializer": "~0.1.1",
         "entities": "~1.1.1",
         "htmlparser2": "^3.9.1",
-        "lodash": "^4.15.0",
+        "lodash": "4.18.1",
         "parse5": "^3.0.1"
       }
     },
@@ -26620,7 +26557,7 @@
         "glob": "7.2.3",
         "inquirer": "8.2.5",
         "is-utf8": "^0.2.1",
-        "lodash": "4.17.21",
+        "lodash": "4.18.1",
         "minimist": "1.2.7",
         "strip-bom": "4.0.0",
         "strip-json-comments": "3.1.1"
@@ -26787,7 +26724,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "4.18.1",
         "meow": "^8.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -27092,7 +27029,7 @@
       "requires": {
         "is-text-path": "^1.0.0",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.2.1",
+        "lodash": "4.18.1",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^2.0.0",
@@ -29895,7 +29832,7 @@
         "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "mute-stream": "0.0.8",
         "ora": "^5.4.1",
         "run-async": "^2.4.0",
@@ -31641,9 +31578,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true
     },
     "lodash-es": {
@@ -32375,7 +32312,7 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "4.18.1"
       }
     },
     "node-fetch": {
@@ -35865,7 +35802,7 @@
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "4.18.1"
       }
     },
     "request-promise-native": {
@@ -38131,7 +38068,7 @@
         "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
         "highlight.js": "^9.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",

--- a/plugins/multi-cloudinary/package.json
+++ b/plugins/multi-cloudinary/package.json
@@ -110,5 +110,8 @@
     "cross-env": "^6.0.3",
     "react": "^16.11.0",
     "react-helmet": "^5.2.1"
+  },
+  "overrides": {
+    "lodash": "4.18.1"
   }
 }

--- a/plugins/phrase-conector/package-lock.json
+++ b/plugins/phrase-conector/package-lock.json
@@ -12,7 +12,7 @@
         "@builder.io/commerce-plugin-tools": "^0.3.0",
         "@builder.io/utils": "^1.1.23",
         "fast-json-stable-stringify": "^2.1.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "object-hash": "^3.0.0",
         "traverse": "^0.6.6",
         "uuid": "^8.3.2"
@@ -1598,12 +1598,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/cli/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -1630,12 +1624,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/ensure/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "7.6.0",
@@ -1690,12 +1678,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/lint/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/load": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.6.2.tgz",
@@ -1749,12 +1731,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/load/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/load/node_modules/parse-json": {
       "version": "4.0.0",
@@ -1831,12 +1807,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/resolve-extends/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
       "version": "5.0.0",
@@ -6937,12 +6907,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/commitizen/node_modules/lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-      "dev": true
     },
     "node_modules/commitizen/node_modules/shelljs": {
       "version": "0.7.6",
@@ -18330,6 +18294,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-dom": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0"
+      }
+    },
     "node_modules/react-event-listener": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.6.tgz",
@@ -19263,6 +19243,17 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/scheduler": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "node_modules/semantic-release": {
       "version": "21.0.1",
@@ -22405,7 +22396,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "^4.18.1"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -22506,7 +22497,7 @@
       "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.13"
+        "lodash": "^4.18.1"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -22860,7 +22851,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "^4.18.1"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -23237,7 +23228,7 @@
       "dev": true,
       "requires": {
         "find-cache-dir": "^2.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "^4.18.1",
         "make-dir": "^2.1.0",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.16"
@@ -23348,7 +23339,7 @@
         "@material-ui/core": "^3.9.2",
         "@material-ui/icons": "^1.1.1",
         "@types/pluralize": "0.0.29",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "mobx": "^5.15.4",
         "mobx-react": "^6.1.8",
         "pluralize": "^8.0.0",
@@ -23372,7 +23363,8 @@
         "mobx-react-lite": {
           "version": "2.2.2",
           "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-2.2.2.tgz",
-          "integrity": "sha512-2SlXALHIkyUPDsV4VTKVR9DW7K3Ksh1aaIv3NrNJygTbhXe2A9GrcKHZ2ovIiOp/BXilOcTYemfHHZubP431dg=="
+          "integrity": "sha512-2SlXALHIkyUPDsV4VTKVR9DW7K3Ksh1aaIv3NrNJygTbhXe2A9GrcKHZ2ovIiOp/BXilOcTYemfHHZubP431dg==",
+          "requires": {}
         }
       }
     },
@@ -23407,7 +23399,7 @@
       "integrity": "sha512-9wfJ8tJ5gEDB4xQ1URO2QJCk20wTfWQPoJ0nx7FTRQk+IOPk6iqKJGPxIcqtpgzEXXRROU183YTlEPkyLc1I4Q==",
       "requires": {
         "@types/lodash": "^4.14.182",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "traverse": "^0.6.6"
       }
     },
@@ -23431,7 +23423,7 @@
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "7.0.0",
-        "lodash": "4.17.11",
+        "lodash": "^4.18.1",
         "meow": "5.0.0",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0"
@@ -23447,12 +23439,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.2.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -23474,15 +23460,7 @@
       "integrity": "sha512-pSUrNud5L/8y+cLWo3LEa8Ce4bAAR33xMderFUhuNPHj7TwpNS7L4ROMnhL4ZlCYRazCRDlnPaJLPikMoWThfA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "^4.18.1"
       }
     },
     "@commitlint/execute-rule": {
@@ -23523,15 +23501,7 @@
         "@commitlint/parse": "^7.6.0",
         "@commitlint/rules": "^7.6.0",
         "babel-runtime": "^6.23.0",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "^4.18.1"
       }
     },
     "@commitlint/load": {
@@ -23544,7 +23514,7 @@
         "@commitlint/resolve-extends": "^7.6.0",
         "babel-runtime": "^6.23.0",
         "cosmiconfig": "^5.2.0",
-        "lodash": "4.17.11",
+        "lodash": "^4.18.1",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -23578,12 +23548,6 @@
             }
           }
         },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -23616,7 +23580,7 @@
       "requires": {
         "conventional-changelog-angular": "^1.3.3",
         "conventional-commits-parser": "^2.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.18.1"
       }
     },
     "@commitlint/read": {
@@ -23639,17 +23603,11 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.11",
+        "lodash": "^4.18.1",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -24788,7 +24746,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "7.0.1",
@@ -25035,7 +24994,7 @@
         "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "^4.18.1",
         "micromatch": "^4.0.2"
       },
       "dependencies": {
@@ -25093,7 +25052,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "^4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -25459,7 +25418,7 @@
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "^4.18.1",
         "mime": "^3.0.0",
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
@@ -25815,7 +25774,7 @@
         "get-stream": "^6.0.0",
         "import-from": "^4.0.0",
         "into-stream": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "^4.18.1",
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
@@ -25864,7 +25823,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "^4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -27566,7 +27525,7 @@
         "glob": "7.1.3",
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
-        "lodash": "4.17.14",
+        "lodash": "^4.18.1",
         "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
@@ -27586,12 +27545,6 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.14",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-          "dev": true
         },
         "shelljs": {
           "version": "0.7.6",
@@ -27698,7 +27651,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "^4.18.1",
         "meow": "^8.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -28012,7 +27965,7 @@
       "requires": {
         "is-text-path": "^1.0.0",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.2.1",
+        "lodash": "^4.18.1",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^2.0.0",
@@ -29836,7 +29789,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.0",
         "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.18.1",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.1.0",
@@ -31193,7 +31146,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "29.4.3",
@@ -31968,12 +31922,14 @@
     "jss-default-unit": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
-      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg=="
+      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg==",
+      "requires": {}
     },
     "jss-global": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
-      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q=="
+      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q==",
+      "requires": {}
     },
     "jss-nested": {
       "version": "6.0.1",
@@ -31996,7 +31952,8 @@
     "jss-props-sort": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
-      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g=="
+      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g==",
+      "requires": {}
     },
     "jss-vendor-prefixer": {
       "version": "7.0.0",
@@ -33032,13 +32989,15 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.4.0.tgz",
       "integrity": "sha512-bRuZp3C0itgLKHu/VNxi66DN/XVkQG7xtoBVWxpvC5FhAqbOCP21+nPhULjnzEqd7xBMybp6KwytdUpZKEgpIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "mobx-state-tree": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.1.5.tgz",
       "integrity": "sha512-jugIic0PYWW+nzzYfp4RUy9dec002Z778OC6KzoOyBHnqxupK9iPCsUJYkHjmNRHjZ8E4Z7qQpsKV3At/ntGVw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "modify-values": {
       "version": "1.0.1",
@@ -33113,7 +33072,7 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "^4.18.1"
       }
     },
     "node-fetch": {
@@ -35932,6 +35891,18 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-dom": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "peer": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
+      }
+    },
     "react-event-listener": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.6.tgz",
@@ -36676,6 +36647,16 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "scheduler": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "peer": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "semantic-release": {
       "version": "21.0.1",
@@ -38264,7 +38245,7 @@
         "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
         "highlight.js": "^9.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.18.1",
         "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",

--- a/plugins/phrase-conector/package.json
+++ b/plugins/phrase-conector/package.json
@@ -128,12 +128,13 @@
     "@builder.io/commerce-plugin-tools": "^0.3.0",
     "@builder.io/utils": "^1.1.23",
     "fast-json-stable-stringify": "^2.1.0",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "object-hash": "^3.0.0",
     "traverse": "^0.6.6",
     "uuid": "^8.3.2"
   },
   "overrides": {
+    "lodash": "$lodash",
     "minimist@<1": "0.2.4",
     "minimist@1": "1.2.8"
   }

--- a/plugins/rich-text/package-lock.json
+++ b/plugins/rich-text/package-lock.json
@@ -1387,12 +1387,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/cli/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -1419,12 +1413,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/ensure/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "7.6.0",
@@ -1479,12 +1467,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/lint/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/load": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.6.2.tgz",
@@ -1538,12 +1520,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/load/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/load/node_modules/parse-json": {
       "version": "4.0.0",
@@ -1620,12 +1596,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/resolve-extends/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
       "version": "5.0.0",
@@ -6116,12 +6086,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/commitizen/node_modules/lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-      "dev": true
     },
     "node_modules/commitizen/node_modules/shelljs": {
       "version": "0.7.6",
@@ -13764,9 +13728,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -25473,7 +25438,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -25600,7 +25565,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -25675,7 +25640,7 @@
         "@babel/helper-split-export-declaration": "^7.8.3",
         "@babel/template": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -25699,7 +25664,7 @@
       "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -25992,7 +25957,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -26369,7 +26334,7 @@
       "dev": true,
       "requires": {
         "find-cache-dir": "^2.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "make-dir": "^2.1.0",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.16"
@@ -26493,7 +26458,7 @@
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "7.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "meow": "5.0.0",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0"
@@ -26509,12 +26474,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.2.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -26536,15 +26495,7 @@
       "integrity": "sha512-pSUrNud5L/8y+cLWo3LEa8Ce4bAAR33xMderFUhuNPHj7TwpNS7L4ROMnhL4ZlCYRazCRDlnPaJLPikMoWThfA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/execute-rule": {
@@ -26585,15 +26536,7 @@
         "@commitlint/parse": "^7.6.0",
         "@commitlint/rules": "^7.6.0",
         "babel-runtime": "^6.23.0",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/load": {
@@ -26606,7 +26549,7 @@
         "@commitlint/resolve-extends": "^7.6.0",
         "babel-runtime": "^6.23.0",
         "cosmiconfig": "^5.2.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -26640,12 +26583,6 @@
             }
           }
         },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -26678,7 +26615,7 @@
       "requires": {
         "conventional-changelog-angular": "^1.3.3",
         "conventional-commits-parser": "^2.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/read": {
@@ -26701,17 +26638,11 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -27109,7 +27040,7 @@
         "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "micromatch": "^4.0.2"
       },
       "dependencies": {
@@ -27167,7 +27098,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -27533,7 +27464,7 @@
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mime": "^3.0.0",
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
@@ -27906,7 +27837,7 @@
         "get-stream": "^6.0.0",
         "import-from": "^4.0.0",
         "into-stream": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
@@ -27955,7 +27886,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -28962,7 +28893,7 @@
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "4.18.1"
       }
     },
     "async-each": {
@@ -29079,7 +29010,7 @@
         "convert-source-map": "^1.5.1",
         "debug": "^2.6.9",
         "json5": "^0.5.1",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "minimatch": "^3.0.4",
         "path-is-absolute": "^1.0.1",
         "private": "^0.1.8",
@@ -29106,7 +29037,7 @@
         "babel-types": "^6.26.0",
         "detect-indent": "^4.0.0",
         "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "source-map": "^0.5.7",
         "trim-right": "^1.0.1"
       },
@@ -29261,7 +29192,7 @@
         "babel-runtime": "^6.26.0",
         "core-js": "^2.5.0",
         "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.4.15"
       },
@@ -29308,7 +29239,7 @@
         "babel-traverse": "^6.26.0",
         "babel-types": "^6.26.0",
         "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "lodash": "4.18.1"
       }
     },
     "babel-traverse": {
@@ -29325,7 +29256,7 @@
         "debug": "^2.6.8",
         "globals": "^9.18.0",
         "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "lodash": "4.18.1"
       }
     },
     "babel-types": {
@@ -29336,7 +29267,7 @@
       "requires": {
         "babel-runtime": "^6.26.0",
         "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "to-fast-properties": "^1.0.3"
       },
       "dependencies": {
@@ -30339,7 +30270,7 @@
         "glob": "7.1.3",
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
-        "lodash": "4.17.14",
+        "lodash": "4.18.1",
         "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
@@ -30359,12 +30290,6 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.14",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-          "dev": true
         },
         "shelljs": {
           "version": "0.7.6",
@@ -30548,7 +30473,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "4.18.1",
         "meow": "^8.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -30862,7 +30787,7 @@
       "requires": {
         "is-text-path": "^1.0.0",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.2.1",
+        "lodash": "4.18.1",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^2.0.0",
@@ -33928,7 +33853,7 @@
       "requires": {
         "http-proxy": "^1.17.0",
         "is-glob": "^4.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "4.18.1",
         "micromatch": "^3.1.10"
       }
     },
@@ -34241,7 +34166,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.0",
         "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.1.0",
@@ -36414,9 +36339,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash-es": {
       "version": "4.17.21",
@@ -37208,7 +37133,7 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "4.18.1"
       }
     },
     "node-fetch": {
@@ -40686,7 +40611,7 @@
       "requires": {
         "@types/quill": "1.3.10",
         "create-react-class": "^15.6.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "prop-types": "^15.5.10",
         "quill": "^1.3.7",
         "react-dom-factories": "^1.0.0"
@@ -41125,7 +41050,7 @@
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "4.18.1"
       }
     },
     "request-promise-native": {
@@ -43845,7 +43770,7 @@
         "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
         "highlight.js": "^9.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",

--- a/plugins/rich-text/package.json
+++ b/plugins/rich-text/package.json
@@ -125,6 +125,7 @@
     "react-quill": "^1.3.5"
   },
   "overrides": {
+    "lodash": "4.18.1",
     "minimist@<1": "0.2.4",
     "minimist@1": "1.2.8"
   }

--- a/plugins/salesforce-commerce-api-plugin/package-lock.json
+++ b/plugins/salesforce-commerce-api-plugin/package-lock.json
@@ -94,12 +94,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/cli/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -126,12 +120,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/ensure/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "7.6.0",
@@ -186,12 +174,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/lint/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/load": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.6.2.tgz",
@@ -245,12 +227,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/load/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/load/node_modules/parse-json": {
       "version": "4.0.0",
@@ -327,12 +303,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/resolve-extends/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
       "version": "5.0.0",
@@ -1239,12 +1209,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/commitizen/node_modules/lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-      "dev": true
     },
     "node_modules/commitizen/node_modules/shelljs": {
       "version": "0.7.6",
@@ -3094,9 +3058,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
@@ -5513,7 +5478,7 @@
       "resolved": "https://registry.npmjs.org/@builder.io/plugin-tools/-/plugin-tools-0.0.5.tgz",
       "integrity": "sha512-8Unfq9cBhi9nDULLFmXbDRSLnYQWuSE978q34OwYfA+70oQhFYX9P9+ageUxQ+qxg0aitlxTIXAPzZGILcQjOQ==",
       "requires": {
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "pluralize": "^8.0.0"
       }
     },
@@ -5530,7 +5495,7 @@
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "7.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "meow": "5.0.0",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0"
@@ -5546,12 +5511,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.2.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -5573,15 +5532,7 @@
       "integrity": "sha512-pSUrNud5L/8y+cLWo3LEa8Ce4bAAR33xMderFUhuNPHj7TwpNS7L4ROMnhL4ZlCYRazCRDlnPaJLPikMoWThfA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/execute-rule": {
@@ -5622,15 +5573,7 @@
         "@commitlint/parse": "^7.6.0",
         "@commitlint/rules": "^7.6.0",
         "babel-runtime": "^6.23.0",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/load": {
@@ -5643,7 +5586,7 @@
         "@commitlint/resolve-extends": "^7.6.0",
         "babel-runtime": "^6.23.0",
         "cosmiconfig": "^5.2.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -5677,12 +5620,6 @@
             }
           }
         },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -5715,7 +5652,7 @@
       "requires": {
         "conventional-changelog-angular": "^1.3.3",
         "conventional-commits-parser": "^2.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/read": {
@@ -5738,17 +5675,11 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -6472,7 +6403,7 @@
         "glob": "7.1.3",
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
-        "lodash": "4.17.14",
+        "lodash": "4.18.1",
         "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
@@ -6492,12 +6423,6 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.14",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-          "dev": true
         },
         "shelljs": {
           "version": "0.7.6",
@@ -6564,7 +6489,7 @@
       "requires": {
         "is-text-path": "^1.0.0",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.2.1",
+        "lodash": "4.18.1",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^2.0.0",
@@ -7578,7 +7503,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.0",
         "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.1.0",
@@ -7976,9 +7901,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/plugins/salesforce-commerce-api-plugin/package.json
+++ b/plugins/salesforce-commerce-api-plugin/package.json
@@ -56,6 +56,7 @@
     "commerce-sdk-isomorphic": "2.1.0"
   },
   "overrides": {
+    "lodash": "4.18.1",
     "minimist@<1": "0.2.4",
     "minimist@1": "1.2.8"
   }

--- a/plugins/salesforce-einstein-api/package-lock.json
+++ b/plugins/salesforce-einstein-api/package-lock.json
@@ -1601,12 +1601,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/cli/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -1633,12 +1627,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/ensure/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "7.6.0",
@@ -1693,12 +1681,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/lint/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/load": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.6.2.tgz",
@@ -1752,12 +1734,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/load/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/load/node_modules/parse-json": {
       "version": "4.0.0",
@@ -1834,12 +1810,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/resolve-extends/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
       "version": "5.0.0",
@@ -6885,12 +6855,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/commitizen/node_modules/lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-      "dev": true
     },
     "node_modules/commitizen/node_modules/shelljs": {
       "version": "0.7.6",
@@ -13416,9 +13380,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
@@ -22444,7 +22409,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -22545,7 +22510,7 @@
       "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -22898,7 +22863,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -23275,7 +23240,7 @@
       "dev": true,
       "requires": {
         "find-cache-dir": "^2.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "make-dir": "^2.1.0",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.16"
@@ -23386,7 +23351,7 @@
         "@material-ui/core": "^3.9.2",
         "@material-ui/icons": "^1.1.1",
         "@types/pluralize": "0.0.29",
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "mobx": "^5.15.4",
         "mobx-react": "^6.1.8",
         "pluralize": "^8.0.0",
@@ -23488,7 +23453,7 @@
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "7.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "meow": "5.0.0",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0"
@@ -23504,12 +23469,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.2.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -23531,15 +23490,7 @@
       "integrity": "sha512-pSUrNud5L/8y+cLWo3LEa8Ce4bAAR33xMderFUhuNPHj7TwpNS7L4ROMnhL4ZlCYRazCRDlnPaJLPikMoWThfA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/execute-rule": {
@@ -23580,15 +23531,7 @@
         "@commitlint/parse": "^7.6.0",
         "@commitlint/rules": "^7.6.0",
         "babel-runtime": "^6.23.0",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/load": {
@@ -23601,7 +23544,7 @@
         "@commitlint/resolve-extends": "^7.6.0",
         "babel-runtime": "^6.23.0",
         "cosmiconfig": "^5.2.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -23635,12 +23578,6 @@
             }
           }
         },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -23673,7 +23610,7 @@
       "requires": {
         "conventional-changelog-angular": "^1.3.3",
         "conventional-commits-parser": "^2.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/read": {
@@ -23696,17 +23633,11 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -25113,7 +25044,7 @@
         "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "micromatch": "^4.0.2"
       },
       "dependencies": {
@@ -25171,7 +25102,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -25522,7 +25453,7 @@
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mime": "^3.0.0",
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
@@ -25868,7 +25799,7 @@
         "get-stream": "^6.0.0",
         "import-from": "^4.0.0",
         "into-stream": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
@@ -25917,7 +25848,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -27584,7 +27515,7 @@
         "glob": "7.1.3",
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
-        "lodash": "4.17.14",
+        "lodash": "4.18.1",
         "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
@@ -27604,12 +27535,6 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.14",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-          "dev": true
         },
         "shelljs": {
           "version": "0.7.6",
@@ -27716,7 +27641,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "4.18.1",
         "meow": "^8.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -28015,7 +27940,7 @@
       "requires": {
         "is-text-path": "^1.0.0",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.2.1",
+        "lodash": "4.18.1",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^2.0.0",
@@ -29818,7 +29743,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.0",
         "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.1.0",
@@ -32539,9 +32464,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash-es": {
       "version": "4.18.1",
@@ -33215,7 +33140,7 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "4.18.1"
       }
     },
     "node-fetch": {
@@ -38374,7 +38299,7 @@
         "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
         "highlight.js": "^9.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",

--- a/plugins/salesforce-einstein-api/package.json
+++ b/plugins/salesforce-einstein-api/package.json
@@ -125,6 +125,7 @@
     "commerce-sdk-isomorphic": "^1.7.0"
   },
   "overrides": {
+    "lodash": "4.18.1",
     "minimist@<1": "0.2.4",
     "minimist@1": "1.2.8"
   }

--- a/plugins/sfcc-headless/package-lock.json
+++ b/plugins/sfcc-headless/package-lock.json
@@ -1575,12 +1575,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/cli/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -1607,12 +1601,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/ensure/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "7.6.0",
@@ -1667,12 +1655,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/lint/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/load": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.6.2.tgz",
@@ -1726,12 +1708,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/load/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/load/node_modules/parse-json": {
       "version": "4.0.0",
@@ -1808,12 +1784,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/resolve-extends/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
       "version": "5.0.0",
@@ -12558,9 +12528,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
@@ -21209,7 +21180,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -21310,7 +21281,7 @@
       "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -21664,7 +21635,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -22041,7 +22012,7 @@
       "dev": true,
       "requires": {
         "find-cache-dir": "^2.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "make-dir": "^2.1.0",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.16"
@@ -22137,7 +22108,7 @@
         "@material-ui/core": "^3.9.2",
         "@material-ui/icons": "^1.1.1",
         "@types/pluralize": "0.0.29",
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "mobx": "^5.15.4",
         "mobx-react": "^6.1.8",
         "pluralize": "^8.0.0",
@@ -22244,7 +22215,7 @@
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "7.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "meow": "5.0.0",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0"
@@ -22260,12 +22231,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.2.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -22287,15 +22252,7 @@
       "integrity": "sha512-pSUrNud5L/8y+cLWo3LEa8Ce4bAAR33xMderFUhuNPHj7TwpNS7L4ROMnhL4ZlCYRazCRDlnPaJLPikMoWThfA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/execute-rule": {
@@ -22336,15 +22293,7 @@
         "@commitlint/parse": "^7.6.0",
         "@commitlint/rules": "^7.6.0",
         "babel-runtime": "^6.23.0",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/load": {
@@ -22357,7 +22306,7 @@
         "@commitlint/resolve-extends": "^7.6.0",
         "babel-runtime": "^6.23.0",
         "cosmiconfig": "^5.2.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -22391,12 +22340,6 @@
             }
           }
         },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -22429,7 +22372,7 @@
       "requires": {
         "conventional-changelog-angular": "^1.3.3",
         "conventional-commits-parser": "^2.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/read": {
@@ -22452,17 +22395,11 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -23783,7 +23720,7 @@
         "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "micromatch": "^4.0.2"
       },
       "dependencies": {
@@ -23832,7 +23769,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -24149,7 +24086,7 @@
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mime": "^3.0.0",
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
@@ -24490,7 +24427,7 @@
         "get-stream": "^6.0.0",
         "import-from": "^4.0.0",
         "into-stream": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
@@ -24539,7 +24476,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -26099,7 +26036,7 @@
         "glob": "7.2.3",
         "inquirer": "8.2.5",
         "is-utf8": "^0.2.1",
-        "lodash": "4.17.21",
+        "lodash": "4.18.1",
         "minimist": "1.2.7",
         "strip-bom": "4.0.0",
         "strip-json-comments": "3.1.1"
@@ -26260,7 +26197,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "4.18.1",
         "meow": "^8.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -26574,7 +26511,7 @@
       "requires": {
         "is-text-path": "^1.0.0",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.2.1",
+        "lodash": "4.18.1",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^2.0.0",
@@ -28094,7 +28031,7 @@
         "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "mute-stream": "0.0.8",
         "ora": "^5.4.1",
         "run-async": "^2.4.0",
@@ -30618,9 +30555,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash-es": {
       "version": "4.18.1",
@@ -31228,7 +31165,7 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "4.18.1"
       }
     },
     "node-fetch": {
@@ -36196,7 +36133,7 @@
         "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
         "highlight.js": "^9.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",

--- a/plugins/sfcc-headless/package.json
+++ b/plugins/sfcc-headless/package.json
@@ -133,5 +133,8 @@
     "react-vtree": "^2.0.4",
     "react-window": "^1.8.6",
     "safe-localstorage": "^1.0.1"
+  },
+  "overrides": {
+    "lodash": "4.18.1"
   }
 }

--- a/plugins/sfcc-sync/package-lock.json
+++ b/plugins/sfcc-sync/package-lock.json
@@ -1534,12 +1534,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/cli/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -1566,12 +1560,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/ensure/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "7.6.0",
@@ -1626,12 +1614,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/lint/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/load": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.6.2.tgz",
@@ -1685,12 +1667,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/load/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/load/node_modules/parse-json": {
       "version": "4.0.0",
@@ -1767,12 +1743,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/resolve-extends/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
       "version": "5.0.0",
@@ -6577,12 +6547,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/commitizen/node_modules/lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-      "dev": true
     },
     "node_modules/commitizen/node_modules/shelljs": {
       "version": "0.7.6",
@@ -12828,10 +12792,11 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -21659,7 +21624,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -21761,7 +21726,7 @@
       "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -22118,7 +22083,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -22495,7 +22460,7 @@
       "dev": true,
       "requires": {
         "find-cache-dir": "^2.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "make-dir": "^2.1.0",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.16"
@@ -22643,7 +22608,7 @@
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "7.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "meow": "5.0.0",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0"
@@ -22659,12 +22624,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.2.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -22686,15 +22645,7 @@
       "integrity": "sha512-pSUrNud5L/8y+cLWo3LEa8Ce4bAAR33xMderFUhuNPHj7TwpNS7L4ROMnhL4ZlCYRazCRDlnPaJLPikMoWThfA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/execute-rule": {
@@ -22735,15 +22686,7 @@
         "@commitlint/parse": "^7.6.0",
         "@commitlint/rules": "^7.6.0",
         "babel-runtime": "^6.23.0",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/load": {
@@ -22756,7 +22699,7 @@
         "@commitlint/resolve-extends": "^7.6.0",
         "babel-runtime": "^6.23.0",
         "cosmiconfig": "^5.2.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -22790,12 +22733,6 @@
             }
           }
         },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -22828,7 +22765,7 @@
       "requires": {
         "conventional-changelog-angular": "^1.3.3",
         "conventional-commits-parser": "^2.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/read": {
@@ -22851,17 +22788,11 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -24114,7 +24045,7 @@
         "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "micromatch": "^4.0.2"
       },
       "dependencies": {
@@ -24172,7 +24103,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -24523,7 +24454,7 @@
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mime": "^3.0.0",
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
@@ -24869,7 +24800,7 @@
         "get-stream": "^6.0.0",
         "import-from": "^4.0.0",
         "into-stream": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
@@ -24918,7 +24849,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -26548,7 +26479,7 @@
         "glob": "7.1.3",
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
-        "lodash": "4.17.14",
+        "lodash": "4.18.1",
         "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
@@ -26568,12 +26499,6 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.14",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-          "dev": true
         },
         "shelljs": {
           "version": "0.7.6",
@@ -26680,7 +26605,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "4.18.1",
         "meow": "^8.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -26979,7 +26904,7 @@
       "requires": {
         "is-text-path": "^1.0.0",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.2.1",
+        "lodash": "4.18.1",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^2.0.0",
@@ -28720,7 +28645,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.0",
         "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.1.0",
@@ -31248,9 +31173,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true
     },
     "lodash-es": {
@@ -31902,7 +31827,7 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "4.18.1"
       }
     },
     "node-fetch": {
@@ -36968,7 +36893,7 @@
         "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
         "highlight.js": "^9.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",

--- a/plugins/sfcc-sync/package.json
+++ b/plugins/sfcc-sync/package.json
@@ -121,6 +121,7 @@
     "typescript": "^3.0.3"
   },
   "overrides": {
+    "lodash": "4.18.1",
     "minimist@<1": "0.2.4",
     "minimist@1": "1.2.8"
   }

--- a/plugins/shopify-demo/package-lock.json
+++ b/plugins/shopify-demo/package-lock.json
@@ -1373,12 +1373,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/cli/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -1405,12 +1399,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/ensure/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "7.6.0",
@@ -1465,12 +1453,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/lint/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/load": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.6.2.tgz",
@@ -1524,12 +1506,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/load/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/load/node_modules/parse-json": {
       "version": "4.0.0",
@@ -1606,12 +1582,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/resolve-extends/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
       "version": "5.0.0",
@@ -6396,12 +6366,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/commitizen/node_modules/lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-      "dev": true
     },
     "node_modules/commitizen/node_modules/shelljs": {
       "version": "0.7.6",
@@ -12730,10 +12694,11 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
@@ -21635,7 +21600,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -21736,7 +21701,7 @@
       "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -22090,7 +22055,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -22467,7 +22432,7 @@
       "dev": true,
       "requires": {
         "find-cache-dir": "^2.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "make-dir": "^2.1.0",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.16"
@@ -22617,7 +22582,7 @@
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "7.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "meow": "5.0.0",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0"
@@ -22633,12 +22598,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.2.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -22660,15 +22619,7 @@
       "integrity": "sha512-pSUrNud5L/8y+cLWo3LEa8Ce4bAAR33xMderFUhuNPHj7TwpNS7L4ROMnhL4ZlCYRazCRDlnPaJLPikMoWThfA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/execute-rule": {
@@ -22709,15 +22660,7 @@
         "@commitlint/parse": "^7.6.0",
         "@commitlint/rules": "^7.6.0",
         "babel-runtime": "^6.23.0",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/load": {
@@ -22730,7 +22673,7 @@
         "@commitlint/resolve-extends": "^7.6.0",
         "babel-runtime": "^6.23.0",
         "cosmiconfig": "^5.2.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -22764,12 +22707,6 @@
             }
           }
         },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -22802,7 +22739,7 @@
       "requires": {
         "conventional-changelog-angular": "^1.3.3",
         "conventional-commits-parser": "^2.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/read": {
@@ -22825,17 +22762,11 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -23974,7 +23905,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "7.0.1",
@@ -24095,7 +24027,7 @@
         "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "micromatch": "^4.0.2"
       },
       "dependencies": {
@@ -24153,7 +24085,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -24504,7 +24436,7 @@
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mime": "^3.0.0",
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
@@ -24850,7 +24782,7 @@
         "get-stream": "^6.0.0",
         "import-from": "^4.0.0",
         "into-stream": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
@@ -24899,7 +24831,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -26530,7 +26462,7 @@
         "glob": "7.1.3",
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
-        "lodash": "4.17.14",
+        "lodash": "4.18.1",
         "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
@@ -26550,12 +26482,6 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.14",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-          "dev": true
         },
         "shelljs": {
           "version": "0.7.6",
@@ -26662,7 +26588,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "4.18.1",
         "meow": "^8.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -26961,7 +26887,7 @@
       "requires": {
         "is-text-path": "^1.0.0",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.2.1",
+        "lodash": "4.18.1",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^2.0.0",
@@ -28746,7 +28672,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.0",
         "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.1.0",
@@ -30112,7 +30038,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "29.4.3",
@@ -31339,9 +31266,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true
     },
     "lodash-es": {
@@ -32000,7 +31927,7 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "4.18.1"
       }
     },
     "node-fetch": {
@@ -37170,7 +37097,7 @@
         "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
         "highlight.js": "^9.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",

--- a/plugins/shopify-demo/package.json
+++ b/plugins/shopify-demo/package.json
@@ -126,6 +126,7 @@
     "react": "^16.11.0"
   },
   "overrides": {
+    "lodash": "4.18.1",
     "minimist@<1": "0.2.4",
     "minimist@1": "1.2.8"
   }

--- a/plugins/shopify/package-lock.json
+++ b/plugins/shopify/package-lock.json
@@ -95,12 +95,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/cli/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -127,12 +121,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/ensure/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "7.6.0",
@@ -187,12 +175,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/lint/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/load": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.6.2.tgz",
@@ -246,12 +228,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/load/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/load/node_modules/parse-json": {
       "version": "4.0.0",
@@ -328,12 +304,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/resolve-extends/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
       "version": "5.0.0",
@@ -1209,12 +1179,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/commitizen/node_modules/lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-      "dev": true
     },
     "node_modules/commitizen/node_modules/shelljs": {
       "version": "0.7.6",
@@ -3091,9 +3055,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
@@ -5410,7 +5375,7 @@
       "resolved": "https://registry.npmjs.org/@builder.io/plugin-tools/-/plugin-tools-0.0.3.tgz",
       "integrity": "sha512-YoRHFxR7b/PfucuuVYW7rXUODP3mB/6LhYaU/3C11pQN5+KDmko9JjlN4JWQbZJPGPdH59gR9KPEkASgf6gzsA==",
       "requires": {
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "pluralize": "^8.0.0"
       }
     },
@@ -5427,7 +5392,7 @@
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "7.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "meow": "5.0.0",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0"
@@ -5443,12 +5408,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.2.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -5470,15 +5429,7 @@
       "integrity": "sha512-pSUrNud5L/8y+cLWo3LEa8Ce4bAAR33xMderFUhuNPHj7TwpNS7L4ROMnhL4ZlCYRazCRDlnPaJLPikMoWThfA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/execute-rule": {
@@ -5519,15 +5470,7 @@
         "@commitlint/parse": "^7.6.0",
         "@commitlint/rules": "^7.6.0",
         "babel-runtime": "^6.23.0",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/load": {
@@ -5540,7 +5483,7 @@
         "@commitlint/resolve-extends": "^7.6.0",
         "babel-runtime": "^6.23.0",
         "cosmiconfig": "^5.2.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -5574,12 +5517,6 @@
             }
           }
         },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -5612,7 +5549,7 @@
       "requires": {
         "conventional-changelog-angular": "^1.3.3",
         "conventional-commits-parser": "^2.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/read": {
@@ -5635,17 +5572,11 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -6350,7 +6281,7 @@
         "glob": "7.1.3",
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
-        "lodash": "4.17.14",
+        "lodash": "4.18.1",
         "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
@@ -6370,12 +6301,6 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.14",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-          "dev": true
         },
         "shelljs": {
           "version": "0.7.6",
@@ -6442,7 +6367,7 @@
       "requires": {
         "is-text-path": "^1.0.0",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.2.1",
+        "lodash": "4.18.1",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^2.0.0",
@@ -7462,7 +7387,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.0",
         "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.1.0",
@@ -7871,9 +7796,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/plugins/shopify/package.json
+++ b/plugins/shopify/package.json
@@ -104,6 +104,7 @@
     "shopify-buy": "^3.0.4"
   },
   "overrides": {
+    "lodash": "4.18.1",
     "minimist@<1": "0.2.4",
     "minimist@1": "1.2.8"
   }

--- a/plugins/smartling/package-lock.json
+++ b/plugins/smartling/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@builder.io/utils": "1.1.31",
         "fast-json-stable-stringify": "^2.1.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "object-hash": "^3.0.0",
         "traverse": "^0.6.6",
         "uuid": "^8.3.2"
@@ -1545,12 +1545,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/cli/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -1577,12 +1571,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/ensure/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "7.6.0",
@@ -1637,12 +1625,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/lint/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/load": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.6.2.tgz",
@@ -1696,12 +1678,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/load/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/load/node_modules/parse-json": {
       "version": "4.0.0",
@@ -1778,12 +1754,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/resolve-extends/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
       "version": "5.0.0",
@@ -6922,12 +6892,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/commitizen/node_modules/lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-      "dev": true
     },
     "node_modules/commitizen/node_modules/shelljs": {
       "version": "0.7.6",
@@ -18342,6 +18306,39 @@
         "rc": "cli.js"
       }
     },
+    "node_modules/react": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0"
+      }
+    },
     "node_modules/react-event-listener": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.6.tgz",
@@ -19287,6 +19284,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "node_modules/scheduler": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "node_modules/semantic-release": {
       "version": "21.0.1",
@@ -22436,7 +22445,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "^4.18.1"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -22538,7 +22547,7 @@
       "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.13"
+        "lodash": "^4.18.1"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -22895,7 +22904,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "^4.18.1"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -23272,7 +23281,7 @@
       "dev": true,
       "requires": {
         "find-cache-dir": "^2.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "^4.18.1",
         "make-dir": "^2.1.0",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.16"
@@ -23406,7 +23415,7 @@
       "integrity": "sha512-ApC6OFJb/IMacy+YwcZeMr61k/8NnWOlg3eyl67gFFADmtjsa/ZwulMgyUbqPUF7158JqcpgAab1MC9LMCIZSA==",
       "requires": {
         "@types/lodash": "^4.14.182",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "traverse": "^0.6.6"
       }
     },
@@ -23430,7 +23439,7 @@
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "7.0.0",
-        "lodash": "4.17.11",
+        "lodash": "^4.18.1",
         "meow": "5.0.0",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0"
@@ -23446,12 +23455,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.2.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -23473,15 +23476,7 @@
       "integrity": "sha512-pSUrNud5L/8y+cLWo3LEa8Ce4bAAR33xMderFUhuNPHj7TwpNS7L4ROMnhL4ZlCYRazCRDlnPaJLPikMoWThfA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "^4.18.1"
       }
     },
     "@commitlint/execute-rule": {
@@ -23522,15 +23517,7 @@
         "@commitlint/parse": "^7.6.0",
         "@commitlint/rules": "^7.6.0",
         "babel-runtime": "^6.23.0",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "^4.18.1"
       }
     },
     "@commitlint/load": {
@@ -23543,7 +23530,7 @@
         "@commitlint/resolve-extends": "^7.6.0",
         "babel-runtime": "^6.23.0",
         "cosmiconfig": "^5.2.0",
-        "lodash": "4.17.11",
+        "lodash": "^4.18.1",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -23577,12 +23564,6 @@
             }
           }
         },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -23615,7 +23596,7 @@
       "requires": {
         "conventional-changelog-angular": "^1.3.3",
         "conventional-commits-parser": "^2.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.18.1"
       }
     },
     "@commitlint/read": {
@@ -23638,17 +23619,11 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.11",
+        "lodash": "^4.18.1",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -24810,7 +24785,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "7.0.1",
@@ -25057,7 +25033,7 @@
         "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "^4.18.1",
         "micromatch": "^4.0.2"
       },
       "dependencies": {
@@ -25115,7 +25091,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "^4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -25481,7 +25457,7 @@
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "^4.18.1",
         "mime": "^3.0.0",
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
@@ -25837,7 +25813,7 @@
         "get-stream": "^6.0.0",
         "import-from": "^4.0.0",
         "into-stream": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "^4.18.1",
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
@@ -25886,7 +25862,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "^4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -27603,7 +27579,7 @@
         "glob": "7.1.3",
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
-        "lodash": "4.17.14",
+        "lodash": "^4.18.1",
         "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
@@ -27623,12 +27599,6 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.14",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-          "dev": true
         },
         "shelljs": {
           "version": "0.7.6",
@@ -27735,7 +27705,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "^4.18.1",
         "meow": "^8.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -28049,7 +28019,7 @@
       "requires": {
         "is-text-path": "^1.0.0",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.2.1",
+        "lodash": "^4.18.1",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^2.0.0",
@@ -29895,7 +29865,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.0",
         "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.18.1",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.1.0",
@@ -31260,7 +31230,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "29.4.3",
@@ -32041,13 +32012,15 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
       "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jss-global": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
       "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jss-nested": {
       "version": "6.0.1",
@@ -32073,7 +32046,8 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
       "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jss-vendor-prefixer": {
       "version": "7.0.0",
@@ -33112,13 +33086,15 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.4.0.tgz",
       "integrity": "sha512-bRuZp3C0itgLKHu/VNxi66DN/XVkQG7xtoBVWxpvC5FhAqbOCP21+nPhULjnzEqd7xBMybp6KwytdUpZKEgpIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "mobx-state-tree": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.1.5.tgz",
       "integrity": "sha512-jugIic0PYWW+nzzYfp4RUy9dec002Z778OC6KzoOyBHnqxupK9iPCsUJYkHjmNRHjZ8E4Z7qQpsKV3At/ntGVw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "modify-values": {
       "version": "1.0.1",
@@ -33193,7 +33169,7 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "^4.18.1"
       }
     },
     "node-fetch": {
@@ -36005,6 +35981,31 @@
         "strip-json-comments": "~2.0.1"
       }
     },
+    "react": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "react-dom": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
+      }
+    },
     "react-event-listener": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.6.tgz",
@@ -36760,6 +36761,17 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "scheduler": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "semantic-release": {
       "version": "21.0.1",
@@ -38350,7 +38362,7 @@
         "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
         "highlight.js": "^9.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.18.1",
         "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",

--- a/plugins/smartling/package.json
+++ b/plugins/smartling/package.json
@@ -127,12 +127,13 @@
   "dependencies": {
     "@builder.io/utils": "1.1.31",
     "fast-json-stable-stringify": "^2.1.0",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "object-hash": "^3.0.0",
     "traverse": "^0.6.6",
     "uuid": "^8.3.2"
   },
   "overrides": {
+    "lodash": "$lodash",
     "minimist@<1": "0.2.4",
     "minimist@1": "1.2.8"
   }

--- a/plugins/swell/package-lock.json
+++ b/plugins/swell/package-lock.json
@@ -2021,12 +2021,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/config-conventional": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-7.6.0.tgz",
@@ -2044,12 +2038,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/ensure/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "7.6.0",
@@ -2104,12 +2092,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/lint/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/load": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.6.2.tgz",
@@ -2126,12 +2108,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/load/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/message": {
       "version": "7.6.0",
@@ -2186,12 +2162,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/resolve-extends/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/rules": {
       "version": "7.6.0",
@@ -12891,9 +12861,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
@@ -24411,7 +24382,7 @@
         "@material-ui/core": "^3.9.2",
         "@material-ui/icons": "^1.1.1",
         "@types/pluralize": "0.0.29",
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "mobx": "^5.15.4",
         "mobx-react": "^6.1.8",
         "pluralize": "^8.0.0",
@@ -24463,18 +24434,10 @@
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "7.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "meow": "5.0.0",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
       }
     },
     "@commitlint/config-conventional": {
@@ -24489,15 +24452,7 @@
       "integrity": "sha512-pSUrNud5L/8y+cLWo3LEa8Ce4bAAR33xMderFUhuNPHj7TwpNS7L4ROMnhL4ZlCYRazCRDlnPaJLPikMoWThfA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/execute-rule": {
@@ -24538,15 +24493,7 @@
         "@commitlint/parse": "^7.6.0",
         "@commitlint/rules": "^7.6.0",
         "babel-runtime": "^6.23.0",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/load": {
@@ -24559,16 +24506,8 @@
         "@commitlint/resolve-extends": "^7.6.0",
         "babel-runtime": "^6.23.0",
         "cosmiconfig": "^5.2.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
       }
     },
     "@commitlint/message": {
@@ -24585,7 +24524,7 @@
       "requires": {
         "conventional-changelog-angular": "^1.3.3",
         "conventional-commits-parser": "^2.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/read": {
@@ -24608,17 +24547,9 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
       }
     },
     "@commitlint/rules": {
@@ -26028,7 +25959,7 @@
         "conventional-commits-parser": "^3.0.7",
         "debug": "^4.0.0",
         "import-from": "^3.0.0",
-        "lodash": "^4.17.4"
+        "lodash": "4.18.1"
       },
       "dependencies": {
         "camelcase": {
@@ -26076,7 +26007,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -26420,7 +26351,7 @@
         "http-proxy-agent": "^3.0.0",
         "https-proxy-agent": "^4.0.0",
         "issue-parser": "^5.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mime": "^2.4.3",
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
@@ -26509,7 +26440,7 @@
         "aggregate-error": "^3.0.0",
         "execa": "^3.2.0",
         "fs-extra": "^8.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "4.18.1",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^4.0.0",
         "npm": "^6.10.3",
@@ -26665,7 +26596,7 @@
         "get-stream": "^5.0.0",
         "import-from": "^3.0.0",
         "into-stream": "^5.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
@@ -26714,7 +26645,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -27522,7 +27453,7 @@
       "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "4.18.1"
       }
     },
     "asynckit": {
@@ -28387,7 +28318,7 @@
         "glob": "7.2.3",
         "inquirer": "8.2.5",
         "is-utf8": "^0.2.1",
-        "lodash": "4.17.21",
+        "lodash": "4.18.1",
         "minimist": "1.2.7",
         "strip-bom": "4.0.0",
         "strip-json-comments": "3.1.1"
@@ -28550,7 +28481,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.6",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "4.18.1",
         "meow": "^8.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -28901,7 +28832,7 @@
       "requires": {
         "is-text-path": "^1.0.0",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.2.1",
+        "lodash": "4.18.1",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^2.0.0",
@@ -30394,7 +30325,7 @@
         "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "mute-stream": "0.0.8",
         "ora": "^5.4.1",
         "run-async": "^2.4.0",
@@ -32812,9 +32743,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -33438,7 +33369,7 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "4.18.1"
       }
     },
     "node-fetch": {
@@ -38702,7 +38633,7 @@
         "git-log-parser": "^1.2.0",
         "hook-std": "^2.0.0",
         "hosted-git-info": "^3.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "4.18.1",
         "marked": "^0.7.0",
         "marked-terminal": "^3.2.0",
         "p-locate": "^4.0.0",
@@ -40062,7 +39993,7 @@
         "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
         "highlight.js": "^9.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",

--- a/plugins/swell/package.json
+++ b/plugins/swell/package.json
@@ -131,5 +131,8 @@
     "@material-ui/icons": "^1.1.1",
     "react": "^16.11.0",
     "swell-js": "^3.8.6"
+  },
+  "overrides": {
+    "lodash": "4.18.1"
   }
 }

--- a/plugins/virtocommerce/package-lock.json
+++ b/plugins/virtocommerce/package-lock.json
@@ -1571,12 +1571,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/cli/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -1603,12 +1597,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/ensure/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "7.6.0",
@@ -1663,12 +1651,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/lint/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/load": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.6.2.tgz",
@@ -1722,12 +1704,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/load/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/load/node_modules/parse-json": {
       "version": "4.0.0",
@@ -1804,12 +1780,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/resolve-extends/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
       "version": "5.0.0",
@@ -12430,9 +12400,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -21110,7 +21081,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -21211,7 +21182,7 @@
       "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -21565,7 +21536,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -21942,7 +21913,7 @@
       "dev": true,
       "requires": {
         "find-cache-dir": "^2.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "make-dir": "^2.1.0",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.16"
@@ -22038,7 +22009,7 @@
         "@material-ui/core": "^3.9.2",
         "@material-ui/icons": "^1.1.1",
         "@types/pluralize": "0.0.29",
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "mobx": "^5.15.4",
         "mobx-react": "^6.1.8",
         "pluralize": "^8.0.0",
@@ -22140,7 +22111,7 @@
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "7.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "meow": "5.0.0",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0"
@@ -22156,12 +22127,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.2.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -22183,15 +22148,7 @@
       "integrity": "sha512-pSUrNud5L/8y+cLWo3LEa8Ce4bAAR33xMderFUhuNPHj7TwpNS7L4ROMnhL4ZlCYRazCRDlnPaJLPikMoWThfA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/execute-rule": {
@@ -22232,15 +22189,7 @@
         "@commitlint/parse": "^7.6.0",
         "@commitlint/rules": "^7.6.0",
         "babel-runtime": "^6.23.0",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/load": {
@@ -22253,7 +22202,7 @@
         "@commitlint/resolve-extends": "^7.6.0",
         "babel-runtime": "^6.23.0",
         "cosmiconfig": "^5.2.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -22287,12 +22236,6 @@
             }
           }
         },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -22325,7 +22268,7 @@
       "requires": {
         "conventional-changelog-angular": "^1.3.3",
         "conventional-commits-parser": "^2.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/read": {
@@ -22348,17 +22291,11 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -23667,7 +23604,7 @@
         "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "micromatch": "^4.0.2"
       },
       "dependencies": {
@@ -23716,7 +23653,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -24018,7 +23955,7 @@
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mime": "^3.0.0",
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
@@ -24349,7 +24286,7 @@
         "get-stream": "^6.0.0",
         "import-from": "^4.0.0",
         "into-stream": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
@@ -24398,7 +24335,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -25949,7 +25886,7 @@
         "glob": "7.2.3",
         "inquirer": "8.2.5",
         "is-utf8": "^0.2.1",
-        "lodash": "4.17.21",
+        "lodash": "4.18.1",
         "minimist": "1.2.8",
         "strip-bom": "4.0.0",
         "strip-json-comments": "3.1.1"
@@ -26110,7 +26047,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "4.18.1",
         "meow": "^8.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -26409,7 +26346,7 @@
       "requires": {
         "is-text-path": "^1.0.0",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.2.1",
+        "lodash": "4.18.1",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^2.0.0",
@@ -27929,7 +27866,7 @@
         "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "mute-stream": "0.0.8",
         "ora": "^5.4.1",
         "run-async": "^2.4.0",
@@ -30427,9 +30364,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash-es": {
       "version": "4.17.21",
@@ -31042,7 +30979,7 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "4.18.1"
       }
     },
     "node-fetch": {
@@ -35945,7 +35882,7 @@
         "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
         "highlight.js": "^9.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",

--- a/plugins/virtocommerce/package.json
+++ b/plugins/virtocommerce/package.json
@@ -125,6 +125,7 @@
     "@moltin/sdk": "^8.8.1"
   },
   "overrides": {
+    "lodash": "4.18.1",
     "minimist@<1": "0.2.4",
     "minimist@1": "1.2.8"
   }

--- a/plugins/vtex/package-lock.json
+++ b/plugins/vtex/package-lock.json
@@ -1610,12 +1610,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/cli/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/cli/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -1642,12 +1636,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/ensure/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/execute-rule": {
       "version": "7.6.0",
@@ -1702,12 +1690,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@commitlint/lint/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
     "node_modules/@commitlint/load": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.6.2.tgz",
@@ -1761,12 +1743,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/load/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/load/node_modules/parse-json": {
       "version": "4.0.0",
@@ -1843,12 +1819,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@commitlint/resolve-extends/node_modules/lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
     },
     "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
       "version": "5.0.0",
@@ -6854,12 +6824,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/commitizen/node_modules/lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-      "dev": true
     },
     "node_modules/commitizen/node_modules/shelljs": {
       "version": "0.7.6",
@@ -13432,9 +13396,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -22485,7 +22450,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.8.3",
         "@babel/types": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -22586,7 +22551,7 @@
       "integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -22940,7 +22905,7 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
-        "lodash": "^4.17.13"
+        "lodash": "4.18.1"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -23317,7 +23282,7 @@
       "dev": true,
       "requires": {
         "find-cache-dir": "^2.0.0",
-        "lodash": "^4.17.13",
+        "lodash": "4.18.1",
         "make-dir": "^2.1.0",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.16"
@@ -23428,7 +23393,7 @@
         "@material-ui/core": "^3.9.2",
         "@material-ui/icons": "^1.1.1",
         "@types/pluralize": "0.0.29",
-        "lodash": "^4.17.21",
+        "lodash": "4.18.1",
         "mobx": "^5.15.4",
         "mobx-react": "^6.1.8",
         "pluralize": "^8.0.0",
@@ -23530,7 +23495,7 @@
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "7.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "meow": "5.0.0",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0"
@@ -23546,12 +23511,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.2.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -23573,15 +23532,7 @@
       "integrity": "sha512-pSUrNud5L/8y+cLWo3LEa8Ce4bAAR33xMderFUhuNPHj7TwpNS7L4ROMnhL4ZlCYRazCRDlnPaJLPikMoWThfA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/execute-rule": {
@@ -23622,15 +23573,7 @@
         "@commitlint/parse": "^7.6.0",
         "@commitlint/rules": "^7.6.0",
         "babel-runtime": "^6.23.0",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        }
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/load": {
@@ -23643,7 +23586,7 @@
         "@commitlint/resolve-extends": "^7.6.0",
         "babel-runtime": "^6.23.0",
         "cosmiconfig": "^5.2.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -23677,12 +23620,6 @@
             }
           }
         },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -23715,7 +23652,7 @@
       "requires": {
         "conventional-changelog-angular": "^1.3.3",
         "conventional-commits-parser": "^2.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "4.18.1"
       }
     },
     "@commitlint/read": {
@@ -23738,17 +23675,11 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.11",
+        "lodash": "4.18.1",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-          "dev": true
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -25158,7 +25089,7 @@
         "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "micromatch": "^4.0.2"
       },
       "dependencies": {
@@ -25216,7 +25147,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -25567,7 +25498,7 @@
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "mime": "^3.0.0",
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
@@ -25896,7 +25827,7 @@
         "get-stream": "^6.0.0",
         "import-from": "^4.0.0",
         "into-stream": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash": "4.18.1",
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
@@ -25945,7 +25876,7 @@
           "requires": {
             "is-text-path": "^1.0.1",
             "JSONStream": "^1.0.4",
-            "lodash": "^4.17.15",
+            "lodash": "4.18.1",
             "meow": "^8.0.0",
             "split2": "^3.0.0",
             "through2": "^4.0.0"
@@ -27598,7 +27529,7 @@
         "glob": "7.1.3",
         "inquirer": "6.2.0",
         "is-utf8": "^0.2.1",
-        "lodash": "4.17.14",
+        "lodash": "4.18.1",
         "minimist": "1.2.8",
         "shelljs": "0.7.6",
         "strip-bom": "3.0.0",
@@ -27618,12 +27549,6 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.14",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-          "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-          "dev": true
         },
         "shelljs": {
           "version": "0.7.6",
@@ -27730,7 +27655,7 @@
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "4.18.1",
         "meow": "^8.0.0",
         "semver": "^6.0.0",
         "split": "^1.0.0",
@@ -28029,7 +27954,7 @@
       "requires": {
         "is-text-path": "^1.0.0",
         "JSONStream": "^1.0.4",
-        "lodash": "^4.2.1",
+        "lodash": "4.18.1",
         "meow": "^4.0.0",
         "split2": "^2.0.0",
         "through2": "^2.0.0",
@@ -29874,7 +29799,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.0",
         "figures": "^2.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.1.0",
@@ -32595,9 +32520,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash-es": {
       "version": "4.17.21",
@@ -33266,7 +33191,7 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "4.18.1"
       }
     },
     "node-fetch": {
@@ -38450,7 +38375,7 @@
         "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
         "highlight.js": "^9.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "4.18.1",
         "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",

--- a/plugins/vtex/package.json
+++ b/plugins/vtex/package.json
@@ -125,6 +125,7 @@
     "@moltin/sdk": "^8.8.1"
   },
   "overrides": {
+    "lodash": "4.18.1",
     "minimist@<1": "0.2.4",
     "minimist@1": "1.2.8"
   }


### PR DESCRIPTION
## Description

Fixes below alerts:

| Project | Alerts |
| --- | --- |
| plugins/async-dropdown | [2298](https://github.com/BuilderIO/builder/security/dependabot/2298), [7339](https://github.com/BuilderIO/builder/security/dependabot/7339), [2307](https://github.com/BuilderIO/builder/security/dependabot/2307), [16076](https://github.com/BuilderIO/builder/security/dependabot/16076) |
| plugins/emporix | [7419](https://github.com/BuilderIO/builder/security/dependabot/7419), [7459](https://github.com/BuilderIO/builder/security/dependabot/7459), [7431](https://github.com/BuilderIO/builder/security/dependabot/7431), [16040](https://github.com/BuilderIO/builder/security/dependabot/16040) |
| plugins/example-app-campaign-builder | [2499](https://github.com/BuilderIO/builder/security/dependabot/2499), [7347](https://github.com/BuilderIO/builder/security/dependabot/7347), [1338](https://github.com/BuilderIO/builder/security/dependabot/1338), [16079](https://github.com/BuilderIO/builder/security/dependabot/16079) |
| plugins/example-app-simple | [2522](https://github.com/BuilderIO/builder/security/dependabot/2522), [7348](https://github.com/BuilderIO/builder/security/dependabot/7348), [1395](https://github.com/BuilderIO/builder/security/dependabot/1395), [16082](https://github.com/BuilderIO/builder/security/dependabot/16082) |
| plugins/jodit-html-editor | [8298](https://github.com/BuilderIO/builder/security/dependabot/8298), [8376](https://github.com/BuilderIO/builder/security/dependabot/8376), [8321](https://github.com/BuilderIO/builder/security/dependabot/8321), [16081](https://github.com/BuilderIO/builder/security/dependabot/16081) |
| plugins/localized-preview | [2545](https://github.com/BuilderIO/builder/security/dependabot/2545), [7346](https://github.com/BuilderIO/builder/security/dependabot/7346), [1447](https://github.com/BuilderIO/builder/security/dependabot/1447), [16085](https://github.com/BuilderIO/builder/security/dependabot/16085) |
| plugins/multi-cloudinary | [8984](https://github.com/BuilderIO/builder/security/dependabot/8984), [9035](https://github.com/BuilderIO/builder/security/dependabot/9035), [8999](https://github.com/BuilderIO/builder/security/dependabot/8999), [16015](https://github.com/BuilderIO/builder/security/dependabot/16015) |
| plugins/phrase-conector | [6019](https://github.com/BuilderIO/builder/security/dependabot/6019), [7362](https://github.com/BuilderIO/builder/security/dependabot/7362), [6041](https://github.com/BuilderIO/builder/security/dependabot/6041), [16019](https://github.com/BuilderIO/builder/security/dependabot/16019) |
| plugins/rich-text | [2594](https://github.com/BuilderIO/builder/security/dependabot/2594), [7345](https://github.com/BuilderIO/builder/security/dependabot/7345), [1535](https://github.com/BuilderIO/builder/security/dependabot/1535), [16083](https://github.com/BuilderIO/builder/security/dependabot/16083) |
| plugins/salesforce-commerce-api-plugin | [4392](https://github.com/BuilderIO/builder/security/dependabot/4392), [7358](https://github.com/BuilderIO/builder/security/dependabot/7358), [4415](https://github.com/BuilderIO/builder/security/dependabot/4415), [16008](https://github.com/BuilderIO/builder/security/dependabot/16008) |
| plugins/salesforce-einstein-api | [4535](https://github.com/BuilderIO/builder/security/dependabot/4535), [7359](https://github.com/BuilderIO/builder/security/dependabot/7359), [4557](https://github.com/BuilderIO/builder/security/dependabot/4557), [16065](https://github.com/BuilderIO/builder/security/dependabot/16065) |
| plugins/sfcc-headless | [4021](https://github.com/BuilderIO/builder/security/dependabot/4021), [7356](https://github.com/BuilderIO/builder/security/dependabot/7356), [4045](https://github.com/BuilderIO/builder/security/dependabot/4045), [16053](https://github.com/BuilderIO/builder/security/dependabot/16053) |
| plugins/sfcc-sync | [2617](https://github.com/BuilderIO/builder/security/dependabot/2617), [7331](https://github.com/BuilderIO/builder/security/dependabot/7331), [2629](https://github.com/BuilderIO/builder/security/dependabot/2629), [16060](https://github.com/BuilderIO/builder/security/dependabot/16060) |
| plugins/shopify | [2666](https://github.com/BuilderIO/builder/security/dependabot/2666), [7337](https://github.com/BuilderIO/builder/security/dependabot/7337), [2678](https://github.com/BuilderIO/builder/security/dependabot/2678), [16009](https://github.com/BuilderIO/builder/security/dependabot/16009) |
| plugins/shopify-demo | [2643](https://github.com/BuilderIO/builder/security/dependabot/2643), [7338](https://github.com/BuilderIO/builder/security/dependabot/7338), [1622](https://github.com/BuilderIO/builder/security/dependabot/1622), [16051](https://github.com/BuilderIO/builder/security/dependabot/16051) |
| plugins/smartling | [4211](https://github.com/BuilderIO/builder/security/dependabot/4211), [7357](https://github.com/BuilderIO/builder/security/dependabot/7357), [4234](https://github.com/BuilderIO/builder/security/dependabot/4234), [16012](https://github.com/BuilderIO/builder/security/dependabot/16012) |
| plugins/swell | [2692](https://github.com/BuilderIO/builder/security/dependabot/2692), [7344](https://github.com/BuilderIO/builder/security/dependabot/7344), [1698](https://github.com/BuilderIO/builder/security/dependabot/1698), [16058](https://github.com/BuilderIO/builder/security/dependabot/16058) |
| plugins/virtocommerce | [9927](https://github.com/BuilderIO/builder/security/dependabot/9927), [7363](https://github.com/BuilderIO/builder/security/dependabot/7363), [9939](https://github.com/BuilderIO/builder/security/dependabot/9939), [16070](https://github.com/BuilderIO/builder/security/dependabot/16070) |
| plugins/vtex | [2718](https://github.com/BuilderIO/builder/security/dependabot/2718), [7334](https://github.com/BuilderIO/builder/security/dependabot/7334), [2730](https://github.com/BuilderIO/builder/security/dependabot/2730), [16045](https://github.com/BuilderIO/builder/security/dependabot/16045) |
| examples/embed-starter-kit/plugin | [2749](https://github.com/BuilderIO/builder/security/dependabot/2749), [7349](https://github.com/BuilderIO/builder/security/dependabot/7349), [1779](https://github.com/BuilderIO/builder/security/dependabot/1779), [16078](https://github.com/BuilderIO/builder/security/dependabot/16078) |


**Screenshot/Clip**
NA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only security pin with no runtime code changes; minor risk if lodash 4.18.1 behavior differs from 4.17.x in edge cases.
> 
> **Overview**
> Pins **lodash** to **4.18.1** across several example and plugin packages to address prototype pollution in older transitive versions (e.g. 4.17.11, 4.17.21).
> 
> Each affected `package.json` gains an npm **`overrides`** entry for `"lodash": "4.18.1"` (alongside existing `minimist` overrides where present). **`plugins/emporix`** adds a new `overrides` block with only lodash. Matching **`package-lock.json`** updates resolve the whole tree to 4.18.1 and drop redundant nested `lodash` copies under `@commitlint` and similar packages.
> 
> No application source changes—lockfile and manifest dependency policy only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33157f7fae85b56a0f907a7a66ec9398c99230d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->