### PR TITLE
fix[sdk][studio]: ENG-13439 boolean targeting in Builder Studio

### DIFF
--- a/.changeset/mighty-phones-dress.md
+++ b/.changeset/mighty-phones-dress.md
@@ -1,0 +1,12 @@
+---
+'@builder.io/sdk-angular': patch
+'@builder.io/sdk-react-nextjs': patch
+'@builder.io/sdk-qwik': patch
+'@builder.io/sdk-react': patch
+'@builder.io/sdk-react-native': patch
+'@builder.io/sdk-solid': patch
+'@builder.io/sdk-svelte': patch
+'@builder.io/sdk-vue': patch
+---
+
+Fix boolean user attributes in Builder Studio targeting requests.

--- a/packages/sdks/src/functions/get-content/generate-content-url.test.ts
+++ b/packages/sdks/src/functions/get-content/generate-content-url.test.ts
@@ -264,4 +264,33 @@ describe('Generate Content URL', () => {
     });
     expect(output).toMatchSnapshot();
   });
+
+  test('converts Studio boolean user attributes from query parameters', () => {
+    vi.stubGlobal('window', {
+      location: {
+        search:
+          '?builder.preview=BUILDER_STUDIO&builder.userAttributes.isLoggedIn=true&builder.userAttributes.isGuest=false&builder.userAttributes.audience=members',
+        pathname: '/products',
+        host: 'www.example.com',
+      },
+    });
+    vi.stubGlobal('document', {});
+
+    try {
+      const output = generateContentUrl({
+        apiKey: testKey,
+        model: testModel,
+      });
+
+      expect(JSON.parse(output.searchParams.get('userAttributes')!)).toEqual({
+        isLoggedIn: true,
+        isGuest: false,
+        audience: 'members',
+        urlPath: '/products',
+        host: 'www.example.com',
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 });

--- a/packages/sdks/src/functions/get-content/generate-content-url.ts
+++ b/packages/sdks/src/functions/get-content/generate-content-url.ts
@@ -118,11 +118,17 @@ export const generateContentUrl = (options: GetContentOptions): URL => {
   return url;
 };
 
+const parseStudioUserAttribute = (value: unknown) => {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return value;
+};
+
 const getUserAttributesFromQueryOptions = (queryOptions: any) => {
   const newUserAttributes: any = {};
   for (const key in queryOptions) {
     if (key.startsWith('userAttributes.')) {
-      newUserAttributes[key] = queryOptions[key];
+      newUserAttributes[key] = parseStudioUserAttribute(queryOptions[key]);
       delete queryOptions[key];
     }
   }


### PR DESCRIPTION
## Description
- This fixes boolean targeting rules that failed because Studio sent string values instead of booleans.
- Convert Studio user attribute values `"true"` and `"false"` back to booleans before sending the Content API request.

**Link to JIRA ticket (if applicable):**
https://builder-io.atlassian.net/browse/ENG-13439

**Screenshot/Clip**
Clip - https://clips.agent-native.com/share/A3fWy4lLi4dJ?ref=clip_share

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, Studio-preview-only change to query parsing with a focused unit test; no auth or persistence impact.
> 
> **Overview**
> Fixes **boolean targeting** in Builder Studio preview by normalizing user-attribute query values before they are sent to the Content API.
> 
> When `preview=BUILDER_STUDIO`, `builder.userAttributes.*` URL params are parsed via `parseStudioUserAttribute`, which turns string `"true"` / `"false"` into real booleans (other values stay unchanged). A test covers mixed boolean and string attributes plus the existing `urlPath` / `host` injection.
> 
> Patch bumps all framework SDK packages via changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9861b0c41f16f562bcc6777beafa73f95acb6be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->