### PR TITLE
fix[gen2][scripts]: ENG-13137 stop injecting personalization scripts on pages with multiple Content components 

### DIFF
--- a/.changeset/personalization-init-script-dedupe.md
+++ b/.changeset/personalization-init-script-dedupe.md
@@ -1,0 +1,12 @@
+---
+'@builder.io/sdk-react': patch
+'@builder.io/sdk-vue': patch
+'@builder.io/sdk-svelte': patch
+'@builder.io/sdk-solid': patch
+'@builder.io/sdk-qwik': patch
+'@builder.io/sdk-angular': patch
+'@builder.io/sdk-react-nextjs': patch
+'@builder.io/sdk-react-native': patch
+---
+
+Stop injecting personalization inline scripts on pages that do not use them. The `window.builderIoPersonalization` / `window.filterWithCustomTargeting` / `window.updateVisibilityStylesScript` init script was emitted once per top-level `Content` regardless of whether any Variant Container was present. It is now emitted only by a `Content` whose blocks actually contain one, and the definitions are idempotent — matching the treatment `window.builderIoAbTest` received previously.

--- a/packages/sdks/src/blocks/personalization-container/helpers.ts
+++ b/packages/sdks/src/blocks/personalization-container/helpers.ts
@@ -2,6 +2,7 @@ import { TARGET } from '../../constants/target.js';
 import { isBrowser } from '../../functions/is-browser.js';
 import { isEditing } from '../../functions/is-editing.js';
 import type { BuilderBlock } from '../../types/builder-block.js';
+import type { BuilderContent } from '../../types/builder-content.js';
 import type { Target } from '../../types/targets.js';
 import {
   FILTER_WITH_CUSTOM_TARGETING_SCRIPT,
@@ -15,6 +16,8 @@ export const DEFAULT_INDEX = 'default';
 const FILTER_WITH_CUSTOM_TARGETING_SCRIPT_FN_NAME = 'filterWithCustomTargeting';
 const BUILDER_IO_PERSONALIZATION_SCRIPT_FN_NAME = 'builderIoPersonalization';
 const UPDATE_VARIANT_VISIBILITY_SCRIPT_FN_NAME = 'updateVisibilityStylesScript';
+
+const PERSONALIZATION_CONTAINER_COMPONENT_NAME = 'PersonalizationContainer';
 
 export type UserAttributes = {
   date?: string | Date;
@@ -147,11 +150,45 @@ export function getBlocksToRender({
   return fallback;
 }
 
+/**
+ * Walks every value rather than a known set of child paths, so containers nested inside columns,
+ * tabs, slots, inline symbols or other variants are never missed. A missed container would leave
+ * the inlined fns undefined at parse time and render every variant at once.
+ */
+const containsPersonalizationContainer = (value: unknown): boolean => {
+  if (Array.isArray(value)) {
+    return value.some(containsPersonalizationContainer);
+  }
+
+  if (!value || typeof value !== 'object') return false;
+
+  if (
+    (value as BuilderBlock).component?.name ===
+    PERSONALIZATION_CONTAINER_COMPONENT_NAME
+  ) {
+    return true;
+  }
+
+  return Object.values(value).some(containsPersonalizationContainer);
+};
+
+export const hasPersonalizationContainer = (
+  content: BuilderContent | null | undefined
+) => containsPersonalizationContainer(content?.data?.blocks);
+
 export const getInitPersonalizationVariantsFnsScriptString = () => {
   return `
-  window.${FILTER_WITH_CUSTOM_TARGETING_SCRIPT_FN_NAME} = ${FILTER_WITH_CUSTOM_TARGETING_SCRIPT}
-  window.${BUILDER_IO_PERSONALIZATION_SCRIPT_FN_NAME} = ${PERSONALIZATION_SCRIPT}
-  window.${UPDATE_VARIANT_VISIBILITY_SCRIPT_FN_NAME} = ${UPDATE_VISIBILITY_STYLES_SCRIPT}
+  (function() {
+    if (!window.${FILTER_WITH_CUSTOM_TARGETING_SCRIPT_FN_NAME}) {
+      window.${FILTER_WITH_CUSTOM_TARGETING_SCRIPT_FN_NAME} = ${FILTER_WITH_CUSTOM_TARGETING_SCRIPT};
+    }
+    if (!window.${BUILDER_IO_PERSONALIZATION_SCRIPT_FN_NAME}) {
+      window.${BUILDER_IO_PERSONALIZATION_SCRIPT_FN_NAME} = ${PERSONALIZATION_SCRIPT};
+    }
+    if (!window.${UPDATE_VARIANT_VISIBILITY_SCRIPT_FN_NAME}) {
+      window.${UPDATE_VARIANT_VISIBILITY_SCRIPT_FN_NAME} = ${UPDATE_VISIBILITY_STYLES_SCRIPT};
+    }
+  })();
   `;
 };
 

--- a/packages/sdks/src/blocks/personalization-container/helpers.ts
+++ b/packages/sdks/src/blocks/personalization-container/helpers.ts
@@ -151,9 +151,10 @@ export function getBlocksToRender({
 }
 
 /**
- * Walks every value rather than a known set of child paths, so containers nested inside columns,
- * tabs, slots, inline symbols or other variants are never missed. A missed container would leave
- * the inlined fns undefined at parse time and render every variant at once.
+ * Walks the whole content rather than a known set of paths. A/B variation blocks live on
+ * `variations[*].data.blocks`, a sibling of `data.blocks`, and containers can sit inside columns,
+ * tabs, slots or inlined symbols. A missed container leaves the inlined fns undefined at parse
+ * time, so every variant renders at once.
  */
 const containsPersonalizationContainer = (value: unknown): boolean => {
   if (Array.isArray(value)) {
@@ -174,7 +175,7 @@ const containsPersonalizationContainer = (value: unknown): boolean => {
 
 export const hasPersonalizationContainer = (
   content: BuilderContent | null | undefined
-) => containsPersonalizationContainer(content?.data?.blocks);
+) => containsPersonalizationContainer(content);
 
 export const getInitPersonalizationVariantsFnsScriptString = () => {
   return `

--- a/packages/sdks/src/components/content-variants/content-variants.lite.tsx
+++ b/packages/sdks/src/components/content-variants/content-variants.lite.tsx
@@ -9,6 +9,7 @@ import {
 import {
   SDKS_SUPPORTING_PERSONALIZATION,
   getInitPersonalizationVariantsFnsScriptString,
+  hasPersonalizationContainer,
 } from '../../blocks/personalization-container/helpers.js';
 import { TARGET } from '../../constants/target.js';
 import { handleABTestingSync } from '../../helpers/ab-tests.js';
@@ -63,6 +64,12 @@ export default function ContentVariants(props: VariantsProviderProps) {
       canTrack: getDefaultCanTrack(props.canTrack),
       content: props.content,
     }),
+    /**
+     * Derived only from `props.content` so server and client agree during hydration.
+     * Nested renders are included because a symbol's content is absent from its parent's blocks.
+     */
+    shouldEmitPersonalizationFns:
+      TARGET !== 'reactNative' && hasPersonalizationContainer(props.content),
     get updateCookieAndStylesScriptStr() {
       return getUpdateCookieAndStylesScript(
         getVariants(props.content).map((value) => ({
@@ -90,7 +97,7 @@ export default function ContentVariants(props: VariantsProviderProps) {
 
   return (
     <>
-      <Show when={!props.isNestedRender && TARGET !== 'reactNative'}>
+      <Show when={state.shouldEmitPersonalizationFns}>
         {SDKS_SUPPORTING_PERSONALIZATION.includes(TARGET) && (
           <InlinedScript
             nonce={props.nonce || ''}


### PR DESCRIPTION
## Description
On SSR pages, the personalization inline scripts were injected **once per `<Content>` component**, even on pages that use no personalization at all.

A page with a header, a page body and a footer shipped three identical copies of `window.builderIoPersonalization`, `window.filterWithCustomTargeting` and `window.updateVisibilityStylesScript` — roughly **4KB of duplicated HTML per Content**.

The 5.2.4 fix (#4691) solved this for the A/B testing equivalent (`window.builderIoAbTest`) but left the three personalization globals untouched.

**Root cause:**

In `content-variants.lite.tsx` the script was emitted on a single condition: "am I a top-level Content?":
`<Show when={!props.isNestedRender && TARGET !== 'reactNative'}>`
It never checked whether the content actually contained a Variant Container. The A/B equivalent, by contrast, is gated on `shouldRenderVariants`, so it only appears when variants really render.

**Fix:**
- **Emit only when needed**. New `hasPersonalizationContainer()` helper checks whether the content actually contains a Variant Container, and the script is gated on that.
- **Make the definitions idempotent**. Each global is now assigned only `if (!window.X)`, matching what 5.2.4 did for `builderIoAbTest`.

**Link to JIRA ticket (if applicable):**
https://builder-io.atlassian.net/browse/ENG-13137

**Screenshot/Clip**
https://clips.agent-native.com/share/CJBhbNylaNH1?ref=clip_share
