### PR TITLE
fix[smartling][utils]: ENG-13615 plugin sends enum field values from custom components to translation jobs

### DIFF
--- a/packages/utils/src/translation-helpers.test.ts
+++ b/packages/utils/src/translation-helpers.test.ts
@@ -1659,3 +1659,61 @@ test('getTranslateableFields excludes an enum subfield that is itself a Localize
     },
   });
 });
+
+test('applyTranslation ignores translated enum values from a job created before the fix', () => {
+  const content = textColumnsContent(textColumnsMeta);
+
+  // A job uploaded before the exclusions existed: real copy alongside translated enums.
+  const legacyTranslation = {
+    'blocks.builder-textcolumns#textColumns#0#headline': { value: 'DE headline' },
+    'blocks.builder-textcolumns#textColumns#0#bodyText': { value: 'DE body' },
+    'blocks.builder-textcolumns#textColumns#0#textColumnAlignment': { value: 'Links' },
+    'blocks.builder-textcolumns#textColumns#0#textRowAlignment': { value: 'Unteres' },
+    'blocks.builder-textcolumns#textColumns#0#backgroundColor': { value: 'Weiss' },
+  };
+
+  const result = applyTranslation(content, legacyTranslation, 'de-DE', 'en-US');
+  const columns = (result.data as any).blocks[0].component.options.textColumns['de-DE'];
+
+  expect(columns[0]).toEqual({
+    headline: 'DE headline',
+    bodyText: 'DE body',
+    textColumnAlignment: 'Left',
+    textRowAlignment: 'Bottom',
+    backgroundColor: 'White',
+  });
+});
+
+test('applyTranslation keeps the source payload when a job returns only excluded enum values', () => {
+  const content = textColumnsContent(textColumnsMeta);
+
+  const result = applyTranslation(
+    content,
+    { 'blocks.builder-textcolumns#textColumns#0#backgroundColor': { value: 'Weiss' } },
+    'de-DE',
+    'en-US'
+  );
+  const columns = (result.data as any).blocks[0].component.options.textColumns['de-DE'];
+
+  // Without the locale branch the SDK resolves the list to undefined and it vanishes.
+  expect(columns[0].backgroundColor).toEqual('White');
+  expect(columns[0].headline).toEqual('Get paid faster');
+});
+
+test('applyTranslation is unaffected when no exclusions are recorded', () => {
+  const content = textColumnsContent({ localizedTextInputs: ['textColumns'] });
+
+  const result = applyTranslation(
+    content,
+    {
+      'blocks.builder-textcolumns#textColumns#0#headline': { value: 'DE headline' },
+      'blocks.builder-textcolumns#textColumns#0#backgroundColor': { value: 'Weiss' },
+    },
+    'de-DE',
+    'en-US'
+  );
+  const columns = (result.data as any).blocks[0].component.options.textColumns['de-DE'];
+
+  expect(columns[0].headline).toEqual('DE headline');
+  expect(columns[0].backgroundColor).toEqual('Weiss');
+});

--- a/packages/utils/src/translation-helpers.test.ts
+++ b/packages/utils/src/translation-helpers.test.ts
@@ -1717,3 +1717,42 @@ test('applyTranslation is unaffected when no exclusions are recorded', () => {
   expect(columns[0].headline).toEqual('DE headline');
   expect(columns[0].backgroundColor).toEqual('Weiss');
 });
+
+const configRowsContent = (): BuilderContent => ({
+  data: {
+    blocks: [
+      {
+        '@type': '@builder.io/sdk:Element',
+        id: 'builder-configrows',
+        meta: {
+          localizedTextInputs: ['configRows'],
+          nonTranslatableInputs: ['configRows.*.alignment', 'configRows.*.background'],
+        },
+        component: {
+          name: 'ConfigRows',
+          options: {
+            configRows: {
+              '@type': localizedType,
+              Default: [
+                { alignment: 'Left', background: 'White' },
+                { alignment: 'Right', background: 'Black' },
+              ],
+            },
+          },
+        },
+      },
+    ],
+  },
+});
+
+test('getTranslateableFields sends nothing for an input whose leaves are all excluded', () => {
+  expect(getTranslateableFields(configRowsContent(), 'en-US', 'instructions')).toEqual({});
+});
+
+test('applyTranslation seeds the source when an input had nothing to translate', () => {
+  const result = applyTranslation(configRowsContent(), {}, 'de-DE', 'en-US');
+  const rows = (result.data as any).blocks[0].component.options.configRows;
+
+  // Without the locale branch the SDK renders undefined and the rows disappear.
+  expect(rows['de-DE']).toEqual(rows.Default);
+});

--- a/packages/utils/src/translation-helpers.test.ts
+++ b/packages/utils/src/translation-helpers.test.ts
@@ -1592,12 +1592,10 @@ test('getTranslateableFields keeps sending every leaf when no exclusions are rec
 test('applyTranslation leaves excluded enum subfields untouched in the target locale', () => {
   const content = textColumnsContent(textColumnsMeta);
   const translation = getTranslateableFields(content, 'en-US', 'instructions');
-  const translated = Object.fromEntries(
-    Object.entries(translation).map(([key, field]) => [
-      key,
-      { ...field, value: 'DE ' + field.value },
-    ])
-  );
+  const translated: typeof translation = {};
+  Object.keys(translation).forEach(key => {
+    translated[key] = { ...translation[key], value: 'DE ' + translation[key].value };
+  });
 
   const result = applyTranslation(content, translated, 'de-DE', 'en-US');
   const columns = (result.data as any).blocks[0].component.options.textColumns['de-DE'];

--- a/packages/utils/src/translation-helpers.test.ts
+++ b/packages/utils/src/translation-helpers.test.ts
@@ -1493,3 +1493,169 @@ test('getTranslateableFields falls back to string leaves when a localized list h
     },
   });
 });
+
+function textColumnsContent(meta: Record<string, any>): BuilderContent {
+  return {
+    data: {
+      blocks: [
+        {
+          '@type': '@builder.io/sdk:Element',
+          id: 'builder-textcolumns',
+          meta,
+          component: {
+            name: 'TextColumns',
+            options: {
+              textColumns: {
+                '@type': localizedType,
+                Default: [
+                  {
+                    headline: 'Get paid faster',
+                    bodyText: 'Take card payments anywhere.',
+                    textColumnAlignment: 'Left',
+                    textRowAlignment: 'Bottom',
+                    backgroundColor: 'White',
+                  },
+                  {
+                    headline: 'Grow with insights',
+                    bodyText: 'See how your business is doing.',
+                    textColumnAlignment: 'Center',
+                    textRowAlignment: 'Top',
+                    backgroundColor: 'Grey',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    },
+  };
+}
+
+const textColumnsMeta = {
+  localizedTextInputs: ['textColumns'],
+  nonTranslatableInputs: [
+    'textColumns.*.textColumnAlignment',
+    'textColumns.*.textRowAlignment',
+    'textColumns.*.backgroundColor',
+  ],
+};
+
+test('getTranslateableFields skips enum subfields listed in nonTranslatableInputs', () => {
+  const result = getTranslateableFields(
+    textColumnsContent(textColumnsMeta),
+    'en-US',
+    'instructions'
+  );
+
+  expect(result).toEqual({
+    'blocks.builder-textcolumns#textColumns#0#headline': {
+      value: 'Get paid faster',
+      instructions: 'instructions',
+    },
+    'blocks.builder-textcolumns#textColumns#0#bodyText': {
+      value: 'Take card payments anywhere.',
+      instructions: 'instructions',
+    },
+    'blocks.builder-textcolumns#textColumns#1#headline': {
+      value: 'Grow with insights',
+      instructions: 'instructions',
+    },
+    'blocks.builder-textcolumns#textColumns#1#bodyText': {
+      value: 'See how your business is doing.',
+      instructions: 'instructions',
+    },
+  });
+});
+
+test('getTranslateableFields keeps sending every leaf when no exclusions are recorded', () => {
+  const result = getTranslateableFields(
+    textColumnsContent({ localizedTextInputs: ['textColumns'] }),
+    'en-US',
+    'instructions'
+  );
+
+  expect(Object.keys(result).sort()).toEqual([
+    'blocks.builder-textcolumns#textColumns#0#backgroundColor',
+    'blocks.builder-textcolumns#textColumns#0#bodyText',
+    'blocks.builder-textcolumns#textColumns#0#headline',
+    'blocks.builder-textcolumns#textColumns#0#textColumnAlignment',
+    'blocks.builder-textcolumns#textColumns#0#textRowAlignment',
+    'blocks.builder-textcolumns#textColumns#1#backgroundColor',
+    'blocks.builder-textcolumns#textColumns#1#bodyText',
+    'blocks.builder-textcolumns#textColumns#1#headline',
+    'blocks.builder-textcolumns#textColumns#1#textColumnAlignment',
+    'blocks.builder-textcolumns#textColumns#1#textRowAlignment',
+  ]);
+});
+
+test('applyTranslation leaves excluded enum subfields untouched in the target locale', () => {
+  const content = textColumnsContent(textColumnsMeta);
+  const translation = getTranslateableFields(content, 'en-US', 'instructions');
+  const translated = Object.fromEntries(
+    Object.entries(translation).map(([key, field]) => [
+      key,
+      { ...field, value: 'DE ' + field.value },
+    ])
+  );
+
+  const result = applyTranslation(content, translated, 'de-DE', 'en-US');
+  const columns = (result.data as any).blocks[0].component.options.textColumns['de-DE'];
+
+  expect(columns).toEqual([
+    {
+      headline: 'DE Get paid faster',
+      bodyText: 'DE Take card payments anywhere.',
+      textColumnAlignment: 'Left',
+      textRowAlignment: 'Bottom',
+      backgroundColor: 'White',
+    },
+    {
+      headline: 'DE Grow with insights',
+      bodyText: 'DE See how your business is doing.',
+      textColumnAlignment: 'Center',
+      textRowAlignment: 'Top',
+      backgroundColor: 'Grey',
+    },
+  ]);
+});
+
+test('getTranslateableFields excludes an enum subfield that is itself a LocalizedValue', () => {
+  const content: BuilderContent = {
+    data: {
+      blocks: [
+        {
+          '@type': '@builder.io/sdk:Element',
+          id: 'builder-marked',
+          meta: {
+            localizedTextInputs: ['cards'],
+            nonTranslatableInputs: ['cards.*.alignment'],
+          },
+          component: {
+            name: 'Cards',
+            options: {
+              cards: {
+                '@type': localizedType,
+                Default: [
+                  {
+                    headline: { '@type': localizedType, Default: 'Marked headline' },
+                    alignment: { '@type': localizedType, Default: 'Left' },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    },
+  };
+
+  const result = getTranslateableFields(content, 'en-US', 'instructions');
+
+  expect(result).toEqual({
+    'blocks.builder-marked#cards#0#headline': {
+      value: 'Marked headline',
+      instructions: 'instructions',
+    },
+  });
+});

--- a/packages/utils/src/translation-helpers.ts
+++ b/packages/utils/src/translation-helpers.ts
@@ -195,8 +195,7 @@ function resolveTranslation({
   }
 }
 
-// Numeric segments collapse to `*` so a schema path recorded off list item 0 covers
-// every item, and `.` / `#` separators compare equally.
+// List indices collapse to a wildcard, and `.` / `#` separators compare equally.
 function toComparablePath(path: string) {
   return path
     .split(/[.#]/)
@@ -204,9 +203,7 @@ function toComparablePath(path: string) {
     .join('.');
 }
 
-// The editor records, per block, the schema paths of inputs that hold configuration
-// rather than prose (enums, numbers, colors...). Without it the extractor cannot tell
-// a headline from a `Left` / `Bottom` dropdown value and ships both to the provider.
+// Recorded by the editor, since the extractor has no access to component schemas.
 function getExcludedPaths(nonTranslatableInputs: unknown, blockId: string): Set<string> | undefined {
   if (!Array.isArray(nonTranslatableInputs) || !nonTranslatableInputs.length) {
     return undefined;
@@ -315,8 +312,7 @@ function extractLocalizedLeaves(
     const nested = value[sourceLocaleId] != null ? value[sourceLocaleId] : value.Default;
     const nestedInstructions = value.meta?.instructions || instructions;
     if (typeof nested === 'string') {
-      // Still counts as a localized leaf when excluded, so the caller does not treat the
-      // payload as unmarked and fall back to sweeping up every string.
+      // Counts even when excluded, else the caller sweeps up every string instead.
       if (nested && !isExcludedPath(excluded, basePath)) {
         results[basePath] = { value: nested, instructions: nestedInstructions };
       }
@@ -437,6 +433,11 @@ export function getTranslateableFields(
                   : inputValue?.Default;
               const instructions = el.meta?.instructions || defaultInstructions;
               const path = `blocks.${el.id}#${inputKey}`;
+
+              // Only an exact match on the input's own path skips; a list keeps its other leaves.
+              if (isExcludedPath(excludedPaths, path)) {
+                return;
+              }
 
               if (typeof valueToBeTranslated === 'string') {
                 if (valueToBeTranslated) {
@@ -799,6 +800,8 @@ export function applyTranslation(
       if (el && el.id && el.meta?.localizedTextInputs && !isExcluded) {
         // there's a localized input
         const keys = el.meta?.localizedTextInputs as string[];
+        // Jobs created before the exclusions existed still carry translated enum values.
+        const excludedPaths = getExcludedPaths(el.meta.nonTranslatableInputs, el.id);
         let options = el.component.options;
 
         const markTranslated = () => {
@@ -818,6 +821,28 @@ export function applyTranslation(
         keys.forEach(key => {
           const flatKey = `blocks.${el.id}#${key}`;
           const existing = get(options, key);
+
+          const sourceValue =
+            sourceLocaleId && existing?.[sourceLocaleId] != null
+              ? existing[sourceLocaleId]
+              : existing?.Default;
+
+          // The SDK resolves a missing locale key to undefined, not to Default.
+          const seedSourceIntoLocale = () => {
+            if (!existing || existing[locale] != null || sourceValue == null) {
+              return;
+            }
+            const seeded = JSON.parse(JSON.stringify(sourceValue));
+            seedLocaleBranches(seeded, locale, sourceLocaleId);
+            set(options, key, { ...existing, [locale]: seeded });
+            markTranslated();
+          };
+
+          // Guards every branch below, including the legacy whole-payload write.
+          if (isExcludedPath(excludedPaths, flatKey)) {
+            seedSourceIntoLocale();
+            return;
+          }
 
           const flatValue = translation[flatKey]?.value;
           const writeFlatValue = () => {
@@ -847,15 +872,16 @@ export function applyTranslation(
           // Leaves were extracted as `${flatKey}#0#title`: clone the source, patch each
           // leaf, store under the locale.
           const prefix = `${flatKey}#`;
-          const compoundKeys = Object.keys(translation).filter(k => k.startsWith(prefix));
+          const matchingKeys = Object.keys(translation).filter(k => k.startsWith(prefix));
+          const compoundKeys = matchingKeys.filter(k => !isExcludedPath(excludedPaths, k));
           if (!compoundKeys.length) {
+            // Distinct from the provider returning nothing, which must leave the locale alone.
+            if (matchingKeys.length) {
+              seedSourceIntoLocale();
+            }
             return;
           }
 
-          const sourceValue =
-            sourceLocaleId && existing?.[sourceLocaleId] != null
-              ? existing[sourceLocaleId]
-              : existing?.Default;
           if (sourceValue === null || sourceValue === undefined) {
             return;
           }

--- a/packages/utils/src/translation-helpers.ts
+++ b/packages/utils/src/translation-helpers.ts
@@ -838,6 +838,19 @@ export function applyTranslation(
             markTranslated();
           };
 
+          // Same walk extraction uses, so an input it never sent is told apart from one the
+          // provider simply has not answered yet.
+          const hasTranslatableLeaf = () => {
+            const probe: TranslateableFields = {};
+            const sourceLocale = sourceLocaleId ?? '';
+            if (
+              extractLocalizedLeaves(sourceValue, flatKey, probe, '', sourceLocale, excludedPaths) === 0
+            ) {
+              extractNestedStrings(sourceValue, flatKey, probe, '', sourceLocale, excludedPaths);
+            }
+            return Object.keys(probe).length > 0;
+          };
+
           // Guards every branch below, including the legacy whole-payload write.
           if (isExcludedPath(excludedPaths, flatKey)) {
             seedSourceIntoLocale();
@@ -875,8 +888,9 @@ export function applyTranslation(
           const matchingKeys = Object.keys(translation).filter(k => k.startsWith(prefix));
           const compoundKeys = matchingKeys.filter(k => !isExcludedPath(excludedPaths, k));
           if (!compoundKeys.length) {
-            // Distinct from the provider returning nothing, which must leave the locale alone.
-            if (matchingKeys.length) {
+            // Everything came back excluded, or there was never anything to send. Both differ
+            // from the provider not having answered yet, which must leave the locale alone.
+            if (matchingKeys.length || (excludedPaths && !hasTranslatableLeaf())) {
               seedSourceIntoLocale();
             }
             return;

--- a/packages/utils/src/translation-helpers.ts
+++ b/packages/utils/src/translation-helpers.ts
@@ -195,6 +195,33 @@ function resolveTranslation({
   }
 }
 
+// Numeric segments collapse to `*` so a schema path recorded off list item 0 covers
+// every item, and `.` / `#` separators compare equally.
+function toComparablePath(path: string) {
+  return path
+    .split(/[.#]/)
+    .map(segment => (/^\d+$/.test(segment) ? '*' : segment))
+    .join('.');
+}
+
+// The editor records, per block, the schema paths of inputs that hold configuration
+// rather than prose (enums, numbers, colors...). Without it the extractor cannot tell
+// a headline from a `Left` / `Bottom` dropdown value and ships both to the provider.
+function getExcludedPaths(nonTranslatableInputs: unknown, blockId: string): Set<string> | undefined {
+  if (!Array.isArray(nonTranslatableInputs) || !nonTranslatableInputs.length) {
+    return undefined;
+  }
+  return new Set(
+    nonTranslatableInputs
+      .filter((entry): entry is string => typeof entry === 'string' && !!entry)
+      .map(entry => toComparablePath(`blocks.${blockId}#${entry}`))
+  );
+}
+
+function isExcludedPath(excluded: Set<string> | undefined, basePath: string) {
+  return excluded ? excluded.has(toComparablePath(basePath)) : false;
+}
+
 // Recursively walks an already-extracted LocalizedValue payload (array or object)
 // and records individual string leaves as separate translation entries.
 function extractNestedStrings(
@@ -202,15 +229,23 @@ function extractNestedStrings(
   basePath: string,
   results: TranslateableFields,
   instructions: string,
-  sourceLocaleId: string
+  sourceLocaleId: string,
+  excluded?: Set<string>
 ) {
   if (typeof value === 'string') {
-    if (value) {
+    if (value && !isExcludedPath(excluded, basePath)) {
       results[basePath] = { value, instructions };
     }
   } else if (Array.isArray(value)) {
     value.forEach((item, index) => {
-      extractNestedStrings(item, `${basePath}#${index}`, results, instructions, sourceLocaleId);
+      extractNestedStrings(
+        item,
+        `${basePath}#${index}`,
+        results,
+        instructions,
+        sourceLocaleId,
+        excluded
+      );
     });
   } else if (typeof value === 'object' && value !== null) {
     if (value['@type'] === localizedType) {
@@ -218,13 +253,29 @@ function extractNestedStrings(
       const nested = value[sourceLocaleId] || value.Default;
       const nestedInstructions = value.meta?.instructions || instructions;
       if (typeof nested === 'string' && nested) {
-        results[basePath] = { value: nested, instructions: nestedInstructions };
+        if (!isExcludedPath(excluded, basePath)) {
+          results[basePath] = { value: nested, instructions: nestedInstructions };
+        }
       } else if (nested !== null && nested !== undefined) {
-        extractNestedStrings(nested, basePath, results, nestedInstructions, sourceLocaleId);
+        extractNestedStrings(
+          nested,
+          basePath,
+          results,
+          nestedInstructions,
+          sourceLocaleId,
+          excluded
+        );
       }
     } else {
       Object.entries(value).forEach(([key, v]) => {
-        extractNestedStrings(v, `${basePath}#${key}`, results, instructions, sourceLocaleId);
+        extractNestedStrings(
+          v,
+          `${basePath}#${key}`,
+          results,
+          instructions,
+          sourceLocaleId,
+          excluded
+        );
       });
     }
   }
@@ -237,13 +288,21 @@ function extractLocalizedLeaves(
   basePath: string,
   results: TranslateableFields,
   instructions: string,
-  sourceLocaleId: string
+  sourceLocaleId: string,
+  excluded?: Set<string>
 ): number {
   if (Array.isArray(value)) {
     return value.reduce(
       (found: number, item, index) =>
         found +
-        extractLocalizedLeaves(item, `${basePath}#${index}`, results, instructions, sourceLocaleId),
+        extractLocalizedLeaves(
+          item,
+          `${basePath}#${index}`,
+          results,
+          instructions,
+          sourceLocaleId,
+          excluded
+        ),
       0
     );
   }
@@ -256,7 +315,9 @@ function extractLocalizedLeaves(
     const nested = value[sourceLocaleId] != null ? value[sourceLocaleId] : value.Default;
     const nestedInstructions = value.meta?.instructions || instructions;
     if (typeof nested === 'string') {
-      if (nested) {
+      // Still counts as a localized leaf when excluded, so the caller does not treat the
+      // payload as unmarked and fall back to sweeping up every string.
+      if (nested && !isExcludedPath(excluded, basePath)) {
         results[basePath] = { value: nested, instructions: nestedInstructions };
       }
       return 1;
@@ -268,10 +329,18 @@ function extractLocalizedLeaves(
         basePath,
         results,
         nestedInstructions,
-        sourceLocaleId
+        sourceLocaleId,
+        excluded
       );
       if (deeper === 0) {
-        extractNestedStrings(nested, basePath, results, nestedInstructions, sourceLocaleId);
+        extractNestedStrings(
+          nested,
+          basePath,
+          results,
+          nestedInstructions,
+          sourceLocaleId,
+          excluded
+        );
       }
     }
     return 1;
@@ -280,7 +349,14 @@ function extractLocalizedLeaves(
   return Object.entries(value).reduce(
     (found: number, [key, v]) =>
       found +
-      extractLocalizedLeaves(v, `${basePath}#${key}`, results, instructions, sourceLocaleId),
+      extractLocalizedLeaves(
+        v,
+        `${basePath}#${key}`,
+        results,
+        instructions,
+        sourceLocaleId,
+        excluded
+      ),
     0
   );
 }
@@ -348,6 +424,7 @@ export function getTranslateableFields(
 
       if (this.key && el && el.meta?.localizedTextInputs && !isExcluded) {
         const localizedTextInputs = el.meta.localizedTextInputs as string[];
+        const excludedPaths = getExcludedPaths(el.meta.nonTranslatableInputs, el.id);
         if (localizedTextInputs && Array.isArray(localizedTextInputs)) {
           localizedTextInputs
             .filter(input => get(el.component?.options || {}, `${input}.@type`) === localizedType)
@@ -379,7 +456,8 @@ export function getTranslateableFields(
                 path,
                 results,
                 instructions,
-                sourceLocaleId
+                sourceLocaleId,
+                excludedPaths
               );
               if (localizedLeaves === 0) {
                 extractNestedStrings(
@@ -387,7 +465,8 @@ export function getTranslateableFields(
                   path,
                   results,
                   instructions,
-                  sourceLocaleId
+                  sourceLocaleId,
+                  excludedPaths
                 );
               }
             });


### PR DESCRIPTION
## Description

A customer reported that Smartling translation jobs were full of junk strings like White, Left, and Bottom. These are dropdown (enum) values from custom component fields (these are settings, not text anyone should translate)

**Root Cause:**
When a custom component has a `localized` list field, `getTranslateableFields` first looks for child values that are individually marked as localized. If it doesn't find any, it falls back to grabbing every string inside the list.

That fallback isn't a bug on its own, it's what makes ordinary lists translatable and there's a test pinning it. The real issue is that the extractor has no way to tell a **headline** from a **dropdown value**. It runs on the server against raw content JSON, and a component's `inputs` schema only exists in the app code. The server never sees enum: ["Left", "Center", "Right"].

**Fix:**
Blocks can now carry a list of input paths that should be non-translatable:
```
meta.nonTranslatableInputs: [
  'textColumns.*.textColumnAlignment',
  'textColumns.*.textRowAlignment',
  'textColumns.*.backgroundColor',
]
```
`getTranslateableFields` reads that list and skips those leaves. The * stands in for list indices, so one item's schema covers the whole list.

**Link to JIRA ticket (if applicable):**
https://builder-io.atlassian.net/browse/ENG-13615

**Screenshot/Clip**
https://clips.agent-native.com/r/ATlR8Yi3xWgq



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core translation extract/apply logic for custom components; incorrect path matching could omit real copy or mishandle locale seeding, though behavior without `nonTranslatableInputs` is explicitly preserved by tests.
> 
> **Overview**
> Stops **dropdown/enum values** (e.g. alignment, background color) from being sent to translation providers when custom components use localized list fields whose string leaves were previously all extracted.
> 
> Blocks can declare **`meta.nonTranslatableInputs`** with wildcard paths (`textColumns.*.textColumnAlignment`). **`getTranslateableFields`** normalizes paths (indices → `*`, `#`/`.` equivalent) and omits those leaves during nested extraction; behavior is unchanged when the list is empty.
> 
> **`applyTranslation`** mirrors the same exclusions: it drops compound keys for excluded paths, **ignores legacy job payloads** that still contain translated enums, and **seeds the target locale from source** when an input has no translatable leaves (so lists do not resolve to `undefined` and disappear). Broad test coverage was added for TextColumns-style scenarios and all-excluded inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb6ba9b1f5f4670db49d31705d2ca44786bc18bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->