### PR TITLE
Fix CustomCode scriptsClientOnly not re-running scripts after hydration

### DIFF
--- a/.changeset/shaggy-moles-argue.md
+++ b/.changeset/shaggy-moles-argue.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/react': patch
+---
+
+Fix: Custom Code blocks with `scriptsClientOnly` now re-insert and run their `<script>` tags after hydration. `shouldComponentUpdate` was only comparing `props.code`, which suppressed the one-time re-render triggered by `componentDidMount`.

--- a/packages/react/src/blocks/CustomCode.tsx
+++ b/packages/react/src/blocks/CustomCode.tsx
@@ -10,6 +10,10 @@ interface Props {
   scriptsClientOnly?: boolean;
 }
 
+interface State {
+  hydrated: boolean;
+}
+
 // TODO: settings context to pass this down. do in shopify-specific generated code
 const globalReplaceNodes = ({} as { [key: string]: Node[] }) || null;
 
@@ -48,7 +52,7 @@ if (Builder.isBrowser && globalReplaceNodes) {
   }
 }
 
-class CustomCodeComponent extends React.Component<Props> {
+class CustomCodeComponent extends React.Component<Props, State> {
   elementRef: Element | null = null;
   originalRef: Node | Element | null = null;
 
@@ -57,7 +61,7 @@ class CustomCodeComponent extends React.Component<Props> {
 
   firstLoad = true;
   replaceNodes = false;
-  state = {
+  state: State = {
     hydrated: false,
   };
 
@@ -90,8 +94,9 @@ class CustomCodeComponent extends React.Component<Props> {
     }
   }
 
-  shouldComponentUpdate(nextProps: Readonly<Props>): boolean {
-    return nextProps.code !== this.props.code;
+  shouldComponentUpdate(nextProps: Readonly<Props>, nextState: State): boolean {
+    // `hydrated` flips once, in componentDidMount, to re-render the scripts stripped for SSR parity.
+    return nextProps.code !== this.props.code || nextState.hydrated !== this.state.hydrated;
   }
 
   get noReactRender() {

--- a/packages/react/src/blocks/custom-code.test.tsx
+++ b/packages/react/src/blocks/custom-code.test.tsx
@@ -4,20 +4,15 @@
 
 import * as React from 'react';
 import { renderToString } from 'react-dom/server';
-import { createRoot, hydrateRoot } from 'react-dom/client';
-import { act } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import type { BuilderElement } from '@builder.io/sdk';
-import type { CustomCode as CustomCodeComponent } from '../src/blocks/CustomCode';
+import type { CustomCode as CustomCodeComponent } from './CustomCode';
 
 declare global {
   interface Window {
     __ccRuns?: number;
   }
-  // eslint-disable-next-line no-var
-  var IS_REACT_ACT_ENVIRONMENT: boolean;
 }
-
-globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 // jsdom does not implement innerText, which is what CustomCode reads to eval inline scripts.
 if (!Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'innerText')) {
@@ -50,21 +45,25 @@ const CODE = [
 function loadCustomCode() {
   jest.resetModules();
   const sdk = require('@builder.io/sdk') as typeof import('@builder.io/sdk');
-  const blockModule = require('../src/blocks/CustomCode') as {
+  const blockModule = require('./CustomCode') as {
     CustomCode: typeof CustomCodeComponent;
   };
   return { Builder: sdk.Builder, CustomCode: blockModule.CustomCode };
+}
+
+function customCodeTree(CustomCode: typeof CustomCodeComponent) {
+  return (
+    <div builder-id={BLOCK_ID} className={BLOCK_ID}>
+      <CustomCode code={CODE} scriptsClientOnly builderBlock={builderBlock} />
+    </div>
+  );
 }
 
 function renderSsrMarkup(): string {
   const { Builder, CustomCode } = loadCustomCode();
   Builder.isServer = true;
   try {
-    return renderToString(
-      <div builder-id={BLOCK_ID} className={BLOCK_ID}>
-        <CustomCode code={CODE} scriptsClientOnly builderBlock={builderBlock} />
-      </div>
-    );
+    return renderToString(customCodeTree(CustomCode));
   } finally {
     Builder.isServer = false;
   }
@@ -79,7 +78,6 @@ async function flushNextTick() {
 describe('CustomCode scriptsClientOnly hydration', () => {
   beforeEach(() => {
     delete window.__ccRuns;
-    document.body.innerHTML = '';
     document.head.querySelectorAll(`script[src="${REMOTE_SCRIPT_SRC}"]`).forEach(el => el.remove());
   });
 
@@ -93,23 +91,15 @@ describe('CustomCode scriptsClientOnly hydration', () => {
   it('restores and runs the stripped scripts after hydration', async () => {
     const ssrMarkup = renderSsrMarkup();
 
-    const root = document.createElement('div');
-    root.innerHTML = ssrMarkup;
-    document.body.appendChild(root);
+    const container = document.createElement('div');
+    container.innerHTML = ssrMarkup;
+    document.body.appendChild(container);
 
     const { CustomCode } = loadCustomCode();
-
-    await act(async () => {
-      hydrateRoot(
-        root,
-        <div builder-id={BLOCK_ID} className={BLOCK_ID}>
-          <CustomCode code={CODE} scriptsClientOnly builderBlock={builderBlock} />
-        </div>
-      );
-    });
+    render(customCodeTree(CustomCode), { container, hydrate: true });
     await flushNextTick();
 
-    const customCodeEl = root.querySelector('.builder-custom-code');
+    const customCodeEl = container.querySelector('.builder-custom-code');
     expect(customCodeEl).toBeTruthy();
 
     // The re-render triggered by `hydrated` must put the stripped <script> tags back in the DOM.
@@ -123,9 +113,6 @@ describe('CustomCode scriptsClientOnly hydration', () => {
     const { CustomCode } = loadCustomCode();
     const renderSpy = jest.spyOn(CustomCode.prototype, 'render');
 
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-
     function Parent({ label }: { label: string }) {
       return (
         <div>
@@ -135,18 +122,12 @@ describe('CustomCode scriptsClientOnly hydration', () => {
       );
     }
 
-    const reactRoot = createRoot(container);
-
-    await act(async () => {
-      reactRoot.render(<Parent label="a" />);
-    });
+    const { rerender } = render(<Parent label="a" />);
     await flushNextTick();
 
     const rendersAfterMount = renderSpy.mock.calls.length;
 
-    await act(async () => {
-      reactRoot.render(<Parent label="b" />);
-    });
+    rerender(<Parent label="b" />);
     await flushNextTick();
 
     expect(renderSpy.mock.calls.length).toBe(rendersAfterMount);

--- a/packages/react/test/custom-code.test.tsx
+++ b/packages/react/test/custom-code.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react';
+import { renderToString } from 'react-dom/server';
+import { createRoot, hydrateRoot } from 'react-dom/client';
+import { act } from '@testing-library/react';
+import type { BuilderElement } from '@builder.io/sdk';
+import type { CustomCode as CustomCodeComponent } from '../src/blocks/CustomCode';
+
+declare global {
+  interface Window {
+    __ccRuns?: number;
+  }
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+// jsdom does not implement innerText, which is what CustomCode reads to eval inline scripts.
+if (!Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'innerText')) {
+  Object.defineProperty(HTMLElement.prototype, 'innerText', {
+    configurable: true,
+    get(this: HTMLElement) {
+      return this.textContent;
+    },
+  });
+}
+
+const BLOCK_ID = 'builder-custom-code-hydration';
+const REMOTE_SCRIPT_SRC = 'https://example.com/custom-code.js';
+
+const builderBlock: BuilderElement = {
+  '@type': '@builder.io/sdk:Element',
+  id: BLOCK_ID,
+};
+
+const CODE = [
+  '<div class="cc-body">hello</div>',
+  '<script>window.__ccRuns = (window.__ccRuns || 0) + 1;</script>',
+  `<script src="${REMOTE_SCRIPT_SRC}"></script>`,
+].join('');
+
+/**
+ * CustomCode collects the SSR'd nodes at module scope, so it has to be loaded after the markup
+ * it is meant to hydrate is already in the document.
+ */
+function loadCustomCode() {
+  jest.resetModules();
+  const sdk = require('@builder.io/sdk') as typeof import('@builder.io/sdk');
+  const blockModule = require('../src/blocks/CustomCode') as {
+    CustomCode: typeof CustomCodeComponent;
+  };
+  return { Builder: sdk.Builder, CustomCode: blockModule.CustomCode };
+}
+
+function renderSsrMarkup(): string {
+  const { Builder, CustomCode } = loadCustomCode();
+  Builder.isServer = true;
+  try {
+    return renderToString(
+      <div builder-id={BLOCK_ID} className={BLOCK_ID}>
+        <CustomCode code={CODE} scriptsClientOnly builderBlock={builderBlock} />
+      </div>
+    );
+  } finally {
+    Builder.isServer = false;
+  }
+}
+
+async function flushNextTick() {
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, 0));
+  });
+}
+
+describe('CustomCode scriptsClientOnly hydration', () => {
+  beforeEach(() => {
+    delete window.__ccRuns;
+    document.body.innerHTML = '';
+    document.head.querySelectorAll(`script[src="${REMOTE_SCRIPT_SRC}"]`).forEach(el => el.remove());
+  });
+
+  it('strips scripts from the server render', () => {
+    const ssrMarkup = renderSsrMarkup();
+    expect(ssrMarkup).toContain('cc-body');
+    expect(ssrMarkup).not.toContain('__ccRuns');
+    expect(ssrMarkup).not.toContain(REMOTE_SCRIPT_SRC);
+  });
+
+  it('restores and runs the stripped scripts after hydration', async () => {
+    const ssrMarkup = renderSsrMarkup();
+
+    const root = document.createElement('div');
+    root.innerHTML = ssrMarkup;
+    document.body.appendChild(root);
+
+    const { CustomCode } = loadCustomCode();
+
+    await act(async () => {
+      hydrateRoot(
+        root,
+        <div builder-id={BLOCK_ID} className={BLOCK_ID}>
+          <CustomCode code={CODE} scriptsClientOnly builderBlock={builderBlock} />
+        </div>
+      );
+    });
+    await flushNextTick();
+
+    const customCodeEl = root.querySelector('.builder-custom-code');
+    expect(customCodeEl).toBeTruthy();
+
+    // The re-render triggered by `hydrated` must put the stripped <script> tags back in the DOM.
+    expect(customCodeEl!.querySelector('script')).toBeTruthy();
+    // ...and findAndRunScripts must then pick them up.
+    expect(window.__ccRuns).toBe(1);
+    expect(document.head.querySelector(`script[src="${REMOTE_SCRIPT_SRC}"]`)).toBeTruthy();
+  });
+
+  it('still skips re-renders when neither code nor hydration state change', async () => {
+    const { CustomCode } = loadCustomCode();
+    const renderSpy = jest.spyOn(CustomCode.prototype, 'render');
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    function Parent({ label }: { label: string }) {
+      return (
+        <div>
+          <span>{label}</span>
+          <CustomCode code={CODE} scriptsClientOnly builderBlock={builderBlock} />
+        </div>
+      );
+    }
+
+    const reactRoot = createRoot(container);
+
+    await act(async () => {
+      reactRoot.render(<Parent label="a" />);
+    });
+    await flushNextTick();
+
+    const rendersAfterMount = renderSpy.mock.calls.length;
+
+    await act(async () => {
+      reactRoot.render(<Parent label="b" />);
+    });
+    await flushNextTick();
+
+    expect(renderSpy.mock.calls.length).toBe(rendersAfterMount);
+    renderSpy.mockRestore();
+  });
+});

--- a/packages/react/test/setupTests.ts
+++ b/packages/react/test/setupTests.ts
@@ -1,3 +1,11 @@
+import { TextDecoder, TextEncoder } from 'util';
+
+// jsdom 19 ships without TextEncoder/TextDecoder, which react-dom/server needs on modern Node.
+if (typeof globalThis.TextEncoder === 'undefined') {
+  globalThis.TextEncoder = TextEncoder as typeof globalThis.TextEncoder;
+  globalThis.TextDecoder = TextDecoder as typeof globalThis.TextDecoder;
+}
+
 beforeEach(() => {
   jest.spyOn(global.Math, 'random').mockReturnValue(0.123456789);
 });


### PR DESCRIPTION
## Description

Fixes a regression where `CustomCode` blocks with `scriptsClientOnly: true` fail to restore SSR-stripped `<script>` tags after hydration.

**Root cause:** `shouldComponentUpdate` in `CustomCodeComponent` only compared `nextProps.code !== this.props.code`. This meant the `setState({ hydrated: true })` call made in `componentDidMount` (which is meant to trigger a one-time re-render to re-insert the scripts that were stripped for SSR) was blocked, since only `state.hydrated` changed and not `props.code`.

**Fix:**
- Added a proper `State` type (`{ hydrated: boolean }`) and used it as the generic parameter on `React.Component<Props, State>` instead of leaving the component untyped for state.
- Updated `shouldComponentUpdate` to also accept `nextState: State` and return `true` when `nextState.hydrated !== this.state.hydrated`, in addition to the existing `code` prop comparison. This preserves the original perf optimization (skipping re-renders when `code` is unchanged) while no longer suppressing the one-time hydration re-render.

**Tests:**
- Added `packages/react/test/custom-code.test.tsx` covering:
  - Scripts are correctly stripped from SSR output when `scriptsClientOnly` is true.
  - Scripts are restored in the DOM and executed after hydration (verifying the fix).
  - `CustomCode` still skips unnecessary re-renders when neither `code` nor hydration state change (verifying no perf regression).
- Updated `packages/react/test/setupTests.ts` to polyfill `TextEncoder`/`TextDecoder` in the jsdom test environment, which `react-dom/server`'s `renderToString` requires but jsdom 19 doesn't provide.
- Added a changeset documenting the patch fix for `@builder.io/react`.

**Link to JIRA ticket:**
https://builder-io.atlassian.net/browse/SUPP-2847


---

<a href="https://builder.io/app/projects/b29d4bc79bfe480fb3f0/proto-opening-bmzklsoi"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://b29d4bc79bfe480fb3f0-proto-opening-bmzklsoi.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4848`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b29d4bc79bfe480fb3f0</projectId>-->
<!--<branchName>proto-opening-bmzklsoi</branchName>-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lifecycle fix in CustomCode with regression tests; behavior change is restoring intended client-only script execution after hydration.
> 
> **Overview**
> Fixes a regression where **Custom Code** blocks with `scriptsClientOnly` stripped `<script>` tags on SSR but never put them back or executed them on the client.
> 
> `shouldComponentUpdate` only compared `props.code`, so the one-time `setState({ hydrated: true })` in `componentDidMount` did not trigger a re-render. The change types component state as `{ hydrated: boolean }` and allows updates when `hydrated` changes, while still skipping re-renders when only unrelated parent props change.
> 
> Adds jsdom tests for SSR script stripping, post-hydration script restore/execution, and a render-count guard. Test setup polyfills `TextEncoder`/`TextDecoder` for `renderToString`. Patch changeset for `@builder.io/react`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 274496ed6dab1d76d1547bc3981d63dd75aed78b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->