### PR TITLE
feat[sdk]: forward enrichOptions to the Visual Editor

### DIFF
--- a/.changeset/enrich-options-editor-preview.md
+++ b/.changeset/enrich-options-editor-preview.md
@@ -1,0 +1,12 @@
+---
+'@builder.io/sdk-angular': patch
+'@builder.io/sdk-react-nextjs': patch
+'@builder.io/sdk-qwik': patch
+'@builder.io/sdk-react': patch
+'@builder.io/sdk-react-native': patch
+'@builder.io/sdk-solid': patch
+'@builder.io/sdk-svelte': patch
+'@builder.io/sdk-vue': patch
+---
+
+Add `enrichOptions` to `fetchOneEntry` and to `Content`, so reference enrichment can be constrained (`enrichLevel`, per-model `fields`/`omit`) and the Visual Editor is told which constraints your site fetches with.

--- a/packages/sdks/src/components/content-variants/content-variants.lite.tsx
+++ b/packages/sdks/src/components/content-variants/content-variants.lite.tsx
@@ -144,6 +144,7 @@ export default function ContentVariants(props: VariantsProviderProps) {
               canTrack={props.canTrack}
               locale={props.locale}
               enrich={props.enrich}
+              enrichOptions={props.enrichOptions}
               isSsrAbTest={state.shouldRenderVariants}
               blocksWrapper={props.blocksWrapper}
               blocksWrapperProps={props.blocksWrapperProps}
@@ -183,6 +184,7 @@ export default function ContentVariants(props: VariantsProviderProps) {
         canTrack={props.canTrack}
         locale={props.locale}
         enrich={props.enrich}
+        enrichOptions={props.enrichOptions}
         isSsrAbTest={state.shouldRenderVariants}
         blocksWrapper={props.blocksWrapper}
         blocksWrapperProps={props.blocksWrapperProps}

--- a/packages/sdks/src/components/content-variants/content-variants.types.ts
+++ b/packages/sdks/src/components/content-variants/content-variants.types.ts
@@ -2,6 +2,7 @@ import type {
   BuilderRenderContext,
   RegisteredComponent,
 } from '../../context/types.js';
+import type { EnrichOptions } from '../../functions/get-content/types.js';
 import type { ApiVersion } from '../../types/api-version.js';
 import type { BuilderContent } from '../../types/builder-content.js';
 import type { Nullable } from '../../types/typescript.js';
@@ -65,6 +66,14 @@ export interface ContentVariantsPrps extends ExtraFrameworkProps {
    * Enriching will Include multilevel references in the response. Defaults to `false`.
    */
   enrich?: boolean;
+
+  /**
+   * The `enrichOptions` used to fetch this content (optional).
+   *
+   * Passing the same value you passed to `fetchOneEntry` lets the Visual Editor
+   * resolve references in its preview the way your site fetches them.
+   */
+  enrichOptions?: EnrichOptions;
 
   /**
    * The element that wraps your content. Defaults to `<div>` ('ScrollView' in React Native).

--- a/packages/sdks/src/components/content/components/enable-editor.lite.tsx
+++ b/packages/sdks/src/components/content/components/enable-editor.lite.tsx
@@ -384,6 +384,7 @@ export default function EnableEditor(props: BuilderEditorProps) {
       setupBrowserForEditing({
         ...(props.locale ? { locale: props.locale } : {}),
         ...(props.enrich ? { enrich: props.enrich } : {}),
+        ...(props.enrichOptions ? { enrichOptions: props.enrichOptions } : {}),
         ...(props.trustedHosts ? { trustedHosts: props.trustedHosts } : {}),
         modelName: props.model ?? '',
         apiKey: props.apiKey,

--- a/packages/sdks/src/components/content/content.lite.tsx
+++ b/packages/sdks/src/components/content/content.lite.tsx
@@ -223,6 +223,7 @@ export default function ContentComponent(props: ContentProps) {
       canTrack={props.canTrack}
       locale={props.locale}
       enrich={props.enrich}
+      enrichOptions={props.enrichOptions}
       showContent={props.showContent}
       builderContextSignal={builderContextSignal}
       contentWrapper={props.contentWrapper}

--- a/packages/sdks/src/functions/get-content/generate-content-url.test.ts
+++ b/packages/sdks/src/functions/get-content/generate-content-url.test.ts
@@ -130,6 +130,31 @@ describe('Generate Content URL', () => {
     expect(output).toMatchSnapshot();
   });
 
+  test('generate content url with enrichOptions serialized alongside enrich', () => {
+    const output = generateContentUrl({
+      apiKey: testKey,
+      model: testModel,
+      enrich: true,
+      enrichOptions: {
+        enrichLevel: 1,
+        model: { product: { fields: 'title,price' } },
+      },
+    });
+    expect(JSON.parse(output.searchParams.get('enrichOptions')!)).toEqual({
+      enrichLevel: 1,
+      model: { product: { fields: 'title,price' } },
+    });
+  });
+
+  test('generate content url omits enrichOptions when enrich is not set', () => {
+    const output = generateContentUrl({
+      apiKey: testKey,
+      model: testModel,
+      enrichOptions: { enrichLevel: 1 },
+    });
+    expect(output.searchParams.get('enrichOptions')).toBeNull();
+  });
+
   test('generate content url with enrich option not present', () => {
     const output = generateContentUrl({
       apiKey: testKey,

--- a/packages/sdks/src/functions/get-content/generate-content-url.ts
+++ b/packages/sdks/src/functions/get-content/generate-content-url.ts
@@ -20,6 +20,7 @@ export const generateContentUrl = (options: GetContentOptions): URL => {
     model,
     apiKey,
     enrich,
+    enrichOptions,
     locale,
     apiVersion = DEFAULT_API_VERSION,
     fields,
@@ -59,6 +60,11 @@ export const generateContentUrl = (options: GetContentOptions): URL => {
   let finalUserAttributes: Record<string, any> = userAttributes || {};
 
   if (enrich) url.searchParams.set('enrich', String(enrich));
+
+  // Only honored alongside `enrich=true` by the content API.
+  if (enrich && enrichOptions) {
+    url.searchParams.set('enrichOptions', JSON.stringify(enrichOptions));
+  }
 
   url.searchParams.set('omit', omit ?? 'meta.componentsUsed');
 

--- a/packages/sdks/src/functions/get-content/types.ts
+++ b/packages/sdks/src/functions/get-content/types.ts
@@ -1,3 +1,28 @@
+/**
+ * Options to configure how `enrich` resolves references.
+ *
+ * @see {@link https://www.builder.io/c/docs/content-api#code-enrich-options-code}
+ */
+export interface EnrichOptions {
+  /**
+   * How many levels of nested references to resolve. Higher levels multiply
+   * response size, so prefer the lowest level your content needs.
+   */
+  enrichLevel?: number;
+
+  /**
+   * Per-model field filters applied to resolved references.
+   */
+  model?: {
+    [modelName: string]: {
+      /** Comma-separated list of fields to include */
+      fields?: string;
+      /** Comma-separated list of fields to omit */
+      omit?: string;
+    };
+  };
+}
+
 export interface GetContentOptions {
   /** The model to get content for (required) */
   model: string;
@@ -64,6 +89,11 @@ export interface GetContentOptions {
    * Include multilevel references in the response.
    */
   enrich?: boolean;
+
+  /**
+   * Constrains how `enrich` resolves references. Only honored when `enrich` is `true`.
+   */
+  enrichOptions?: EnrichOptions;
 
   /**
    * If provided, the API will auto-resolve localized objects to the value of this `locale` key.

--- a/packages/sdks/src/scripts/init-editing.ts
+++ b/packages/sdks/src/scripts/init-editing.ts
@@ -1,5 +1,6 @@
 import { SDK_VERSION } from '../constants/sdk-version.js';
 import { TARGET } from '../constants/target.js';
+import type { EnrichOptions } from '../functions/get-content/types.js';
 import { isBrowser } from '../functions/is-browser.js';
 import { isFromTrustedHost } from '../functions/is-from-trusted-host.js';
 
@@ -8,6 +9,9 @@ export const setupBrowserForEditing = (options: {
   modelName: string;
   apiKey: string;
   enrich?: boolean;
+  // Forwarded to the editor as part of `builder.updateContent` below, so its
+  // preview can resolve references with the same constraints as this site's fetch.
+  enrichOptions?: EnrichOptions;
   includeRefs?: boolean;
   locale?: string;
   trustedHosts?: string[];


### PR DESCRIPTION
Pairs with BuilderIO/builder-internal#14691, which consumes this on the editor side.

## Why

The Visual Editor does not use the site's SDK to fetch references for its preview — it resolves them itself and postMessages the resolved content into the iframe. So it never learns how the site fetched them, and reference enrichment is unbounded by default (ENG-13486: a circular reference pair fanning out to ~269KB). The editor had to pick a bound blind.

The SDK already tells the editor `enrich`, `locale` and `modelName` through `builder.updateContent`. This adds `enrichOptions` to that same payload — no new message type.

## What

- `EnrichOptions` (`enrichLevel`, per-model `fields`/`omit`) added to `fetchOneEntry` options and to `Content` / `ContentVariants` props
- `setupBrowserForEditing` forwards it, so it rides the existing `builder.updateContent` `options`
- `generateContentUrl` applies it to the fetch, gated on `enrich` (the content API ignores `enrichOptions` without `enrich=true`), so the value you declare to the editor is one you can actually fetch with

Gen1 needed no change: `builder.class.ts` already posts its full get options, `enrichOptions` included.

## Usage

```ts
const enrichOptions = { enrichLevel: 1, model: { product: { fields: 'title,price' } } };
const content = await fetchOneEntry({ model: 'page', apiKey, enrich: true, enrichOptions });

<Content model="page" content={content} apiKey={apiKey} enrich enrichOptions={enrichOptions} />
```

## Testing

`tsc --noEmit` and eslint clean; 154 SDK tests pass, including two new `generate-content-url` cases (serialized alongside `enrich`, omitted without it). `build:all` (mitosis codegen per framework) not run — the change is a prop pass-through shaped exactly like the existing `enrich` prop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, optional API and prop pass-through with gating on `enrich`; main impact is fetch URL shape and editor preview alignment, not auth or persistence.
> 
> **Overview**
> Adds **`enrichOptions`** so reference enrichment can be bounded (`enrichLevel`, per-model `fields`/`omit`) on content fetches and in the Visual Editor preview.
> 
> A new **`EnrichOptions`** type is wired into **`GetContentOptions`** / **`fetchOneEntry`**. **`generateContentUrl`** JSON-serializes `enrichOptions` on the query string only when **`enrich`** is true (matching Content API behavior). The same option is exposed on **`Content`** / **`ContentVariants`** and passed through **`setupBrowserForEditing`** via the existing **`builder.updateContent`** payload, so the editor can resolve references with the same constraints as the site.
> 
> Patch bumps are recorded for all framework SDK packages in the changeset, with tests covering URL serialization and omission when `enrich` is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b13a7d3feadcd9b4128418add25791efd3ccc6f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->