### PR TITLE
fix[smartling][utils]: ENG-13890 exclude URL, image and link fields from translation jobs

### DIFF
--- a/packages/utils/src/translation-helpers.test.ts
+++ b/packages/utils/src/translation-helpers.test.ts
@@ -1995,3 +1995,48 @@ test('applyTranslation restores a skipped link scheme into the target locale', (
 
   expect((result.data as any).email['de-DE']).toEqual('mailto:support@example.com');
 });
+
+test('getTranslateableFields skips relative link paths', () => {
+  const result = getTranslateableFields(
+    linkSchemeContent({
+      sibling: './checkout',
+      parent: '../support',
+      nested: '../../en-gb/pricing',
+    }),
+    'en-GB',
+    'instructions'
+  );
+
+  expect(result).toEqual({});
+});
+
+test('getTranslateableFields keeps slash-separated copy translatable', () => {
+  const result = getTranslateableFields(
+    linkSchemeContent({
+      conjunction: 'and/or',
+      choice: 'Yes/No',
+      hours: '24/7',
+      sizes: 'S/M/L',
+      category: 'products/item',
+      ellipsis: '...',
+    }),
+    'en-GB',
+    'instructions'
+  );
+
+  expect(Object.keys(result)).toEqual([
+    'metadata.conjunction',
+    'metadata.choice',
+    'metadata.hours',
+    'metadata.sizes',
+    'metadata.category',
+    'metadata.ellipsis',
+  ]);
+});
+
+test('applyTranslation restores a skipped relative path into the target locale', () => {
+  const content = linkSchemeContent({ sibling: './checkout' });
+  const result = applyTranslation(content, {}, 'de-DE', 'en-GB');
+
+  expect((result.data as any).sibling['de-DE']).toEqual('./checkout');
+});

--- a/packages/utils/src/translation-helpers.test.ts
+++ b/packages/utils/src/translation-helpers.test.ts
@@ -1754,3 +1754,111 @@ test('applyTranslation seeds the source when an input had nothing to translate',
   // Without the locale branch the SDK renders undefined and the rows disappear.
   expect(rows['de-DE']).toEqual(rows.Default);
 });
+
+// URLs and asset references are routing values a translator cannot produce; sending them
+// pollutes the job and lets a translator overwrite a live link.
+const assetFieldsContent = (): BuilderContent => ({
+  data: {
+    heroImage: { '@type': localizedType, Default: 'https://cdn.builder.io/api/v1/image/hero.png' },
+    intro: { '@type': localizedType, Default: 'Visit https://example.com for more' },
+    blocks: [
+      {
+        '@type': '@builder.io/sdk:Element',
+        id: 'builder-slides',
+        meta: { localizedTextInputs: ['heroLink', 'slides'] },
+        component: {
+          name: 'Carousel',
+          options: {
+            heroLink: { '@type': localizedType, Default: 'https://example.com/en-gb/hero' },
+            slides: {
+              '@type': localizedType,
+              Default: [
+                {
+                  caption: 'Food and drink',
+                  imageUrl: 'https://cdn.builder.io/api/v1/image/slide.png',
+                  link: '/en-gb/business-types/food-and-drink',
+                },
+              ],
+            },
+          },
+        },
+      },
+      {
+        '@type': '@builder.io/sdk:Element',
+        id: 'builder-symbol',
+        component: {
+          name: 'Symbol',
+          options: {
+            symbol: {
+              data: {
+                buttonUrl: { '@type': localizedType, Default: 'https://example.com/en-gb' },
+                label: { '@type': localizedType, Default: 'Get started' },
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+});
+
+test('getTranslateableFields skips url and asset values but keeps prose containing a url', () => {
+  expect(getTranslateableFields(assetFieldsContent(), 'en-GB', 'instructions')).toEqual({
+    'metadata.intro': { value: 'Visit https://example.com for more', instructions: 'instructions' },
+    'blocks.builder-slides#slides#0#caption': {
+      value: 'Food and drink',
+      instructions: 'instructions',
+    },
+    'blocks.builder-symbol.symbolInput#label': {
+      value: 'Get started',
+      instructions: 'instructions',
+    },
+  });
+});
+
+test('applyTranslation keeps skipped urls readable in the target locale', () => {
+  const result = applyTranslation(
+    assetFieldsContent(),
+    {
+      'blocks.builder-slides#slides#0#caption': { value: 'Essen und Trinken' },
+      'blocks.builder-symbol.symbolInput#label': { value: 'Jetzt starten' },
+      'metadata.intro': { value: 'DE intro' },
+    },
+    'de-DE',
+    'en-GB'
+  );
+  const data = result.data as any;
+  const options = data.blocks[0].component.options;
+  const symbolData = data.blocks[1].component.options.symbol.data;
+
+  expect(options.slides['de-DE']).toEqual([
+    {
+      caption: 'Essen und Trinken',
+      imageUrl: 'https://cdn.builder.io/api/v1/image/slide.png',
+      link: '/en-gb/business-types/food-and-drink',
+    },
+  ]);
+  expect(options.heroLink['de-DE']).toEqual('https://example.com/en-gb/hero');
+  expect(symbolData.buttonUrl['de-DE']).toEqual('https://example.com/en-gb');
+  expect(data.heroImage['de-DE']).toEqual('https://cdn.builder.io/api/v1/image/hero.png');
+});
+
+test('applyTranslation does not seed real copy that a pending job has not returned yet', () => {
+  const result = applyTranslation(assetFieldsContent(), {}, 'de-DE', 'en-GB');
+  const data = result.data as any;
+
+  expect(data.blocks[1].component.options.symbol.data.label['de-DE']).toBeUndefined();
+  expect(data.intro['de-DE']).toBeUndefined();
+  expect(data.blocks[0].component.options.slides['de-DE']).toBeUndefined();
+});
+
+test('applyTranslation does not overwrite a url already localized for the target locale', () => {
+  const content = assetFieldsContent();
+  (content.data as any).blocks[1].component.options.symbol.data.buttonUrl['de-DE'] =
+    'https://example.com/de-de';
+
+  const result = applyTranslation(content, {}, 'de-DE', 'en-GB');
+  const symbolData = (result.data as any).blocks[1].component.options.symbol.data;
+
+  expect(symbolData.buttonUrl['de-DE']).toEqual('https://example.com/de-de');
+});

--- a/packages/utils/src/translation-helpers.test.ts
+++ b/packages/utils/src/translation-helpers.test.ts
@@ -1862,3 +1862,136 @@ test('applyTranslation does not overwrite a url already localized for the target
 
   expect(symbolData.buttonUrl['de-DE']).toEqual('https://example.com/de-de');
 });
+
+// A payload the url guard empties draws no response at all, so the locale branch has to
+// be seeded or the SDK resolves the whole list to undefined and the content disappears.
+const urlOnlyPayloadContent = (): BuilderContent => ({
+  data: {
+    logos: {
+      '@type': localizedType,
+      Default: [{ image: 'https://cdn.builder.io/api/v1/image/logo.png', link: '/en-gb/partners' }],
+    },
+    tiles: {
+      '@type': localizedType,
+      Default: [
+        {
+          icon: { '@type': localizedType, Default: 'https://cdn.builder.io/api/v1/image/i.png' },
+          href: { '@type': localizedType, Default: 'https://example.com/en-gb/x' },
+        },
+      ],
+    },
+    ratings: { '@type': localizedType, Default: [{ score: 4.9, count: 10 }] },
+  },
+});
+
+test('getTranslateableFields sends nothing for a model field whose leaves are all urls', () => {
+  expect(getTranslateableFields(urlOnlyPayloadContent(), 'en-GB', 'instructions')).toEqual({});
+});
+
+test('applyTranslation seeds a model field the url guard emptied', () => {
+  const result = applyTranslation(urlOnlyPayloadContent(), {}, 'de-DE', 'en-GB');
+  const data = result.data as any;
+
+  expect(data.logos['de-DE']).toEqual(data.logos.Default);
+  expect(data.tiles['de-DE'][0].icon['de-DE']).toEqual('https://cdn.builder.io/api/v1/image/i.png');
+  expect(data.tiles['de-DE'][0].href['de-DE']).toEqual('https://example.com/en-gb/x');
+});
+
+test('applyTranslation leaves a model field with no strings untouched', () => {
+  const result = applyTranslation(urlOnlyPayloadContent(), {}, 'de-DE', 'en-GB');
+
+  expect((result.data as any).ratings['de-DE']).toBeUndefined();
+});
+
+// The restore has to select the source the same way the extractor does, or it seeds a
+// value the job was never based on.
+const symbolSourceLocaleContent = (): BuilderContent => ({
+  data: {
+    blocks: [
+      {
+        '@type': '@builder.io/sdk:Element',
+        id: 'builder-symbol-source',
+        component: {
+          name: 'Symbol',
+          options: {
+            symbol: {
+              data: {
+                buttonUrl: {
+                  '@type': localizedType,
+                  Default: 'https://example.com/global',
+                  'en-GB': 'https://example.com/en-gb',
+                },
+                // Default is a url but the source locale is prose awaiting translation.
+                heading: {
+                  '@type': localizedType,
+                  Default: 'https://example.com/placeholder',
+                  'en-GB': 'Get started',
+                },
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+});
+
+test('applyTranslation restores a skipped url from the selected source locale', () => {
+  const result = applyTranslation(symbolSourceLocaleContent(), {}, 'de-DE', 'en-GB');
+  const symbolData = (result.data as any).blocks[0].component.options.symbol.data;
+
+  expect(symbolData.buttonUrl['de-DE']).toEqual('https://example.com/en-gb');
+});
+
+test('applyTranslation does not restore a url over source prose awaiting translation', () => {
+  const content = symbolSourceLocaleContent();
+  expect(getTranslateableFields(content, 'en-GB', '')).toEqual({
+    'blocks.builder-symbol-source.symbolInput#heading': { value: 'Get started', instructions: '' },
+  });
+
+  const result = applyTranslation(content, {}, 'de-DE', 'en-GB');
+  const symbolData = (result.data as any).blocks[0].component.options.symbol.data;
+
+  expect(symbolData.heading['de-DE']).toBeUndefined();
+});
+
+const linkSchemeContent = (fields: Record<string, string>): BuilderContent => {
+  const data: Record<string, any> = {};
+  Object.keys(fields).forEach(key => {
+    data[key] = { '@type': localizedType, Default: fields[key] };
+  });
+  return { data };
+};
+
+test('getTranslateableFields skips non-http link schemes and empty link placeholders', () => {
+  const result = getTranslateableFields(
+    linkSchemeContent({
+      email: 'mailto:support@example.com',
+      phone: 'tel:+441234567890',
+      text: 'sms:+441234567890',
+      inlineAsset: 'data:image/png;base64,iVBORw0KGgo=',
+      placeholder: '#',
+    }),
+    'en-GB',
+    'instructions'
+  );
+
+  expect(result).toEqual({});
+});
+
+test('getTranslateableFields keeps hashtags and anchors translatable', () => {
+  const result = getTranslateableFields(
+    linkSchemeContent({ hashtag: '#SumUp', anchor: '#pricing' }),
+    'en-GB',
+    'instructions'
+  );
+
+  expect(Object.keys(result)).toEqual(['metadata.hashtag', 'metadata.anchor']);
+});
+
+test('applyTranslation restores a skipped link scheme into the target locale', () => {
+  const content = linkSchemeContent({ email: 'mailto:support@example.com' });
+  const result = applyTranslation(content, {}, 'de-DE', 'en-GB');
+
+  expect((result.data as any).email['de-DE']).toEqual('mailto:support@example.com');
+});

--- a/packages/utils/src/translation-helpers.ts
+++ b/packages/utils/src/translation-helpers.ts
@@ -14,8 +14,8 @@ export type TranslateableFields = {
   };
 };
 
-// A bare URL or asset reference is a routing/config value, never a translation unit.
-// Whitespace means prose ("Visit https://x.com for more"), which stays translatable.
+// A bare url or asset is routing config, never copy. Whitespace means prose
+// ("Visit https://x.com for more"), which stays translatable.
 function isNonTranslatableValue(value: string) {
   const trimmed = value.trim();
   if (!trimmed || /\s/.test(trimmed)) {
@@ -24,8 +24,7 @@ function isNonTranslatableValue(value: string) {
   const lower = trimmed.toLowerCase();
   return (
     lower.startsWith('/') ||
-    // './x' and '../x' are unambiguous relative links. A bare 'foo/bar' is not: it is
-    // shape-identical to real copy like 'and/or', 'Yes/No' or '24/7', so it stays in.
+    // './x' and '../x' are clearly links. Bare 'foo/bar' is not: it looks like 'and/or'.
     lower.startsWith('./') ||
     lower.startsWith('../') ||
     lower.startsWith('http://') ||
@@ -35,8 +34,7 @@ function isNonTranslatableValue(value: string) {
     lower.startsWith('tel:') ||
     lower.startsWith('sms:') ||
     lower.startsWith('data:') ||
-    // Bare '#' is an empty link placeholder, but '#anchor' is shape-identical to a
-    // campaign hashtag like '#SumUp', so those stay translatable.
+    // Bare '#' is an empty placeholder; '#anchor' looks like a hashtag, so it stays in.
     lower === '#'
   );
 }
@@ -171,9 +169,8 @@ function resolveTranslation({
       } else {
         // No direct translation - check if Default value contains nested LocalizedValues
         const defaultValue = value?.Default;
-        // Restore a leaf the extractor skipped. Selecting the source the same way the
-        // extractor does keeps the two from disagreeing: reading Default here would seed
-        // a url over prose that is still out for translation, or miss the url entirely.
+        // Restore a skipped leaf. Picking the source the same way the extractor does
+        // avoids seeding a url over prose still out for translation.
         const skippedSource = (sourceLocaleId && value?.[sourceLocaleId]) || value?.Default;
         if (
           typeof skippedSource === 'string' &&
@@ -573,8 +570,7 @@ export function getTranslateableFields(
   return results;
 }
 
-// Tells a payload the url guard emptied from one that never held a string, so only the
-// former is restored into the target locale.
+// Separates a payload the url guard emptied from one that never held a string.
 function hasStringLeaf(value: any): boolean {
   if (typeof value === 'string') return Boolean(value);
   if (Array.isArray(value)) return value.some(hasStringLeaf);
@@ -678,8 +674,8 @@ export function applyTranslation(
       const sourceValue = (sourceLocaleId && el[sourceLocaleId] != null)
           ? el[sourceLocaleId]
           : el.Default;
-      // Restore what the extractor skipped: a url-only field or payload draws no response,
-      // and the SDK resolves a missing locale to undefined, so it would vanish there.
+      // A url-only payload draws no response, and the SDK reads a missing locale as
+      // undefined, so restore it or it vanishes in the target locale.
       const metaHasTranslatableLeaf = () => {
         const probe: TranslateableFields = {};
         extractNestedStrings(sourceValue, metaKey, probe, '', sourceLocaleId ?? '');
@@ -716,6 +712,9 @@ export function applyTranslation(
         });
         this.update({ ...el, [locale]: localeValue });
       }
+      // Nested leaves are handled above; descending would only write locale keys into
+      // the source payload.
+      this.block();
     }
   });
 

--- a/packages/utils/src/translation-helpers.ts
+++ b/packages/utils/src/translation-helpers.ts
@@ -14,6 +14,22 @@ export type TranslateableFields = {
   };
 };
 
+// A bare URL or asset reference is a routing/config value, never a translation unit.
+// Whitespace means prose ("Visit https://x.com for more"), which stays translatable.
+function isNonTranslatableValue(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed || /\s/.test(trimmed)) {
+    return false;
+  }
+  const lower = trimmed.toLowerCase();
+  return (
+    lower.startsWith('/') ||
+    lower.startsWith('http://') ||
+    lower.startsWith('https://') ||
+    lower.startsWith('cdn.builder.io/')
+  );
+}
+
 function unescapeStringOrObject(input: string | Record<string, any>) {
   // Check if input is a string
   if (typeof input === 'string') {
@@ -62,7 +78,7 @@ function recordValue({
       const extractedValue = value?.[sourceLocaleId] || value?.Default;
 
       // If the extracted value is a string, store it directly
-      if (typeof extractedValue === 'string') {
+      if (typeof extractedValue === 'string' && !isNonTranslatableValue(extractedValue)) {
         results[path] = {
           value: extractedValue,
           instructions,
@@ -141,6 +157,15 @@ function resolveTranslation({
       } else {
         // No direct translation - check if Default value contains nested LocalizedValues
         const defaultValue = value?.Default;
+        // Restore a leaf the extractor skipped: the SDK resolves a missing locale to
+        // undefined, so the link would otherwise vanish in the target locale.
+        if (
+          typeof defaultValue === 'string' &&
+          isNonTranslatableValue(defaultValue) &&
+          value[locale] == null
+        ) {
+          set(data, dataPath, { ...value, [locale]: defaultValue });
+        }
         if (
           Array.isArray(defaultValue) ||
           (typeof defaultValue === 'object' && defaultValue !== null)
@@ -230,7 +255,7 @@ function extractNestedStrings(
   excluded?: Set<string>
 ) {
   if (typeof value === 'string') {
-    if (value && !isExcludedPath(excluded, basePath)) {
+    if (value && !isExcludedPath(excluded, basePath) && !isNonTranslatableValue(value)) {
       results[basePath] = { value, instructions };
     }
   } else if (Array.isArray(value)) {
@@ -250,7 +275,7 @@ function extractNestedStrings(
       const nested = value[sourceLocaleId] || value.Default;
       const nestedInstructions = value.meta?.instructions || instructions;
       if (typeof nested === 'string' && nested) {
-        if (!isExcludedPath(excluded, basePath)) {
+        if (!isExcludedPath(excluded, basePath) && !isNonTranslatableValue(nested)) {
           results[basePath] = { value: nested, instructions: nestedInstructions };
         }
       } else if (nested !== null && nested !== undefined) {
@@ -313,7 +338,7 @@ function extractLocalizedLeaves(
     const nestedInstructions = value.meta?.instructions || instructions;
     if (typeof nested === 'string') {
       // Counts even when excluded, else the caller sweeps up every string instead.
-      if (nested && !isExcludedPath(excluded, basePath)) {
+      if (nested && !isExcludedPath(excluded, basePath) && !isNonTranslatableValue(nested)) {
         results[basePath] = { value: nested, instructions: nestedInstructions };
       }
       return 1;
@@ -379,7 +404,7 @@ export function getTranslateableFields(
     if (value['@type'] === localizedType) {
       const instructions = value.meta?.instructions || defaultInstructions;
       const extractedValue = value[sourceLocaleId] || value.Default;
-      if (typeof extractedValue === 'string') {
+      if (typeof extractedValue === 'string' && !isNonTranslatableValue(extractedValue)) {
         results[path] = { value: extractedValue, instructions };
       } else if (extractedValue !== null && extractedValue !== undefined) {
         // Value is an array or object — extract individual string leaves so each
@@ -440,7 +465,7 @@ export function getTranslateableFields(
               }
 
               if (typeof valueToBeTranslated === 'string') {
-                if (valueToBeTranslated) {
+                if (valueToBeTranslated && !isNonTranslatableValue(valueToBeTranslated)) {
                   results[path] = { instructions, value: valueToBeTranslated };
                 }
                 return;
@@ -625,6 +650,15 @@ export function applyTranslation(
       const sourceValue = (sourceLocaleId && el[sourceLocaleId] != null)
           ? el[sourceLocaleId]
           : el.Default;
+      // Same restore for a model field the extractor skipped.
+      if (
+        !compoundKeys.length &&
+        typeof sourceValue === 'string' &&
+        isNonTranslatableValue(sourceValue) &&
+        el[locale] == null
+      ) {
+        this.update({ ...el, [locale]: sourceValue });
+      }
       if (compoundKeys.length > 0 && sourceValue !== null && sourceValue !== undefined) {
         const localeValue = JSON.parse(JSON.stringify(sourceValue));
         compoundKeys.forEach(key => {
@@ -890,7 +924,7 @@ export function applyTranslation(
           if (!compoundKeys.length) {
             // Everything came back excluded, or there was never anything to send. Both differ
             // from the provider not having answered yet, which must leave the locale alone.
-            if (matchingKeys.length || (excludedPaths && !hasTranslatableLeaf())) {
+            if (matchingKeys.length || !hasTranslatableLeaf()) {
               seedSourceIntoLocale();
             }
             return;

--- a/packages/utils/src/translation-helpers.ts
+++ b/packages/utils/src/translation-helpers.ts
@@ -24,6 +24,10 @@ function isNonTranslatableValue(value: string) {
   const lower = trimmed.toLowerCase();
   return (
     lower.startsWith('/') ||
+    // './x' and '../x' are unambiguous relative links. A bare 'foo/bar' is not: it is
+    // shape-identical to real copy like 'and/or', 'Yes/No' or '24/7', so it stays in.
+    lower.startsWith('./') ||
+    lower.startsWith('../') ||
     lower.startsWith('http://') ||
     lower.startsWith('https://') ||
     lower.startsWith('cdn.builder.io/') ||

--- a/packages/utils/src/translation-helpers.ts
+++ b/packages/utils/src/translation-helpers.ts
@@ -26,7 +26,14 @@ function isNonTranslatableValue(value: string) {
     lower.startsWith('/') ||
     lower.startsWith('http://') ||
     lower.startsWith('https://') ||
-    lower.startsWith('cdn.builder.io/')
+    lower.startsWith('cdn.builder.io/') ||
+    lower.startsWith('mailto:') ||
+    lower.startsWith('tel:') ||
+    lower.startsWith('sms:') ||
+    lower.startsWith('data:') ||
+    // Bare '#' is an empty link placeholder, but '#anchor' is shape-identical to a
+    // campaign hashtag like '#SumUp', so those stay translatable.
+    lower === '#'
   );
 }
 
@@ -119,6 +126,7 @@ function resolveTranslation({
   translation,
   transformedMeta,
   locale,
+  sourceLocaleId,
 }: {
   data: any;
   basePath: string;
@@ -128,6 +136,7 @@ function resolveTranslation({
   translation: any;
   transformedMeta: Record<string, string>;
   locale: string;
+  sourceLocaleId?: string;
 }) {
   if (Array.isArray(value)) {
     value.forEach((item, index) => {
@@ -140,6 +149,7 @@ function resolveTranslation({
         translation,
         transformedMeta,
         locale,
+        sourceLocaleId,
       });
     });
   } else if (typeof value === 'object' && value !== null) {
@@ -157,14 +167,16 @@ function resolveTranslation({
       } else {
         // No direct translation - check if Default value contains nested LocalizedValues
         const defaultValue = value?.Default;
-        // Restore a leaf the extractor skipped: the SDK resolves a missing locale to
-        // undefined, so the link would otherwise vanish in the target locale.
+        // Restore a leaf the extractor skipped. Selecting the source the same way the
+        // extractor does keeps the two from disagreeing: reading Default here would seed
+        // a url over prose that is still out for translation, or miss the url entirely.
+        const skippedSource = (sourceLocaleId && value?.[sourceLocaleId]) || value?.Default;
         if (
-          typeof defaultValue === 'string' &&
-          isNonTranslatableValue(defaultValue) &&
+          typeof skippedSource === 'string' &&
+          isNonTranslatableValue(skippedSource) &&
           value[locale] == null
         ) {
-          set(data, dataPath, { ...value, [locale]: defaultValue });
+          set(data, dataPath, { ...value, [locale]: skippedSource });
         }
         if (
           Array.isArray(defaultValue) ||
@@ -181,6 +193,7 @@ function resolveTranslation({
             translation,
             transformedMeta,
             locale,
+            sourceLocaleId,
           });
         }
 
@@ -200,6 +213,7 @@ function resolveTranslation({
             translation,
             transformedMeta,
             locale,
+            sourceLocaleId,
           });
         }
       }
@@ -214,6 +228,7 @@ function resolveTranslation({
           translation,
           transformedMeta,
           locale,
+          sourceLocaleId,
         });
       });
     }
@@ -554,6 +569,15 @@ export function getTranslateableFields(
   return results;
 }
 
+// Tells a payload the url guard emptied from one that never held a string, so only the
+// former is restored into the target locale.
+function hasStringLeaf(value: any): boolean {
+  if (typeof value === 'string') return Boolean(value);
+  if (Array.isArray(value)) return value.some(hasStringLeaf);
+  if (value && typeof value === 'object') return Object.values(value).some(hasStringLeaf);
+  return false;
+}
+
 // Seeds every nested LocalizedValue with a locale branch from the source: the SDK
 // resolves a missing locale key to undefined rather than to Default, so untranslated
 // leaves would otherwise vanish.
@@ -650,14 +674,22 @@ export function applyTranslation(
       const sourceValue = (sourceLocaleId && el[sourceLocaleId] != null)
           ? el[sourceLocaleId]
           : el.Default;
-      // Same restore for a model field the extractor skipped.
+      // Restore what the extractor skipped: a url-only field or payload draws no response,
+      // and the SDK resolves a missing locale to undefined, so it would vanish there.
+      const metaHasTranslatableLeaf = () => {
+        const probe: TranslateableFields = {};
+        extractNestedStrings(sourceValue, metaKey, probe, '', sourceLocaleId ?? '');
+        return Object.keys(probe).length > 0;
+      };
       if (
         !compoundKeys.length &&
-        typeof sourceValue === 'string' &&
-        isNonTranslatableValue(sourceValue) &&
-        el[locale] == null
+        el[locale] == null &&
+        hasStringLeaf(sourceValue) &&
+        !metaHasTranslatableLeaf()
       ) {
-        this.update({ ...el, [locale]: sourceValue });
+        const seeded = JSON.parse(JSON.stringify(sourceValue));
+        seedLocaleBranches(seeded, locale, sourceLocaleId);
+        this.update({ ...el, [locale]: seeded });
       }
       if (compoundKeys.length > 0 && sourceValue !== null && sourceValue !== undefined) {
         const localeValue = JSON.parse(JSON.stringify(sourceValue));
@@ -727,6 +759,7 @@ export function applyTranslation(
                 translation,
                 transformedMeta,
                 locale,
+                sourceLocaleId,
               });
 
               this.update({


### PR DESCRIPTION
## Description

Image links, button URLs and page links from Builder content were all showing up as strings for Smartling to translate.

**Root Cause:**
This is a regression from #4651 (June). That PR taught the extractor to look inside a localized list or object and send each string it finds as its own translation unit, which was the right fix for text fields that were previously being skipped.

The catch is that the extractor has no idea what type a field is. So once it starts walking a payload, it picks up every string in there. `imageUrl`, `link` and `screenImage` are strings, so off they went.

We already patched one version of this in #4826, where the same walk was sending dropdown values like "White" and "Left". That fix relied on the editor recording which fields are non-translatable, which only helps for localized list fields on blocks that carry that metadata. URLs on symbols and on model fields go through different code paths and were never covered.

**Fix:**
Added one small check: a string is not translatable if it has no whitespace and starts with /, http://, https:// or cdn.builder.io/. That check now runs everywhere a string becomes a translation unit (7 places: symbol inputs, model fields, the two nested-string branches, the localized-leaf branch, and the block flat-string case).

The whitespace part matters. "Visit https://sumup.com for more" is a real sentence and still gets translated. Only a bare URL on its own gets skipped.

Skipping a field means Smartling never returns a value for it, and the SDK resolves a missing locale to undefined rather than falling back to Default, so the link would just vanish on the translated page. To prevent that, the source URL is now copied into the target locale for any field we skip. Three changes for that: the block path already had this logic behind a condition that was too narrow, so the condition was widened; the symbol and model-field paths had none, so each got a small block.

Both new blocks are gated on the same URL check, so they only ever restore a value we deliberately skipped. A field that's still waiting on a pending job is left alone, so English never leaks into a translated locale.

**Link to JIRA ticket (if applicable):**
https://builder-io.atlassian.net/browse/ENG-13890

**Screenshot/Clip**
https://clips.agent-native.com/r/uFQLIO0vOcIM
