### PR TITLE
fix[abTests][gen1]: ENG-13175 A/B Variation Hydration Mismatch on First Server Render

### DIFF
--- a/.changeset/tricky-pugs-invite.md
+++ b/.changeset/tricky-pugs-invite.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/react': patch
+---
+
+Fix: A/B test variation previews no longer flash the default variation before switching. The `builder.tests.<contentId>` URL parameter is now applied when the SSR variants script selects a variation, so the first paint matches what React renders during hydration.

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -2,10 +2,6 @@ module.exports = {
   testEnvironment: 'jest-environment-jsdom',
   setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect', '<rootDir>/test/setupTests.ts'],
   testMatch: ['**/?(*.)test.ts?(x)'],
-  // matches the `baseUrl` in tsconfig.json, which allows `src/...` imports
-  moduleNameMapper: {
-    '^src/(.*)$': '<rootDir>/src/$1',
-  },
   globals: {
     'ts-jest': {
       tsConfig: 'tsconfig.json',

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -2,6 +2,10 @@ module.exports = {
   testEnvironment: 'jest-environment-jsdom',
   setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect', '<rootDir>/test/setupTests.ts'],
   testMatch: ['**/?(*.)test.ts?(x)'],
+  // matches the `baseUrl` in tsconfig.json, which allows `src/...` imports
+  moduleNameMapper: {
+    '^src/(.*)$': '<rootDir>/src/$1',
+  },
   globals: {
     'ts-jest': {
       tsConfig: 'tsconfig.json',

--- a/packages/react/src/components/variants-provider.component.tsx
+++ b/packages/react/src/components/variants-provider.component.tsx
@@ -18,6 +18,28 @@ function getData(content: BuilderContentVariation) {
   return newData;
 }
 
+// Mirrors the precedence used by the inlined variants script below, so that the DOM
+// the script produces before hydration matches what React renders while hydrating.
+function getVariantIdFromUrl(contentId: string) {
+  const search = (Builder.isBrowser && location.search) || '';
+  if (search.indexOf('builder') === -1) {
+    return null;
+  }
+  const names = ['builder.tests.' + contentId, 'builder_tests_' + contentId];
+  const entries = (search.charAt(0) === '?' ? search.substring(1) : search).split('&');
+  for (const entry of entries) {
+    const parts = entry.split('=');
+    if (names.indexOf(parts[0]) > -1) {
+      try {
+        return decodeURIComponent(parts[1] || '');
+      } catch (err) {
+        return parts[1] || null;
+      }
+    }
+  }
+  return null;
+}
+
 const variantsScript = (variantsString: string, contentId: string) =>
   `
 (function() {
@@ -58,11 +80,34 @@ const variantsScript = (variantsString: string, contentId: string) =>
     }
     return null;
   }
+  function getVariantFromUrl() {
+    var search = location.search || '';
+    if (search.indexOf('builder') === -1) {
+      return null;
+    }
+    var names = ['builder.tests.${contentId}', 'builder_tests_${contentId}'];
+    var entries = (search.charAt(0) === '?' ? search.substring(1) : search).split('&');
+    for (var i = 0; i < entries.length; i++) {
+      var parts = entries[i].split('=');
+      if (names.indexOf(parts[0]) > -1) {
+        try {
+          return decodeURIComponent(parts[1] || '');
+        } catch (err) {
+          return parts[1] || null;
+        }
+      }
+    }
+    return null;
+  }
   var cookieName = 'builder.tests.${contentId}';
   var variantInCookie = getCookie(cookieName);
   var availableIDs = variants.map(function(vr) { return vr.id }).concat('${contentId}');
   var variantId;
-  if (availableIDs.indexOf(variantInCookie) > -1) {
+  var variantInUrl = getVariantFromUrl();
+  if (availableIDs.indexOf(variantInUrl) > -1) {
+    variantId = variantInUrl;
+    setCookie(cookieName, variantId);
+  } else if (availableIDs.indexOf(variantInCookie) > -1) {
     variantId = variantInCookie;
   }
   if (!variantId) {
@@ -141,7 +186,11 @@ export const VariantsProvider = ({ initialContent, children, nonce }: VariantsPr
 
   const cookieName = `builder.tests.${initialContent.id}`;
 
-  let variantId = builder.getCookie(cookieName);
+  const variantIdFromUrl = getVariantIdFromUrl(initialContent.id!);
+
+  let variantId = allVariants.some(item => item.id === variantIdFromUrl)
+    ? variantIdFromUrl
+    : builder.getCookie(cookieName);
 
   if (!variantId && Builder.isBrowser) {
     let n = 0;

--- a/packages/react/test/variants-ab-hydration.test.tsx
+++ b/packages/react/test/variants-ab-hydration.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"url": "https://example.com/?builder.tests.contentid1=variationa1"}
+ */
+import React from 'react';
+import { TextEncoder, TextDecoder } from 'util';
+
+Object.assign(global, { TextEncoder, TextDecoder });
+
+import { BuilderComponent } from '../src/components/builder-component.component';
+import { builder } from '@builder.io/sdk';
+
+builder.init('abc123');
+
+const CONTENT_ID = 'contentid1';
+const VARIATION_ID = 'variationa1';
+
+const textBlock = (text: string) => ({
+  '@type': '@builder.io/sdk:Element' as const,
+  id: 'blk-' + text,
+  component: { name: 'Text', options: { text } },
+});
+
+const content: any = {
+  id: CONTENT_ID,
+  name: 'test',
+  data: { blocks: [textBlock('CONTROL')] },
+  variations: {
+    [VARIATION_ID]: {
+      id: VARIATION_ID,
+      name: 'Variation A',
+      // Below the mocked Math.random (0.1234), so the random path never picks it.
+      testRatio: 0.05,
+      data: { blocks: [textBlock('VARIATION_A')] },
+    },
+  },
+};
+
+test('browser render honours the builder.tests url param when the cookie is unavailable', () => {
+  document.cookie = 'builder.tests.' + CONTENT_ID + '=; Max-Age=0; path=/';
+  expect(document.cookie).not.toContain(VARIATION_ID);
+
+  const { renderToString } = require('react-dom/server');
+  const html = renderToString(<BuilderComponent model="page" content={content} />);
+
+  // Must match what the inlined script put in the DOM before hydration.
+  expect(html).toContain('blk-VARIATION_A');
+  expect(html).not.toContain('blk-CONTROL');
+});

--- a/packages/react/test/variants-ab-hydration.test.tsx
+++ b/packages/react/test/variants-ab-hydration.test.tsx
@@ -2,6 +2,12 @@
  * @jest-environment jsdom
  * @jest-environment-options {"url": "https://example.com/?builder.tests.contentid1=variationa1"}
  */
+jest.mock(
+  'src/functions/extract-localized-values',
+  () => ({ containsLocalizedValues: () => false, extractLocalizedValues: () => ({}) }),
+  { virtual: true }
+);
+
 import React from 'react';
 import { TextEncoder, TextDecoder } from 'util';
 

--- a/packages/react/test/variants-ab-ssr.test.tsx
+++ b/packages/react/test/variants-ab-ssr.test.tsx
@@ -1,3 +1,9 @@
+jest.mock(
+  'src/functions/extract-localized-values',
+  () => ({ containsLocalizedValues: () => false, extractLocalizedValues: () => ({}) }),
+  { virtual: true }
+);
+
 import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { JSDOM } from 'jsdom';

--- a/packages/react/test/variants-ab-ssr.test.tsx
+++ b/packages/react/test/variants-ab-ssr.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { JSDOM } from 'jsdom';
+import { CookieJar } from 'tough-cookie';
+import { BuilderComponent } from '../src/components/builder-component.component';
+import { builder } from '@builder.io/sdk';
+
+builder.init('abc123');
+
+const CONTENT_ID = 'contentid1';
+const VARIATION_ID = 'variationa1';
+
+const textBlock = (text: string) => ({
+  '@type': '@builder.io/sdk:Element' as const,
+  id: 'blk-' + text,
+  component: { name: 'Text', options: { text } },
+});
+
+const getContent = () => ({
+  id: CONTENT_ID,
+  name: 'test',
+  data: { blocks: [textBlock('CONTROL')] },
+  variations: {
+    [VARIATION_ID]: {
+      id: VARIATION_ID,
+      name: 'Variation A',
+      // Lower than the mocked Math.random (0.1234), so the random path never
+      // picks this variation. Anything that selects it did so deliberately.
+      testRatio: 0.05,
+      data: { blocks: [textBlock('VARIATION_A')] },
+    },
+  },
+});
+
+const ssrHtml = () =>
+  renderToString(<BuilderComponent model="page" content={getContent() as any} />);
+
+/** Parses the SSR output in jsdom, which runs the inlined variants script as a browser would. */
+const runInBrowser = (html: string, { url, cookie }: { url: string; cookie?: string }) => {
+  const cookieJar = new CookieJar();
+  if (cookie) {
+    cookieJar.setCookieSync(cookie + '; Path=/', url);
+  }
+  const dom = new JSDOM('<html><body>' + html + '</body></html>', {
+    url,
+    cookieJar,
+    runScripts: 'dangerously',
+    // the inlined script runs inside this window, so it needs its own stub. 0.9999 is
+    // above every testRatio below, so the random path always lands on the control.
+    beforeParse(window) {
+      window.Math.random = () => 0.9999;
+    },
+  });
+  return dom.window.document.body.innerHTML;
+};
+
+const CONTROL_BLOCK = 'blk-CONTROL';
+const VARIATION_BLOCK = 'blk-VARIATION_A';
+
+describe('SSR a/b test variant selection', () => {
+  test('inlined variants script is syntactically valid', () => {
+    const script = ssrHtml().match(/<script id="variants-script-[^"]+">([\s\S]*?)<\/script>/);
+    expect(script).toBeTruthy();
+    expect(() => new Function(script![1])).not.toThrow();
+  });
+
+  test('builder.tests url param wins over the random assignment', () => {
+    const text = runInBrowser(ssrHtml(), {
+      url: `https://example.com/?builder.tests.${CONTENT_ID}=${VARIATION_ID}`,
+    });
+    expect(text).toContain(VARIATION_BLOCK);
+    expect(text).not.toContain(CONTROL_BLOCK);
+  });
+
+  test('url param is ignored when it is not a known variation', () => {
+    const text = runInBrowser(ssrHtml(), {
+      url: `https://example.com/?builder.tests.${CONTENT_ID}=not-a-variation`,
+    });
+    expect(text).toContain(CONTROL_BLOCK);
+    expect(text).not.toContain(VARIATION_BLOCK);
+  });
+
+  test('falls back to the cookie when no url param is present', () => {
+    const text = runInBrowser(ssrHtml(), {
+      url: 'https://example.com/',
+      cookie: `builder.tests.${CONTENT_ID}=${VARIATION_ID}`,
+    });
+    expect(text).toContain(VARIATION_BLOCK);
+    expect(text).not.toContain(CONTROL_BLOCK);
+  });
+
+  test('falls back to the random assignment with no url param and no cookie', () => {
+    const text = runInBrowser(ssrHtml(), { url: 'https://example.com/' });
+    expect(text).toContain(CONTROL_BLOCK);
+    expect(text).not.toContain(VARIATION_BLOCK);
+  });
+});


### PR DESCRIPTION
## Description

When you preview a non-default A/B variation, the page briefly shows the default variation before switching to the one you asked for. This causes a layout shift and a React hydration error. Reloading fixes it, so it only happens on the first visit.

**Root Cause:**
The editor's preview link carries the chosen variation in the URL as `builder.tests.<contentId>=<variationId>`, but nothing reads it early enough:

- The server doesn't look at it, so the HTML ships all variations.
- The inlined variants script only checks the cookie. On a first visit there is no cookie, so it picks a variation at random, usually the default.
- The SDK then writes the URL's variation into the cookie, and React hydrates with that value. It no longer matches the DOM, so React re-renders and you see the switch.

**Fix:**
Both places that choose a variation now check the URL parameter first, then fall back to the cookie, then to the random assignment as before:

- the inlined SSR script, so the correct variation is on screen at first paint
- `VariantsProvider`'s browser branch, so hydration agrees with the DOM

The URL value is validated against the content's known variation ids, and is read at runtime in the browser, so nothing untrusted is written into the script. 

**Link to JIRA ticket (if applicable):**
https://builder-io.atlassian.net/browse/ENG-13175

**Screenshot/Clip**
Bug: https://clips.agent-native.com/r/lqL0Ngm5BL7m
Fix: https://clips.agent-native.com/r/ByaNuJ0mjqwo


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-paint A/B selection and cookie writes in a widely used React path; behavior is constrained by validating URL ids against known variations.
> 
> **Overview**
> Fixes a **flash of the default A/B variation** (and hydration mismatch) when previewing a variation via `builder.tests.<contentId>` on first visit.
> 
> **Variant selection precedence** is now aligned in two places: the **inlined SSR variants script** and **`VariantsProvider`’s browser path** both read `builder.tests.<contentId>` / `builder_tests_<contentId>` first (validated against known variation ids), then cookie, then random assignment. A valid URL choice is also written to the cookie in the inlined script so later logic stays consistent.
> 
> Adds **Jest coverage** for inlined script syntax, URL vs cookie vs random behavior in jsdom, and browser render matching the URL param when no cookie is set. Ships as a **patch** to `@builder.io/react` via changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab6cac2b9e1fa649445e2fd7929419392fc2b062. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->