### PR TITLE
fix[types][showIf]: ENG-13485 add editor locale context to callback types

### DIFF
--- a/.changeset/tender-cats-shop.md
+++ b/.changeset/tender-cats-shop.md
@@ -1,0 +1,13 @@
+---
+"@builder.io/sdk": patch
+"@builder.io/sdk-angular": patch
+"@builder.io/sdk-react-nextjs": patch
+"@builder.io/sdk-qwik": patch
+"@builder.io/sdk-react": patch
+"@builder.io/sdk-react-native": patch
+"@builder.io/sdk-solid": patch
+"@builder.io/sdk-svelte": patch
+"@builder.io/sdk-vue": patch
+---
+
+Types: allow `showIf` callbacks to receive the existing parent arguments and the current editor locale through `context.locale`.

--- a/packages/core/src/builder.class.ts
+++ b/packages/core/src/builder.class.ts
@@ -700,7 +700,14 @@ export interface Input {
   /** @hidden */
   richText?: boolean;
   /** @hidden */
-  showIf?: ((options: Map<string, any>) => boolean) | string;
+  showIf?:
+    | ((
+        options: Map<string, any>,
+        parent?: any,
+        parentElements?: any,
+        context?: { locale?: string }
+      ) => boolean)
+    | string;
   /** @hidden */
   copyOnAdd?: boolean;
   /**

--- a/packages/json-schema/src/index.ts
+++ b/packages/json-schema/src/index.ts
@@ -129,7 +129,14 @@ export interface Input {
   onChange?: Function | string;
   code?: boolean;
   richText?: boolean;
-  showIf?: ((options: Map<string, any>) => boolean) | string;
+  showIf?:
+    | ((
+        options: Map<string, any>,
+        parent?: any,
+        parentElements?: any,
+        context?: { locale?: string }
+      ) => boolean)
+    | string;
   copyOnAdd?: boolean;
 }
 

--- a/packages/sdks/src/types/input.ts
+++ b/packages/sdks/src/types/input.ts
@@ -120,7 +120,14 @@ export interface Input {
   /** @hidden */
   richText?: boolean;
   /** @hidden */
-  showIf?: ((options: Map<string, any>) => boolean) | string;
+  showIf?:
+    | ((
+        options: Map<string, any>,
+        parent?: any,
+        parentElements?: any,
+        context?: { locale?: string }
+      ) => boolean)
+    | string;
   /** @hidden */
   copyOnAdd?: boolean;
   /**


### PR DESCRIPTION
## Description
- `showIf` callbacks can now receive the current editor locale as their fourth argument, but the public types only allow the `options` argument - https://github.com/BuilderIO/builder-internal/pull/14564
- This updates the Gen 1, Gen 2, and JSON schema types to include the existing `parent` and `parentElements` arguments and the new optional `context.locale` argument.

**Link to JIRA ticket (if applicable):**
https://builder-io.atlassian.net/browse/ENG-13485

**Screenshot/Clip**
T.B.A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Types-only alignment of `showIf` callback parameters. No runtime, auth, or data-handling changes.
> 
> **Overview**
> Updates public `showIf` types so custom-component input callbacks can take the parent, parent elements, and optional `context.locale` that the editor already passes.
> 
> The same signature is applied on Gen 1 (`Input` in `builder.class.ts`), Gen 2 SDK `Input`, and the JSON schema types. Patch changeset only; no runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5474a8fa2a224ac111b677b65ccfe04be7d0c9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->