### PR TITLE
fix: pass --repo to mutating gh pr commands in dependabot merger script

### DIFF
--- a/scripts/merge-dependabot-prs.mjs
+++ b/scripts/merge-dependabot-prs.mjs
@@ -14,6 +14,8 @@
 import { question } from 'zx';
 import { echo } from 'zx/experimental';
 
+const REPO = 'BuilderIO/builder';
+
 console.log('Welcome to the BuilderIO/builder dependabot PR merger!');
 
 let query = '';
@@ -72,7 +74,7 @@ async function approve(prs) {
   const approvePr = async pr => {
     console.log(`Approving ${pr.url}...`);
     try {
-      await $`gh pr review ${pr.number} --approve`;
+      await $`gh pr review ${pr.number} --repo=${REPO} --approve`;
       console.log(`Approved ${pr.url}.`);
     } catch (e) {
       console.log(`Error approving ${pr.url}.`);
@@ -88,7 +90,7 @@ async function enableAutoMerge(prs) {
     console.log(`Enabling auto-merge for ${pr.url}...`);
     try {
       // queues the squash-merge until CI passes
-      await $`gh pr merge ${pr.number} --auto --squash`;
+      await $`gh pr merge ${pr.number} --repo=${REPO} --auto --squash`;
       console.log(`Auto-merge enabled for ${pr.url}.`);
     } catch (e) {
       console.log(`Error enabling auto-merge for ${pr.url}.`);
@@ -108,7 +110,7 @@ async function forceMerge(prs) {
     for (let attempt = 1; attempt <= 2; attempt++) {
       try {
         // --admin bypasses required checks/reviews and merges immediately
-        await $`gh pr merge ${pr.number} --admin --squash`;
+        await $`gh pr merge ${pr.number} --repo=${REPO} --admin --squash`;
         console.log(`Force-merged ${pr.url}.`);
         break;
       } catch (e) {
@@ -137,7 +139,7 @@ async function rebaseAll(prs) {
 async function rebaseDependabot(prNumber) {
   console.log(`Asking Dependabot to rebase: ${prNumber}`);
   try {
-    await $`gh pr comment ${prNumber} --body="@dependabot rebase"`;
+    await $`gh pr comment ${prNumber} --repo=${REPO} --body="@dependabot rebase"`;
     console.log(`Rebased ${prNumber}`);
   } catch (e) {
     console.log(`Error rebasing ${prNumber}`);


### PR DESCRIPTION
Fixed a critical bug where mutating gh pr commands could resolve the repository from the current git context instead of BuilderIO/builder. Added a shared REPO constant and passed --repo=${REPO} to all mutating commands to ensure they always target the correct repository.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only maintenance script change with no production runtime impact; reduces risk of approving or merging the wrong repository when run outside the builder checkout.
> 
> **Overview**
> Fixes the dependabot PR merger so **approve**, **auto-merge**, **admin force-merge**, and **Dependabot rebase comment** steps always run against `BuilderIO/builder` instead of whatever repo `gh` infers from the current working directory.
> 
> Introduces a shared `REPO` constant and adds `--repo=${REPO}` to those mutating `gh pr` invocations. PR discovery already scoped the repo; this aligns write operations with that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77254f9d1ccb05686f2cf1fe17cf214bc5b7b88f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->