### PR TITLE
fix: publish custom event polyfill

### DIFF
--- a/.changeset/blue-mice-relax.md
+++ b/.changeset/blue-mice-relax.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/sdk': patch
+---
+
+Fix the published declaration's missing custom event polyfill module.

--- a/packages/core/src/polyfills/custom-event-polyfill.ts
+++ b/packages/core/src/polyfills/custom-event-polyfill.ts
@@ -1,12 +1,13 @@
+// The generated declaration imports this module, so compile it alongside the SDK.
 (function () {
   if (typeof window === 'undefined' || typeof window.CustomEvent === 'function') return false;
 
-  function CustomEvent(event, params) {
+  function CustomEvent(event: string, params?: CustomEventInit) {
     params = params || { bubbles: false, cancelable: false, detail: null };
-    var evt = document.createEvent('CustomEvent');
+    const evt = document.createEvent('CustomEvent');
     evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail);
     return evt;
   }
 
-  window.CustomEvent = CustomEvent;
+  window.CustomEvent = CustomEvent as unknown as typeof window.CustomEvent;
 })();


### PR DESCRIPTION
## Purpose

Ensure the custom event polyfill referenced by the SDK's generated declarations is included in the published package.

```
> tsc --noEmit

../../node_modules/.pnpm/@builder.io+sdk@6.3.1_encoding@0.1.13/node_modules/@builder.io/sdk/dist/src/bu
ilder.class.d.ts:2:8 - error TS2882: Cannot find module or type declarations for side-effect import of
'./polyfills/custom-event-polyfill'.

2 import './polyfills/custom-event-polyfill';
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Found 1 error in ../../node_modules/.pnpm/@builder.io+sdk@6.3.1_encoding@0.1.13/node_modules/@builder.i
o/sdk/dist/src/builder.class.d.ts:2

 ELIFECYCLE  Command failed with exit code 1.
ERROR: command (/Users/me/Projects/mypackage/apps/mcp-server) /Users/me/Library/p
npm/.tools/pnpm/10.4.1/bin/pnpm run check:types exited (1)
└─ @myorg/my-pkg#check:types ──
```

## Approach and changes

- [x] converted the custom event polyfill from JS to TS so the existing SDK compiler emits its runtime module and empty declaration alongside `builder.class.d.ts`
- [x] preserved the browser fallback behavior: it only defines `window.CustomEvent` when it is missing

## Testing instructions

1. Run `yarn workspace @builder.io/sdk build`
2. Confirm that `packages/core/dist/src/polyfills/custom-event-polyfill.js` and `packages/core/dist/src/polyfills/custom-event-polyfill.d.ts` exist
3. In a TS consumer that enables `noUncheckedSideEffectImports`, import `@builder.io/sdk` and run `tsc --noEmit`. The declaration import of `./polyfills/custom-event-polyfill` should resolve

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small packaging and typing fix for an existing browser polyfill with no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes a **published package gap** where `builder.class.d.ts` side-effect-imports `./polyfills/custom-event-polyfill`, but consumers running `tsc --noEmit` (especially with strict side-effect import checks) could not resolve that module.
> 
> The polyfill is now **TypeScript** so the SDK build emits **`custom-event-polyfill.js`** and a matching **`.d.ts`** next to the generated declarations. Runtime behavior is unchanged: the IIFE still only patches `window.CustomEvent` when it is missing in the browser.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 726f9c69df33d3622f7eb6a7b4486a70c0fd855e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->