### PR TITLE
Add pre-translate option to Phrase plugin

### DIFF
--- a/plugins/phrase-conector/package-lock.json
+++ b/plugins/phrase-conector/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/plugin-phrase-connector",
-  "version": "0.0.17",
+  "version": "0.0.18-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-phrase-connector",
-      "version": "0.0.17",
+      "version": "0.0.18-0",
       "license": "MIT",
       "dependencies": {
         "@builder.io/commerce-plugin-tools": "^0.3.0",

--- a/plugins/phrase-conector/package.json
+++ b/plugins/phrase-conector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-phrase-connector",
-  "version": "0.0.17",
+  "version": "0.0.18-0",
   "description": "",
   "keywords": [],
   "main": "dist/plugin.system.js",

--- a/plugins/phrase-conector/src/phrase-api.ts
+++ b/plugins/phrase-conector/src/phrase-api.ts
@@ -154,11 +154,19 @@ export class PhraseApi {
     model: string,
     sourceLang: string,
     targetLangs: string[],
+    preTranslate: boolean,
     callbackHost?: string
   ): Promise<{ project: Project }> {
     return this.request('job', {
       method: 'POST',
-      body: JSON.stringify({ contentId, model, sourceLang, targetLangs, callbackHost }),
+      body: JSON.stringify({
+        contentId,
+        model,
+        sourceLang,
+        targetLangs,
+        preTranslate,
+        callbackHost,
+      }),
     });
   }
 

--- a/plugins/phrase-conector/src/plugin.tsx
+++ b/plugins/phrase-conector/src/plugin.tsx
@@ -161,6 +161,7 @@ registerPlugin(
             content.modelName,
             picks.sourceLang,
             picks.targetLangs,
+            picks.preTranslate,
             settings.get('callbackHost')
           );
           showJobNotification(project.uid, settings.get('isUSDataCenterAccount'));

--- a/plugins/phrase-conector/src/snackbar-utils.tsx
+++ b/plugins/phrase-conector/src/snackbar-utils.tsx
@@ -10,6 +10,7 @@ import {
   MenuItem,
   ListItemText,
   Checkbox,
+  FormControlLabel,
   Typography,
   Button,
   Radio,
@@ -71,7 +72,9 @@ export function showOutdatedNotifications(callback: () => void) {
 }
 
 interface Props {
-  onChoose: (val: { sourceLang: string; targetLangs: string[] } | null) => void;
+  onChoose: (
+    val: { sourceLang: string; targetLangs: string[]; preTranslate: boolean } | null
+  ) => void;
 }
 const lsKey = 'phrase.sourceLang';
 
@@ -94,6 +97,7 @@ const safeLsSet = (key: string, value: string) => {
 const PhraseConfigurationEditor: React.FC<Props> = props => {
   const store = useLocalStore(() => ({
     targetLangs: [] as string[],
+    preTranslate: false,
     get availableLangs(): string[] {
       return (
         appState.user.organization.value.customTargetingAttributes
@@ -163,6 +167,25 @@ const PhraseConfigurationEditor: React.FC<Props> = props => {
           Pick from the list of available languages
         </Typography>
       </div>
+      <FormControlLabel
+        control={
+          <Checkbox
+            color="primary"
+            checked={store.preTranslate}
+            onChange={action(event => {
+              store.preTranslate = event.target.checked;
+            })}
+          />
+        }
+        label={
+          <div>
+            <Typography>Pre-translate</Typography>
+            <Typography variant="caption">
+              Use approved translations from Phrase Translation Memory to pre-fill this job
+            </Typography>
+          </div>
+        }
+      />
       <DialogActions>
         <Button onClick={() => props.onChoose(null)} color="default">
           cancel
@@ -178,6 +201,7 @@ const PhraseConfigurationEditor: React.FC<Props> = props => {
 export async function getLangPicks(): Promise<{
   sourceLang: string;
   targetLangs: string[];
+  preTranslate: boolean;
 } | null> {
   return new Promise(async resolve => {
     const destroy = await appState.globalState.openDialog(


### PR DESCRIPTION
## Description

Added a "Pre-translate" checkbox option to the Phrase plugin's job creation dialog, allowing users to opt in to using approved translations from Phrase Translation Memory to pre-fill a job.

Changes include:
- Added a `preTranslate` field (defaulting to `false`) to the configuration editor's local store.
- Added a `FormControlLabel` with a `Checkbox` UI control in `snackbar-utils.tsx` to let users toggle the pre-translate option, with a description explaining its behavior.
- Updated the `getLangPicks` return type and `onChoose` callback to include `preTranslate`.
- Passed the `preTranslate` value through `plugin.tsx` when creating a job.
- Updated `PhraseApi.createJob` to accept and send the `preTranslate` flag in the job creation request body.

**Link to JIRA ticket (if applicable):**
https://builder-io.atlassian.net/browse/ENG-13444


---

<a href="https://builder.io/app/projects/b29d4bc79bfe480fb3f0/prime-essence-pwngmcyk"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://b29d4bc79bfe480fb3f0-prime-essence-pwngmcyk.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4820`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b29d4bc79bfe480fb3f0</projectId>-->
<!--<branchName>prime-essence-pwngmcyk</branchName>-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped plugin UI and job-creation payload with default false; behavior unchanged unless users opt in, though the backend must accept the new field.
> 
> **Overview**
> Adds an optional **Pre-translate** control to the Phrase connector’s translate dialog so editors can request Translation Memory pre-fill when starting a job.
> 
> The language picker dialog now includes a checkbox (default **off**) with copy explaining that approved TM matches can pre-fill the job. That choice is carried through `getLangPicks` → `createJob` as a `preTranslate` boolean on `POST /api/v1/memsource/job`. Package version is bumped to `0.0.18-0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17562b19197ff7ac2a60d8c65e92af249cde22f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->