### PR TITLE
fix[image]: ENG-13637 render empty alt attributes when alt text is not provided

### DIFF
--- a/.changeset/silly-pants-smoke.md
+++ b/.changeset/silly-pants-smoke.md
@@ -1,0 +1,12 @@
+---
+"@builder.io/react": patch
+"@builder.io/sdk-angular": patch
+"@builder.io/sdk-react-nextjs": patch
+"@builder.io/sdk-qwik": patch
+"@builder.io/sdk-react": patch
+"@builder.io/sdk-solid": patch
+"@builder.io/sdk-svelte": patch
+"@builder.io/sdk-vue": patch
+---
+
+Fixed Image components to render an explicit empty `alt` attribute when alt text is blank or missing

--- a/packages/react/src/blocks/Image.tsx
+++ b/packages/react/src/blocks/Image.tsx
@@ -339,7 +339,7 @@ class ImageComponent extends React.Component<any, { imageLoaded: boolean; load: 
                       (aspectRatio ? Math.round(1000 / aspectRatio) : undefined),
                   } as any)
                 : null)}
-              alt={this.props.altText}
+              alt={this.props.altText || ''}
               title={this.props.title}
               key={
                 Builder.isEditing

--- a/packages/react/test/__snapshots__/image.test.tsx.snap
+++ b/packages/react/test/__snapshots__/image.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`Image Amp image 1`] = `
           style={Object {}}
         >
           <amp-img
+            alt=""
             className="builder-image css-yue2ks"
             layout="responsive"
             loading="lazy"
@@ -64,6 +65,7 @@ exports[`Image Builder image url 1`] = `
     data-emotion-css="2qdlcf"
   />
   <img
+    alt=""
     className="builder-image css-2qdlcf"
     loading="lazy"
     onLoad={[Function]}
@@ -89,6 +91,7 @@ exports[`Image Builder image url with width 1`] = `
     data-emotion-css="2qdlcf"
   />
   <img
+    alt=""
     className="builder-image css-2qdlcf"
     loading="lazy"
     onLoad={[Function]}
@@ -119,6 +122,7 @@ exports[`Image Shopify image url 1`] = `
     data-emotion-css="2qdlcf"
   />
   <img
+    alt=""
     className="builder-image css-2qdlcf"
     loading="lazy"
     onLoad={[Function]}
@@ -157,6 +161,7 @@ exports[`Image with responsive styles 1`] = `
         >
           <picture>
             <img
+              alt=""
               className="builder-image css-2qdlcf"
               loading="lazy"
               onLoad={[Function]}

--- a/packages/react/test/image.test.tsx
+++ b/packages/react/test/image.test.tsx
@@ -23,6 +23,17 @@ describe('Image', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('renders an empty alt attribute when alt text is missing', () => {
+    const tree = reactTestRenderer
+      .create(
+        <Image image="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F755c131471fb49ab91dc0bdc45bc85b5?width=1003" />
+      )
+      .toJSON() as any;
+    const image = tree.children.find((child: any) => child.type === 'img');
+
+    expect(image.props.alt).toBe('');
+  });
+
   it('Shopify image url', () => {
     const tree = reactTestRenderer
       .create(

--- a/packages/sdks-tests/src/e2e-tests/blocks.spec.ts
+++ b/packages/sdks-tests/src/e2e-tests/blocks.spec.ts
@@ -137,6 +137,16 @@ test.describe('Blocks', () => {
       }
     });
 
+    test('Image alt attribute', async ({ page, sdk }) => {
+      test.skip(checkIsRN(sdk));
+
+      await page.goto('/image');
+
+      const images = page.locator('.builder-image');
+      await expect(images.first()).toHaveAttribute('alt', '');
+      await expect(images.nth(1)).toHaveAttribute('alt', 'alt text test');
+    });
+
     test('Image sizes attribute', async ({ page, sdk }) => {
       test.skip(checkIsRN(sdk));
 

--- a/packages/sdks/src/blocks/image/image.lite.tsx
+++ b/packages/sdks/src/blocks/image/image.lite.tsx
@@ -99,7 +99,7 @@ export default function Image(props: ImageProps) {
         <img
           loading={props.highPriority ? 'eager' : 'lazy'}
           fetchpriority={props.highPriority ? 'high' : 'auto'}
-          alt={props.altText}
+          alt={props.altText || ''}
           title={props.title}
           role={props.altText ? undefined : 'presentation'}
           css={{


### PR DESCRIPTION
## Description
- Render `alt=""` for Gen 1 and Gen 2 Image components when alt text is not provided, while preserving populated alt text.

**Link to JIRA ticket (if applicable):**
https://builder-io.atlassian.net/browse/ENG-13637

**Screenshot/Clip**
<img width="3020" height="1468" alt="image" src="https://github.com/user-attachments/assets/c7de07a8-9713-4d35-9b59-ab7635f9500a" />

Chrome DevTools displays the empty attribute as `alt`, which is valid HTML and equivalent to `alt=""`. The DOM confirms that the attribute exists with an empty-string value - [Reference](https://stackoverflow.com/questions/44764441/is-alt-the-same-as-alt)
