### PR TITLE
feat(sdk): add opt-in debug logging (e.g. to capture x-request-id)

### DIFF
--- a/.changeset/gentle-cameras-behave.md
+++ b/.changeset/gentle-cameras-behave.md
@@ -1,0 +1,5 @@
+---
+"@builder.io/sdk": minor
+---
+
+Added an opt-in `Builder.logLevel` setting (defaulting from the `BUILDER_SDK_LOG_LEVEL` environment variable under Node.js) that logs the request URL, response status, and `x-request-id` response header for every content fetch via `console.debug`. This makes it possible to correlate a specific SDK call with a Builder-side request when reporting intermittent API issues, without changing any existing response shape or default behavior.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -39,6 +39,26 @@ builder
 builder.canTrack = false;
 ```
 
+## Debugging Content API requests
+
+If you're seeing intermittent issues with Content API responses and need to report them to
+Builder.io support, you can opt in to request/response logging so you can correlate a specific
+SDK call with a request on Builder's side (via the `x-request-id` response header):
+
+```javascript
+import { Builder } from '@builder.io/sdk';
+
+// Logs the request URL, method, response status, and x-request-id header
+// (when present) for every content fetch via console.debug.
+Builder.logLevel = 'debug';
+```
+
+Under Node.js, `Builder.logLevel` defaults from the `BUILDER_SDK_LOG_LEVEL` environment variable
+(e.g. `BUILDER_SDK_LOG_LEVEL=debug`), so it can be turned on for a deployment without a code
+change. In browser/edge environments without `process.env`, it falls back to `'silent'` and can
+only be set programmatically as shown above. This setting defaults to `'silent'` and is a no-op
+unless explicitly enabled.
+
 View all options for `builder.get` [here](./docs/interfaces/GetContentOptions.md)
 
 Learn more about how to use the Builder core SDK:

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -16,3 +16,5 @@ export { BuilderContent, BuilderContentVariation } from './src/types/content';
 export { ApiVersion } from './src/types/api-version';
 
 export { builder } from './src/constants/builder';
+
+export { BuilderLogLevel } from './src/functions/log-level.function';

--- a/packages/core/src/builder.class.test.ts
+++ b/packages/core/src/builder.class.test.ts
@@ -36,6 +36,57 @@ describe('Builder', () => {
   });
 });
 
+describe('makeFetchApiCall logging', () => {
+  const url = 'https://cdn.builder.io/api/v3/content/page';
+  let debugSpy: jest.SpyInstance;
+  let originalLogLevel: typeof Builder.logLevel;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+    originalLogLevel = Builder.logLevel;
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    debugSpy.mockRestore();
+    Builder.logLevel = originalLogLevel;
+    globalThis.fetch = originalFetch;
+  });
+
+  test('logs the x-request-id header when Builder.logLevel is debug', async () => {
+    Builder.logLevel = 'debug';
+    const mockResponse = {
+      status: 200,
+      json: async () => ({}),
+      headers: { get: (name: string) => (name === 'x-request-id' ? 'req-abc' : null) },
+    };
+    globalThis.fetch = jest.fn().mockResolvedValue(mockResponse) as any;
+
+    const builder = new Builder();
+    await (builder as any).makeFetchApiCall(url, {});
+
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+    expect(debugSpy.mock.calls[0][0]).toContain(url);
+    expect(debugSpy.mock.calls[0][0]).toContain('req-abc');
+  });
+
+  test('does not log when Builder.logLevel is silent (the default)', async () => {
+    Builder.logLevel = 'silent';
+    const mockResponse = {
+      status: 200,
+      json: async () => ({}),
+      headers: { get: () => 'req-abc' },
+    };
+    globalThis.fetch = jest.fn().mockResolvedValue(mockResponse) as any;
+
+    const builder = new Builder();
+    await (builder as any).makeFetchApiCall(url, {});
+
+    expect(debugSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe('serializeIncludingFunctions', () => {
   test('serializes functions in inputs', () => {
     const input = {

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -1,6 +1,11 @@
 import './polyfills/custom-event-polyfill';
 import { IncomingMessage, ServerResponse } from 'http';
 import { nextTick } from './functions/next-tick.function';
+import {
+  BuilderLogLevel,
+  getDefaultLogLevel,
+  logFetchDebugInfo,
+} from './functions/log-level.function';
 import { QueryString } from './classes/query-string.class';
 import { BehaviorSubject } from './classes/observable.class';
 import { getFetch } from './functions/fetch.function';
@@ -987,6 +992,24 @@ export class Builder {
   static registry: { [key: string]: any[] } = {};
   static overrideHost: string | undefined;
   static attributesCookieName = 'builder.userAttributes';
+
+  /**
+   * Controls SDK diagnostic logging. Set to `'debug'` to log a `console.debug` line for every
+   * content fetch, including the request URL, response status, and the `x-request-id` response
+   * header when the API includes one. This is useful when reporting intermittent API issues to
+   * Builder.io support, since it lets you correlate a specific SDK call with a request on
+   * Builder's side.
+   *
+   * Defaults to the `BUILDER_SDK_LOG_LEVEL` environment variable (e.g.
+   * `BUILDER_SDK_LOG_LEVEL=debug`) when running under Node.js, or `'silent'` otherwise. Can
+   * also be set programmatically at any time, which is the only option in bundled browser code
+   * where environment variables aren't available at runtime:
+   *
+   * ```ts
+   * Builder.logLevel = 'debug';
+   * ```
+   */
+  static logLevel: BuilderLogLevel = getDefaultLogLevel();
 
   /**
    * @todo `key` property on any info where if a key matches a current
@@ -2544,7 +2567,10 @@ export class Builder {
     url: string,
     options?: { headers: { [header: string]: number | string | string[] | undefined }; next?: any }
   ) {
-    return getFetch()(url, this.addSdkHeaders(options)).then(res => res.json());
+    return getFetch()(url, this.addSdkHeaders(options)).then(res => {
+      logFetchDebugInfo(Builder.logLevel, { method: 'GET', url, response: res });
+      return res.json();
+    });
   }
 
   get host() {
@@ -2600,7 +2626,10 @@ export class Builder {
   }
 
   private makeFetchApiCall(url: string, requestOptions: any): Promise<any> {
-    return getFetch()(url, this.addSdkHeaders(requestOptions));
+    return getFetch()(url, this.addSdkHeaders(requestOptions)).then(res => {
+      logFetchDebugInfo(Builder.logLevel, { method: requestOptions?.method, url, response: res });
+      return res;
+    });
   }
 
   /**

--- a/packages/core/src/functions/log-level.function.test.ts
+++ b/packages/core/src/functions/log-level.function.test.ts
@@ -1,0 +1,91 @@
+import { getDefaultLogLevel, logFetchDebugInfo } from './log-level.function';
+
+describe('getDefaultLogLevel', () => {
+  const originalEnv = process.env.BUILDER_SDK_LOG_LEVEL;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.BUILDER_SDK_LOG_LEVEL;
+    } else {
+      process.env.BUILDER_SDK_LOG_LEVEL = originalEnv;
+    }
+  });
+
+  test('defaults to silent when the env var is unset', () => {
+    delete process.env.BUILDER_SDK_LOG_LEVEL;
+    expect(getDefaultLogLevel()).toBe('silent');
+  });
+
+  test('returns debug when BUILDER_SDK_LOG_LEVEL=debug', () => {
+    process.env.BUILDER_SDK_LOG_LEVEL = 'debug';
+    expect(getDefaultLogLevel()).toBe('debug');
+  });
+
+  test('is case-insensitive', () => {
+    process.env.BUILDER_SDK_LOG_LEVEL = 'DEBUG';
+    expect(getDefaultLogLevel()).toBe('debug');
+  });
+
+  test('falls back to silent for unrecognized values', () => {
+    process.env.BUILDER_SDK_LOG_LEVEL = 'verbose';
+    expect(getDefaultLogLevel()).toBe('silent');
+  });
+});
+
+describe('logFetchDebugInfo', () => {
+  let debugSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    debugSpy.mockRestore();
+  });
+
+  test('does not log when log level is silent', () => {
+    logFetchDebugInfo('silent', {
+      url: 'https://cdn.builder.io/api/v3/content/page',
+      response: { status: 200, headers: { get: () => 'req-123' } },
+    });
+
+    expect(debugSpy).not.toHaveBeenCalled();
+  });
+
+  test('logs the url, status, and x-request-id header when log level is debug', () => {
+    logFetchDebugInfo('debug', {
+      method: 'GET',
+      url: 'https://cdn.builder.io/api/v3/content/page',
+      response: { status: 200, headers: { get: () => 'req-123' } },
+    });
+
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+    const [message] = debugSpy.mock.calls[0];
+    expect(message).toContain('GET');
+    expect(message).toContain('https://cdn.builder.io/api/v3/content/page');
+    expect(message).toContain('200');
+    expect(message).toContain('req-123');
+  });
+
+  test('notes when there is no x-request-id header, without throwing', () => {
+    logFetchDebugInfo('debug', {
+      url: 'https://cdn.builder.io/api/v3/content/page',
+      response: { status: 200, headers: { get: () => null } },
+    });
+
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+    const [message] = debugSpy.mock.calls[0];
+    expect(message).toContain('no x-request-id header');
+  });
+
+  test('does not throw when the response has no headers object at all', () => {
+    expect(() =>
+      logFetchDebugInfo('debug', {
+        url: 'https://cdn.builder.io/api/v3/content/page',
+        response: { status: 500 },
+      })
+    ).not.toThrow();
+
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/functions/log-level.function.ts
+++ b/packages/core/src/functions/log-level.function.ts
@@ -1,0 +1,71 @@
+// Minimal, isomorphic diagnostic logging for SDK network calls.
+//
+// This intentionally avoids taking a dependency on something like the `debug` package so it
+// stays safe to load in the browser, React Native, and edge runtimes, in addition to Node.js.
+
+export type BuilderLogLevel = 'silent' | 'debug';
+
+const ENV_VAR_NAME = 'BUILDER_SDK_LOG_LEVEL';
+
+function normalizeLogLevel(value: string | undefined | null): BuilderLogLevel {
+  return typeof value === 'string' && value.toLowerCase() === 'debug' ? 'debug' : 'silent';
+}
+
+/**
+ * Reads the initial log level from the `BUILDER_SDK_LOG_LEVEL` environment variable when
+ * running under Node.js (e.g. `BUILDER_SDK_LOG_LEVEL=debug`). Falls back to `'silent'` in
+ * environments where `process.env` isn't available, such as the browser, without throwing.
+ *
+ * `Builder.logLevel` can also be set programmatically at any time, which is the only option
+ * in bundled browser code where environment variables aren't available at runtime.
+ */
+export function getDefaultLogLevel(): BuilderLogLevel {
+  try {
+    if (typeof process !== 'undefined' && process.env) {
+      return normalizeLogLevel(process.env[ENV_VAR_NAME]);
+    }
+  } catch (err) {
+    // `process` can be a getter that throws in some sandboxed environments (e.g. certain
+    // edge runtimes). Treat that the same as "not available".
+  }
+  return 'silent';
+}
+
+interface FetchDebugInfo {
+  method?: string;
+  url: string;
+  response: {
+    status: number;
+    headers?: {
+      get: (name: string) => string | null | undefined;
+    };
+  };
+}
+
+/**
+ * Logs request/response metadata for a single SDK fetch call, gated behind `logLevel`.
+ *
+ * Reads (but does not consume) the `x-request-id` response header so it can be included
+ * alongside `console.debug` output for the caller. This is meant to make it possible to
+ * correlate a specific SDK call with a Builder-side request when reporting intermittent API
+ * issues, without changing the SDK's public response shape.
+ */
+export function logFetchDebugInfo(logLevel: BuilderLogLevel, info: FetchDebugInfo): void {
+  if (logLevel !== 'debug') {
+    return;
+  }
+
+  let requestId: string | null | undefined;
+  try {
+    requestId = info.response.headers?.get('x-request-id');
+  } catch (err) {
+    // Some minimal `Headers`-like polyfills may not implement `.get()`. Don't let diagnostic
+    // logging ever break the actual request.
+  }
+
+  // eslint-disable-next-line no-console
+  console.debug(
+    `[Builder SDK] ${info.method ?? 'GET'} ${info.url} -> ${info.response.status}` +
+      (requestId ? ` (x-request-id: ${requestId})` : ' (no x-request-id header on response)')
+  );
+}


### PR DESCRIPTION
## Purpose

Delivery failures are hard to investigate on Builder's side without a request ID to look up. The SDK already receives an `x-request-id` response header on Content API responses, but `res.json()` discards headers before consumers ever see them, so there is currently no supported way to capture that ID from `@builder.io/sdk` itself.

## Approach and changes

No existing response shapes, return values, or default behavior were changed. With `logLevel` left at its default (`'silent'`), this is a no-op.

- [x] added an opt-in `Builder.logLevel` static setting (`'silent' | 'debug'`, defaults to `'silent'`) that gates a `console.debug` line for every Content API fetch, including the request URL, method, response status, and the `x-request-id` response header when present.
- [x] under Node.js, `Builder.logLevel` defaults from the `BUILDER_SDK_LOG_LEVEL` environment variable (e.g. `BUILDER_SDK_LOG_LEVEL=debug`), so it can be turned on for a deployment without a code change. In browser/edge environments without `process.env`, it falls back to `'silent'` and can still be set programmatically at runtime via `Builder.logLevel = 'debug'`.
- [x] wired the new logging into the two places that consume a fetch `Response` before headers would otherwise be lost: `makeFetchApiCall` (used by `get`/`getAll`/`flushGetContentQueue`) and the `requestUrl` helper kept for the Angular SDK.
- [x] New logic lives in `packages/core/src/functions/log-level.function.ts` so it can be unit tested independently and reads headers defensively (never throws if a `Headers`-like polyfill doesn't implement `.get()`).

## Testing instructions

1. Set `BUILDER_SDK_LOG_LEVEL=debug` in a Node.js process using the SDK and confirm a `console.debug` line appears for each content fetch, including the `x-request-id` value when the API returns one.
1. With `Builder.logLevel` left unset (default), confirm no additional console output appears compared to the current published behavior.
