### PR TITLE
fix[gen1][symbol]: ENG-13693 Editor flickers when using symbol with slot

### DIFF
--- a/.changeset/lucky-moons-listen.md
+++ b/.changeset/lucky-moons-listen.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/react': patch
+---
+
+Fix: editing a block inside a Symbol's Slot no longer remounts the whole Symbol. Slot content is stored in `symbol.data.<slotName>`, which was part of the hash used to key the Symbol's nested `BuilderComponent`, so every edit to a slot child tore down and rebuilt the subtree. In the Visual Editor that destroyed the DOM node of the selected block, making the inline edit popup flicker while typing. Block values are now excluded from that key while editing; live rendering keeps its existing key.

--- a/.changeset/lucky-moons-listen.md
+++ b/.changeset/lucky-moons-listen.md
@@ -2,4 +2,4 @@
 '@builder.io/react': patch
 ---
 
-Fix: editing a block inside a Symbol's Slot no longer remounts the whole Symbol. Slot content is stored in `symbol.data.<slotName>`, which was part of the hash used to key the Symbol's nested `BuilderComponent`, so every edit to a slot child tore down and rebuilt the subtree. In the Visual Editor that destroyed the DOM node of the selected block, making the inline edit popup flicker while typing. Block values are now excluded from that key while editing; live rendering keeps its existing key.
+Fix: editing a block inside a Symbol's Slot no longer remounts the Symbol. Slot content lives in `symbol.data.<slotName>`, which keyed the nested `BuilderComponent`, so every keystroke rebuilt the subtree and made the Visual Editor's inline edit popup flicker.

--- a/packages/react/src/blocks/Symbol.tsx
+++ b/packages/react/src/blocks/Symbol.tsx
@@ -11,6 +11,14 @@ import { omit } from '../functions/utils';
 
 const size = (thing: object) => Object.keys(thing).length;
 
+const isBuilderElementArray = (value: any) =>
+  Array.isArray(value) && value.some(item => item?.['@type'] === '@builder.io/sdk:Element');
+
+// Slot content lives in `symbol.data.<name>`, so keying on it remounts the symbol on every edit to
+// a block inside a slot, tearing down the node the editor has selected. Blocks update in place.
+const omitBlockValues = (data: Record<string, any>) =>
+  omit(data, ...Object.keys(data).filter(key => isBuilderElementArray(data[key])));
+
 const isShopify = Builder.isBrowser && 'Shopify' in window;
 
 const refs: Record<string, Element> = {};
@@ -113,7 +121,8 @@ class SymbolComponent extends React.Component<PropsWithChildren<SymbolProps>> {
     }
 
     let key = dynamic ? this.props.builderBlock?.id : [model, entry].join(':');
-    const dataString = data && size(data) && hash(data);
+    const keyData = data && (Builder.isEditing ? omitBlockValues(data) : data);
+    const dataString = keyData && size(keyData) && hash(keyData);
 
     if (key && dataString && dataString.length < 300) {
       key += ':' + dataString;

--- a/packages/react/test/symbol-slot-remount.test.tsx
+++ b/packages/react/test/symbol-slot-remount.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { Builder, builder } from '@builder.io/sdk';
+import { BuilderPage } from '../src/builder-react';
+import { block } from './functions/render-block';
+
+builder.init('null');
+
+let mountCount = 0;
+
+const MountCounter = (props: { title?: string; testid?: string }) => {
+  React.useEffect(() => {
+    mountCount++;
+  }, []);
+  return <div data-testid={props.testid || 'counter'}>{props.title}</div>;
+};
+
+Builder.registerComponent(MountCounter, {
+  name: 'MountCounter',
+  inputs: [
+    { name: 'title', type: 'text' },
+    { name: 'testid', type: 'text' },
+  ],
+});
+
+const slotChild = (title: string, id = 'builder-child-1', testid?: string) =>
+  block('MountCounter', { title, testid }, { id } as any);
+
+const symbolBlock = (opts: {
+  id?: string;
+  entry?: string;
+  children?: any[];
+  heading?: string;
+  slotName?: string;
+}) =>
+  block(
+    'Symbol',
+    {
+      symbol: {
+        model: 'symbol',
+        entry: opts.entry || 'entry-1',
+        content: {
+          id: 'sym-1',
+          data: {
+            blocks: [
+              block('Slot', { name: opts.slotName || 'children' }, { id: 'builder-slot-1' } as any),
+            ],
+          },
+        },
+        data: {
+          ...(opts.heading !== undefined && { heading: opts.heading }),
+          [opts.slotName || 'children']: opts.children ?? [slotChild('A')],
+        },
+      },
+    },
+    { id: opts.id || 'builder-symbol-1' } as any
+  );
+
+const page = (blocks: any[]) => ({ id: 'page-1', data: { blocks } });
+
+describe('symbol + slot editing (editor)', () => {
+  beforeEach(() => {
+    mountCount = 0;
+    Builder.isEditing = true;
+  });
+
+  afterEach(() => {
+    Builder.isEditing = false;
+  });
+
+  it('does not remount slot children when their options change', () => {
+    const testApi = render(<BuilderPage model="page" content={page([symbolBlock({})]) as any} />);
+
+    const nodeBefore = testApi.getByTestId('counter');
+    expect(nodeBefore).toHaveTextContent('A');
+    expect(mountCount).toBe(1);
+
+    testApi.rerender(
+      <BuilderPage
+        model="page"
+        content={page([symbolBlock({ children: [slotChild('AB')] })]) as any}
+      />
+    );
+
+    expect(testApi.getByTestId('counter')).toBe(nodeBefore);
+    expect(nodeBefore).toHaveTextContent('AB');
+    expect(mountCount).toBe(1);
+  });
+
+  it('still applies adds and removes of slot children', () => {
+    const testApi = render(<BuilderPage model="page" content={page([symbolBlock({})]) as any} />);
+    expect(testApi.getByTestId('counter')).toHaveTextContent('A');
+
+    testApi.rerender(
+      <BuilderPage
+        model="page"
+        content={
+          page([
+            symbolBlock({
+              children: [slotChild('A'), slotChild('B', 'builder-child-2', 'counter-2')],
+            }),
+          ]) as any
+        }
+      />
+    );
+    expect(testApi.getByTestId('counter-2')).toHaveTextContent('B');
+
+    testApi.rerender(
+      <BuilderPage model="page" content={page([symbolBlock({ children: [] })]) as any} />
+    );
+    expect(testApi.queryByTestId('counter')).toBeNull();
+    expect(testApi.queryByTestId('counter-2')).toBeNull();
+  });
+
+  it('still remounts when a non-slot symbol input changes', () => {
+    const testApi = render(
+      <BuilderPage model="page" content={page([symbolBlock({ heading: 'one' })]) as any} />
+    );
+    const nodeBefore = testApi.getByTestId('counter');
+    expect(mountCount).toBe(1);
+
+    testApi.rerender(
+      <BuilderPage model="page" content={page([symbolBlock({ heading: 'two' })]) as any} />
+    );
+
+    expect(testApi.getByTestId('counter')).not.toBe(nodeBefore);
+    expect(mountCount).toBe(2);
+  });
+
+  it('renders two instances of the same symbol with different slot content', () => {
+    const testApi = render(
+      <BuilderPage
+        model="page"
+        content={
+          page([
+            symbolBlock({ id: 'builder-symbol-1', children: [slotChild('first', 'c1', 'one')] }),
+            symbolBlock({ id: 'builder-symbol-2', children: [slotChild('second', 'c2', 'two')] }),
+          ]) as any
+        }
+      />
+    );
+
+    expect(testApi.getByTestId('one')).toHaveTextContent('first');
+    expect(testApi.getByTestId('two')).toHaveTextContent('second');
+  });
+});
+
+describe('symbol + slot rendering (production)', () => {
+  beforeEach(() => {
+    mountCount = 0;
+  });
+
+  it('renders slot content and reacts to data changes', () => {
+    const testApi = render(
+      <BuilderPage model="page" content={page([symbolBlock({ heading: 'one' })]) as any} />
+    );
+    expect(testApi.getByTestId('counter')).toHaveTextContent('A');
+
+    testApi.rerender(
+      <BuilderPage model="page" content={page([symbolBlock({ heading: 'two' })]) as any} />
+    );
+    expect(testApi.getByTestId('counter')).toHaveTextContent('A');
+  });
+
+  it('keys on slot content exactly as before, since the fix is editor only', () => {
+    const testApi = render(<BuilderPage model="page" content={page([symbolBlock({})]) as any} />);
+    const nodeBefore = testApi.getByTestId('counter');
+    expect(mountCount).toBe(1);
+
+    testApi.rerender(
+      <BuilderPage
+        model="page"
+        content={page([symbolBlock({ children: [slotChild('AB')] })]) as any}
+      />
+    );
+
+    expect(testApi.getByTestId('counter')).not.toBe(nodeBefore);
+    expect(mountCount).toBe(2);
+  });
+});


### PR DESCRIPTION
## Description

Blocks you drop into a Slot are not stored as normal children. They live on the parent Symbol block under `symbol.data.<slotName>`, which you can see in `Slot.tsx`:
`<BuilderBlocks dataPath={`symbol.data.${name}`} blocks={context.state[name] || []} />`

`Symbol.tsx` builds the React key for its nested BuilderComponent from a hash of that same symbol.data object. So every keystroke changed the slot content, which changed the hash, which changed the key. React then threw away the whole symbol subtree and rebuilt it.

This leads to the flickering in the editor when we try to update content. 

**Fix:**
Leave block arrays out of the key while editing. Slot content renders through `BuilderBlocks` and already updates in place when the `data` prop changes, so the remount was not buying us anything.

Live rendering keeps the exact key it has today, so nothing changes for published pages.

**Link to JIRA ticket (if applicable):**
https://builder-io.atlassian.net/browse/ENG-13693

**Screenshot/Clip**
Bug: https://clips.agent-native.com/r/XujJySpqNeDH
Fix: https://clips.agent-native.com/r/1kFnRc088Uj3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editor-only React key change with production parity preserved and regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes Visual Editor flicker when inline-editing blocks inside a Symbol **Slot** by changing how the nested `BuilderComponent` React key is derived **only while `Builder.isEditing`**.
> 
> Slot blocks are stored on `symbol.data.<slotName>`, and hashing that full `data` object used to change the key on every keystroke and remount the Symbol subtree (breaking the selected node and the inline edit UI). **`omitBlockValues`** now strips keys whose values are Builder element arrays from the hash input in edit mode; slot UI still updates in place via `BuilderBlocks`. **Published / non-editing** behavior is unchanged—slot content remains in the key hash as before.
> 
> Adds **`symbol-slot-remount.test.tsx`** to lock in editor vs production remount behavior and a patch **changeset** for `@builder.io/react`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8f148822e00a293fce4af95b656ba3612cbf7a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->