### PR TITLE
chore[utils][smartling]: bump up versions of utils and smartling plugin

### DIFF
--- a/packages/utils/package-lock.json
+++ b/packages/utils/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@builder.io/utils",
-  "version": "1.1.31",
+  "version": "1.1.32",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/utils",
-      "version": "1.1.31",
+      "version": "1.1.32",
       "dependencies": {
         "@types/lodash": "^4.14.182",
         "lodash": "^4.17.21",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/utils",
-  "version": "1.1.31",
+  "version": "1.1.32",
   "description": "Utils for working with Builder.io content",
   "main": "./dist/index.js",
   "scripts": {

--- a/plugins/smartling/package-lock.json
+++ b/plugins/smartling/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@builder.io/plugin-smartling",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@builder.io/plugin-smartling",
-      "version": "0.1.3",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
-        "@builder.io/utils": "1.1.31",
+        "@builder.io/utils": "1.1.32",
         "fast-json-stable-stringify": "^2.1.0",
         "lodash": "^4.18.1",
         "object-hash": "^3.0.0",
@@ -1487,9 +1487,9 @@
       }
     },
     "node_modules/@builder.io/utils": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/@builder.io/utils/-/utils-1.1.31.tgz",
-      "integrity": "sha512-ApC6OFJb/IMacy+YwcZeMr61k/8NnWOlg3eyl67gFFADmtjsa/ZwulMgyUbqPUF7158JqcpgAab1MC9LMCIZSA==",
+      "version": "1.1.32",
+      "resolved": "https://registry.npmjs.org/@builder.io/utils/-/utils-1.1.32.tgz",
+      "integrity": "sha512-X9KjXsX/mhAbafAjAjTWHr1jPZnsLgpn97EE4SORCXr9DCYpkdlarw9u8JSpPJzOZIkxKViZ19HJyr0fJxoV8w==",
       "dependencies": {
         "@types/lodash": "^4.14.182",
         "lodash": "^4.17.21",
@@ -18307,39 +18307,6 @@
         "rc": "cli.js"
       }
     },
-    "node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
     "node_modules/react-event-listener": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.6.tgz",
@@ -19285,18 +19252,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
-    },
-    "node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
     },
     "node_modules/semantic-release": {
       "version": "21.0.1",
@@ -23411,9 +23366,9 @@
       }
     },
     "@builder.io/utils": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/@builder.io/utils/-/utils-1.1.31.tgz",
-      "integrity": "sha512-ApC6OFJb/IMacy+YwcZeMr61k/8NnWOlg3eyl67gFFADmtjsa/ZwulMgyUbqPUF7158JqcpgAab1MC9LMCIZSA==",
+      "version": "1.1.32",
+      "resolved": "https://registry.npmjs.org/@builder.io/utils/-/utils-1.1.32.tgz",
+      "integrity": "sha512-X9KjXsX/mhAbafAjAjTWHr1jPZnsLgpn97EE4SORCXr9DCYpkdlarw9u8JSpPJzOZIkxKViZ19HJyr0fJxoV8w==",
       "requires": {
         "@types/lodash": "^4.14.182",
         "lodash": "^4.18.1",
@@ -24786,8 +24741,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "7.0.1",
@@ -31231,8 +31185,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "29.4.3",
@@ -32013,15 +31966,13 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
       "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jss-global": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
       "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jss-nested": {
       "version": "6.0.1",
@@ -32047,8 +31998,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
       "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jss-vendor-prefixer": {
       "version": "7.0.0",
@@ -33087,15 +33037,13 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.4.0.tgz",
       "integrity": "sha512-bRuZp3C0itgLKHu/VNxi66DN/XVkQG7xtoBVWxpvC5FhAqbOCP21+nPhULjnzEqd7xBMybp6KwytdUpZKEgpIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "mobx-state-tree": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.1.5.tgz",
       "integrity": "sha512-jugIic0PYWW+nzzYfp4RUy9dec002Z778OC6KzoOyBHnqxupK9iPCsUJYkHjmNRHjZ8E4Z7qQpsKV3At/ntGVw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "modify-values": {
       "version": "1.0.1",
@@ -35982,31 +35930,6 @@
         "strip-json-comments": "~2.0.1"
       }
     },
-    "react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      }
-    },
-    "react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      }
-    },
     "react-event-listener": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.6.tgz",
@@ -36762,17 +36685,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
-    },
-    "scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
     },
     "semantic-release": {
       "version": "21.0.1",

--- a/plugins/smartling/package-lock.json
+++ b/plugins/smartling/package-lock.json
@@ -18307,6 +18307,39 @@
         "rc": "cli.js"
       }
     },
+    "node_modules/react": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0"
+      }
+    },
     "node_modules/react-event-listener": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.6.tgz",
@@ -19252,6 +19285,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "node_modules/scheduler": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "node_modules/semantic-release": {
       "version": "21.0.1",
@@ -24741,7 +24786,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "7.0.1",
@@ -31185,7 +31231,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "29.4.3",
@@ -31966,13 +32013,15 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
       "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jss-global": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
       "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jss-nested": {
       "version": "6.0.1",
@@ -31998,7 +32047,8 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
       "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jss-vendor-prefixer": {
       "version": "7.0.0",
@@ -33037,13 +33087,15 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.4.0.tgz",
       "integrity": "sha512-bRuZp3C0itgLKHu/VNxi66DN/XVkQG7xtoBVWxpvC5FhAqbOCP21+nPhULjnzEqd7xBMybp6KwytdUpZKEgpIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "mobx-state-tree": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.1.5.tgz",
       "integrity": "sha512-jugIic0PYWW+nzzYfp4RUy9dec002Z778OC6KzoOyBHnqxupK9iPCsUJYkHjmNRHjZ8E4Z7qQpsKV3At/ntGVw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "modify-values": {
       "version": "1.0.1",
@@ -35930,6 +35982,31 @@
         "strip-json-comments": "~2.0.1"
       }
     },
+    "react": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "react-dom": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
+      }
+    },
     "react-event-listener": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.6.tgz",
@@ -36685,6 +36762,17 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "scheduler": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "semantic-release": {
       "version": "21.0.1",

--- a/plugins/smartling/package.json
+++ b/plugins/smartling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/plugin-smartling",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "description": "",
   "keywords": [],
   "main": "dist/plugin.system.js",
@@ -125,7 +125,7 @@
     "typescript": "^3.0.3"
   },
   "dependencies": {
-    "@builder.io/utils": "1.1.31",
+    "@builder.io/utils": "1.1.32",
     "fast-json-stable-stringify": "^2.1.0",
     "lodash": "^4.18.1",
     "object-hash": "^3.0.0",


### PR DESCRIPTION
## Description

Add a short description of what changes you made, why you made them, and any other context that you think might be helpful for someone to better understand what is contained in this pull request. This sort of information is useful for people reviewing the code, as well as anyone from the future trying to understand why changes were made or why a bug started happening.

**Link to JIRA ticket (if applicable):**
https://builder-io.atlassian.net/browse/...

**Screenshot/Clip**
If relevant, add a screenshot or clip of the changes you made.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and lockfile-only changes with no code diffs; risk is limited to consumers picking up the new published package versions.
> 
> **Overview**
> **Release-only PR** with no application source changes—only package metadata and lockfiles.
> 
> Bumps **`@builder.io/utils`** from `1.1.31` to **`1.1.32`** in `packages/utils` (`package.json` and `package-lock.json`).
> 
> Bumps **`@builder.io/plugin-smartling`** from `0.1.3` to **`0.1.5`** and pins its dependency on **`@builder.io/utils`** to **`1.1.32`**, with matching updates in `plugins/smartling/package-lock.json` (resolved tarball and integrity for utils).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93a342757cbb1b3eba86fb187c7a5bcf13c5498d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->